### PR TITLE
ci: install trivy in docker scan matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,13 @@ jobs:
         image: [api, ui]
     steps:
       - uses: actions/checkout@v6
+      - name: Install Trivy
+        run: |
+          TRIVY_VERSION=0.64.1
+          curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o /tmp/trivy.tar.gz
+          tar -xzf /tmp/trivy.tar.gz -C /tmp
+          install /tmp/trivy /usr/local/bin/trivy
+          trivy --version
       - name: Scan image with Make
         run: make trivy-scan-${{ matrix.image }}
 


### PR DESCRIPTION
Installs Trivy in the docker-scan workflow before running make trivy-scan-${{ matrix.image }}. This addresses recurring failures in Docker image scan jobs where make fails with: "make: trivy: No such file or directory".

Made with [Cursor](https://cursor.com)