### PR TITLE
Align docs and UI with actual busy-machine offline rejection

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -106,7 +106,7 @@ curl -X POST http://localhost:3000/api/machines \
 
 **Request body:** `{ "machine_id": number, "online": boolean }`
 
-**Errors:** `409` if no scenario is loaded.
+**Errors:** `409` if no scenario is loaded. A machine can only be taken offline while idle; if it has active jobs, the domain rejects the transition and the rejection reason is reported via `last_error` in the response snapshot (the same mechanism used for other simulation-thread command errors), not an HTTP error status.
 
 ### `POST /api/agent`
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -42,7 +42,7 @@ Your goal is to keep this loop healthy: enough demand to generate revenue, enoug
 
 Machines (also called equipment in ISA-95 terminology) are the physical resources that do work. Each machine can process one job at a time. You can toggle machines online/offline during a run.
 
-A machine that is **offline** stops accepting new jobs. Jobs already in progress on that machine will still complete, but no new work starts until you bring it back online.
+A machine that is **offline** stops accepting new jobs. A machine can only be taken offline while it is **idle**: if it has active jobs, the request is rejected and the machine keeps running until its current work completes. Wait for the machine to become idle, then take it offline. Once offline, the machine can be brought back online at any time.
 
 ### Products and routings
 

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -91,6 +91,7 @@ export function Sidebar() {
           <ul className="flex flex-col gap-2">
             {machines.map((m) => {
               const online = m.state !== 'Offline';
+              const cannotGoOffline = online && m.active_jobs > 0;
               return (
                 <li
                   key={m.id}
@@ -101,7 +102,8 @@ export function Sidebar() {
                     type="button"
                     role="switch"
                     aria-checked={online}
-                    disabled={loading}
+                    disabled={loading || cannotGoOffline}
+                    title={cannotGoOffline ? 'Machine has active jobs; wait until it is idle to take it offline' : undefined}
                     onClick={() => void changeMachine(m.id, !online)}
                     className={`inline-flex h-7 w-12 shrink-0 cursor-pointer items-center rounded-full border px-0.5 transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
                       online


### PR DESCRIPTION
## Summary
- `Machine.setAvailability(false)` rejects the transition (`InvalidStateTransition`) when a machine has active jobs -- it does not drain running work before going offline. `docs/concepts.md` incorrectly described graceful draining ("jobs already in progress will still complete"), which does not match the implemented domain model.
- Updated `docs/concepts.md` to describe the real contract: a machine can only be taken offline while idle; if busy, the request is rejected and the caller must wait for it to become idle.
- Updated `docs/api.md` to note how the rejection surfaces on `POST /api/machines` -- via `last_error` in the response snapshot, the same mechanism used for other simulation-thread command errors (not a new HTTP error status).
- Disabled the offline toggle in `ui/src/components/layout/Sidebar.tsx` when a machine has active jobs (`active_jobs > 0`), with a tooltip explaining why, so an obviously invalid action isn't exposed in the UI. Domain validation in `Machine.setAvailability` remains the sole source of truth.

No new lifecycle states, endpoints, or draining/queue-evacuation logic were introduced -- this is a docs/UI consistency fix, not a behavior change.

## Test plan
- [x] `MachineStateTest` (existing coverage, unchanged) run via a JDK 25 Docker container -- all 10 tests pass, including `onlineOfflineToggle` (Idle->Offline->Idle) and `cannotGoOfflineWithActiveJobs` (Busy->Offline rejected)
- [x] `tsc -b` in `ui/` -- clean
- [x] `eslint .` in `ui/` -- clean