### PR TITLE
ci: bump Trivy release to valid version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Trivy
         run: |
-          TRIVY_VERSION=0.64.1
+          TRIVY_VERSION=0.69.3
           curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o /tmp/trivy.tar.gz
           tar -xzf /tmp/trivy.tar.gz -C /tmp
           install /tmp/trivy /usr/local/bin/trivy


### PR DESCRIPTION
Fixes docker image scan jobs by bumping Trivy download to a valid release version (v0.69.3), avoiding 404 errors during CI workflow setup. Previously used 0.64.1, which is not available in aquasecurity/trivy releases.

Made with [Cursor](https://cursor.com)