### PR TITLE
fix(ui): patch nginx CVE in UI image (alpine base + apk nginx)

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -9,10 +9,21 @@ COPY . .
 
 RUN npm run build
 
-FROM nginx:1.28-alpine3.23
+# Runtime: Alpine + nginx installed from the Alpine repo. The official
+# `nginx:*-alpine` image pins nginx from nginx.org's repo, so `apk upgrade`
+# cannot pull Alpine's security-patched nginx build (e.g. CVE-2026-9256).
+# Installing nginx via apk keeps it upgradeable with the rest of the OS.
+FROM alpine:3.23
+
+RUN apk add --no-cache nginx ca-certificates \
+    && apk upgrade --no-cache \
+    && mkdir -p /run/nginx /usr/share/nginx/html
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY <<'EOF' /etc/nginx/conf.d/default.conf
+
+# Alpine's nginx.conf includes /etc/nginx/http.d/*.conf; this replaces the
+# packaged default server block.
+COPY <<'EOF' /etc/nginx/http.d/default.conf
 server {
     listen 5173;
     root /usr/share/nginx/html;
@@ -46,6 +57,6 @@ server {
 }
 EOF
 
-RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
-
 EXPOSE 5173
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Fixes the failing **`Docker image scan (ui)`** check on `main`, which every open Dependabot PR (#75-84) inherits.

## Problem
The official `nginx:1.28-alpine3.23` image installs nginx from nginx.org's repo and pins it to matching nginx.org modules, so `apk upgrade` **cannot** pull Alpine's security-patched `nginx-1.28.3-r2` (CVE-2026-9256, rewrite-module RCE/DoS). Trivy flags it CRITICAL/HIGH (`--ignore-unfixed`), failing the gate.

## Fix
Base the runtime stage on `alpine:3.23` and install nginx via `apk add nginx`, so nginx is Alpine-managed and `apk upgrade` keeps it patched (also clears libxml2 / nghttp2 findings). The server block moves to `/etc/nginx/http.d/` (Alpine's `nginx.conf` includes it).

## Verification (in devcontainer)
- `trivy image --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1` → clean
- nginx serves `/health` (200 `ok`), `/` (200), SPA routes (200 via `try_files`); nginx 1.28.3 (Alpine r2)
- `proxy_pass http://api:3000` upstream behavior unchanged (resolved in the compose network)

Once merged, the Dependabot PRs can be rebased/re-run and should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)