### PR TITLE
chore(devcontainer): update Gitleaks and Trivy installation in Docker…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
 
 ARG NODE_MAJOR=24
 ARG TRIVY_VERSION=0.69.3
-ARG GITLEAKS_VERSION=8.24.3
+ARG GITLEAKS_VERSION=8.30.1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -43,6 +43,7 @@ RUN apt-get update \
         libxshmfence1 \
         libxcb1 \
         xvfb \
+    && mkdir -p /usr/local/bin \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
         | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
@@ -50,15 +51,22 @@ RUN apt-get update \
         > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
-    && curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+    && TRIVY_ARCH="$(dpkg --print-architecture | sed 's/amd64/x86_64/;s/arm64/aarch64/')" \
+    && case "$TRIVY_ARCH" in \
+      x86_64) TRIVY_ASSET="Linux-64bit"; GITLEAKS_ASSET="linux_x64" ;; \
+      aarch64) TRIVY_ASSET="Linux-ARM64"; GITLEAKS_ASSET="linux_arm64" ;; \
+      *) echo "Unsupported architecture: $TRIVY_ARCH"; exit 1 ;; \
+      esac \
+    && curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ASSET}.tar.gz" \
         -o /tmp/trivy.tar.gz \
     && tar -xzf /tmp/trivy.tar.gz -C /tmp trivy \
     && install -m 0755 /tmp/trivy /usr/local/bin/trivy \
-    && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-        | tar xz -C /tmp gitleaks \
+    && curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${GITLEAKS_ASSET}.tar.gz" \
+        -o /tmp/gitleaks.tar.gz \
+    && tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks \
     && install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && rm -f /tmp/trivy.tar.gz /tmp/gitleaks
+    && rm -f /tmp/trivy.tar.gz /tmp/gitleaks.tar.gz
 
 RUN rustup component add rustfmt clippy llvm-tools \
     && cargo install cargo-watch \

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -22,6 +22,34 @@ cd ui && npx playwright install chromium && cd ..
 echo "==> Copying .env.example → .env (if not present)..."
 [ -f .env ] || cp .env.example .env
 
+echo "==> Ensuring quality-gate binaries are present..."
+if ! command -v trivy >/dev/null 2>&1; then
+  echo "    - trivy missing, installing v0.69.3"
+  curl -fsSL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp/trivy
+  sudo mv /tmp/trivy/trivy /usr/local/bin/trivy
+fi
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "    - gitleaks missing, installing latest release"
+  VERSION=$(curl -fsSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | sed -n 's/.*\"tag_name\": \"\\([^\"]*\\)\".*/\\1/p' | head -n1)
+  ARCH="$(uname -m)"
+  case "$ARCH" in
+    x86_64) GITLEAKS_ARCH="linux_x64" ;;
+    aarch64|arm64) GITLEAKS_ARCH="linux_arm64" ;;
+    *) echo "Unsupported architecture for gitleaks: $ARCH" ; exit 1 ;;
+  esac
+  ASSET="gitleaks_${VERSION#v}_linux_x64.tar.gz"
+  TMPDIR=$(mktemp -d)
+  curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/$VERSION/${ASSET/linux_x64/$GITLEAKS_ARCH}" -o "$TMPDIR/$ASSET"
+  tar -xzf "$TMPDIR/$ASSET" -C "$TMPDIR"
+  sudo cp "$TMPDIR/gitleaks" /usr/local/bin/gitleaks
+  sudo chmod +x /usr/local/bin/gitleaks
+  rm -rf "$TMPDIR"
+fi
+
+trivy --version >/dev/null 2>&1 && echo "    - trivy: $(trivy --version | head -n1)" || true
+gitleaks version >/dev/null 2>&1 && echo "    - gitleaks: $(gitleaks version)" || true
+
 echo "==> Dev container ready. Quick commands:"
 echo "    cargo test              — run all Rust tests"
 echo "    cargo watch -x test     — watch mode"


### PR DESCRIPTION
…file and post-create script

- Bumped Gitleaks version from 8.24.3 to 8.30.1 in Dockerfile.
- Enhanced architecture detection for Trivy and Gitleaks installations in Dockerfile.
- Updated post-create.sh to ensure the latest Gitleaks version is installed dynamically.
- Added checks for the presence of Trivy and Gitleaks, installing them if missing.

This improves the development environment setup and ensures the latest security tools are available.