### PR TITLE
chore(deps): replace stale cargo Dependabot entry with gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: "gradle"
+    directory: "/java"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Dependabot's cargo ecosystem entry is a dead scan -- the backend was rewritten from Rust to Java/Gradle and Cargo.toml no longer exists in this repo.
- No ecosystem entry currently tracks Java dependency updates for `java/` at all.
- Replaces the `cargo` entry with a `gradle` entry pointed at `/java`, so Dependabot actually watches the production backend's dependencies.

## Test plan

- [x] Confirmed no Cargo.toml exists in the repo
- [x] Confirmed java/settings.gradle.kts and java/build.gradle.kts exist as the Gradle root
- N/A -- config-only change, no build/runtime impact

Generated with Claude Code