### PR TITLE
chore(deps): bump Spring Boot to 4.1.0 and jackson-core/databind to 3.2.2

### DIFF
--- a/java/sim-api/build.gradle.kts
+++ b/java/sim-api/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     // managed version otherwise, so it must be repeated here.
     implementation("tools.jackson.core:jackson-databind:3.2.2")
     implementation("tools.jackson.core:jackson-core:3.2.2")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.22")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     // Reactive client on the test classpath so the tests can build a

--- a/java/sim-api/build.gradle.kts
+++ b/java/sim-api/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 
 plugins {
-    id("org.springframework.boot") version "4.0.6"
+    id("org.springframework.boot") version "4.1.0"
     id("io.spring.dependency-management") version "1.1.7"
 }
 

--- a/java/sim-api/build.gradle.kts
+++ b/java/sim-api/build.gradle.kts
@@ -25,8 +25,8 @@ dependencies {
     // its BOM when declared in this project; a version pinned in sim-core
     // (a transitive project dependency) is silently overridden by the BOM's
     // managed version otherwise, so it must be repeated here.
-    implementation("tools.jackson.core:jackson-databind:3.1.4")
-    implementation("tools.jackson.core:jackson-core:3.1.4")
+    implementation("tools.jackson.core:jackson-databind:3.2.2")
+    implementation("tools.jackson.core:jackson-core:3.2.2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     // Reactive client on the test classpath so the tests can build a

--- a/java/sim-cli/build.gradle.kts
+++ b/java/sim-cli/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 
 plugins {
-    id("org.springframework.boot") version "4.0.6"
+    id("org.springframework.boot") version "4.1.0"
     id("io.spring.dependency-management") version "1.1.7"
     application
 }

--- a/java/sim-cli/build.gradle.kts
+++ b/java/sim-cli/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     // managed version otherwise, so it must be repeated here.
     implementation("tools.jackson.core:jackson-databind:3.2.2")
     implementation("tools.jackson.core:jackson-core:3.2.2")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.22")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/java/sim-cli/build.gradle.kts
+++ b/java/sim-cli/build.gradle.kts
@@ -28,8 +28,8 @@ dependencies {
     // its BOM when declared in this project; a version pinned in sim-core
     // (a transitive project dependency) is silently overridden by the BOM's
     // managed version otherwise, so it must be repeated here.
-    implementation("tools.jackson.core:jackson-databind:3.1.4")
-    implementation("tools.jackson.core:jackson-core:3.1.4")
+    implementation("tools.jackson.core:jackson-databind:3.2.2")
+    implementation("tools.jackson.core:jackson-core:3.2.2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/java/sim-core/build.gradle.kts
+++ b/java/sim-core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(project(":sim-types"))
     implementation("tools.jackson.core:jackson-databind:3.2.2")
     implementation("tools.jackson.core:jackson-core:3.2.2")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.22")
     implementation("tools.jackson.dataformat:jackson-dataformat-toml:3.2.2")
 }
 

--- a/java/sim-core/build.gradle.kts
+++ b/java/sim-core/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 
 dependencies {
     implementation(project(":sim-types"))
-    implementation("tools.jackson.core:jackson-databind:3.1.4")
-    implementation("tools.jackson.core:jackson-core:3.1.4")
+    implementation("tools.jackson.core:jackson-databind:3.2.2")
+    implementation("tools.jackson.core:jackson-core:3.2.2")
     implementation("tools.jackson.dataformat:jackson-dataformat-toml:3.2.2")
 }
 

--- a/java/sim-types/build.gradle.kts
+++ b/java/sim-types/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 
 dependencies {
-    implementation("tools.jackson.core:jackson-databind:3.1.4")
-    implementation("tools.jackson.core:jackson-core:3.1.4")
+    implementation("tools.jackson.core:jackson-databind:3.2.2")
+    implementation("tools.jackson.core:jackson-core:3.2.2")
     implementation("tools.jackson.dataformat:jackson-dataformat-toml:3.2.2")
 }
 

--- a/java/sim-types/build.gradle.kts
+++ b/java/sim-types/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 dependencies {
     implementation("tools.jackson.core:jackson-databind:3.2.2")
     implementation("tools.jackson.core:jackson-core:3.2.2")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.22")
     implementation("tools.jackson.dataformat:jackson-dataformat-toml:3.2.2")
 }
 


### PR DESCRIPTION
## Summary

Combines three separate Dependabot PRs that were unsafe individually or in any two-way pairing:

- #118 -- bump jackson-core 3.1.4 -> 3.2.2
- #119 -- bump jackson-databind 3.1.4 -> 3.2.2
- #125 -- bump Spring Boot plugin 4.0.6 -> 4.1.0

None of these alone (or paired) fixed the actual runtime break: bumping jackson-core/databind to 3.2.2 causes `NoClassDefFoundError: com/fasterxml/jackson/annotation/JsonApplyView` at the API layer, because Spring's `io.spring.dependency-management` BOM silently downgrades the transitive `jackson-annotations` dependency to 2.21 -- one version behind the 2.22 that `jackson-bom:3.2.2` actually requires. `jackson-annotations` keeps classic 2.x-style versioning, independent of core/databind's 3.x line, so it wasn't caught by the existing "repeat the pin here because the BOM silently overrides it" pattern already used for core/databind.

Fix: add an explicit `com.fasterxml.jackson.core:jackson-annotations:2.22` pin alongside the existing jackson-core/databind pins in every module that declares them (sim-types, sim-core, sim-api, sim-cli), following the same override rationale documented in the existing comment.

Verified via `:sim-api:dependencies` that `jackson-bom:3.2.2` requests `jackson-annotations:2.22` and Spring's BOM was forcing it down to 2.21 before this fix.

## Test plan

- [x] Full Gradle test suite + Checkstyle pass via Docker (`gradle:9-jdk25`)
- [x] Confirmed root cause via `:sim-api:dependencies --configuration runtimeClasspath`
- [x] Reproduced the original failure (jackson-core/databind alone, and paired with Spring Boot bump alone) before landing the annotations pin fix

Generated with Claude Code