### PR TITLE
Add Product Charter as normative product north star

### DIFF
--- a/.cursor/rules/analysis-to-plan.mdc
+++ b/.cursor/rules/analysis-to-plan.mdc
@@ -7,6 +7,8 @@ alwaysApply: false
 
 When the user asks you to produce a plan from the current conversation, follow this protocol.
 
+If the plan touches product direction, domain design, or architecture (as opposed to a routine local implementation task), read `PRODUCT_CHARTER.md` at the repository root before writing the Goal or Recommended Approach sections. It is the normative source for what Arcogine is meant to become; a plan that conflicts with it should say so explicitly rather than silently drifting from it. This is strategic grounding, not a gate — don't block routine implementation plans on it.
+
 ## Step 1 — Extract raw material from the conversation
 
 Re-read the full conversation. Collect:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for considering a contribution to Arcogine. This guide covers everything you need to get started.
 
+Before proposing a significant product, domain, or architecture change, read [`PRODUCT_CHARTER.md`](PRODUCT_CHARTER.md). It's the normative source for Arcogine's product direction — significant proposals should be evaluated against it as well as the current architecture constraints in `docs/architecture.md`. It's strategic context for judgment calls, not a rulebook for blocking routine local implementation work.
+
 ## Prerequisites
 
 - **JDK 25** and **Node.js 24+** (for native, non-container development)

--- a/PRODUCT_CHARTER.md
+++ b/PRODUCT_CHARTER.md
@@ -1,0 +1,184 @@
+# Arcogine Product Charter
+
+> Product vision, system thesis, and enduring principles for Arcogine.
+
+## What this document is
+
+This is the single normative source for Arcogine's enduring product direction. It sits above UX decisions, domain design, architecture, ADRs, API and UI design, implementation plans, and current-state documentation — those all operate under it, and a proposal that contradicts this charter should be treated as the thing that needs to change, not the charter.
+
+This document is **not**:
+
+- a roadmap;
+- an implementation plan;
+- a list of promised features;
+- a description of current functionality;
+- marketing copy;
+- an architecture specification.
+
+It defines what Arcogine is ultimately intended to become and the principles against which future initiatives — features, refactors, architecture proposals, ADRs — should be evaluated. It does not promise dates, phases, or that any specific capability will ship. For what Arcogine implements today, see [`docs/architecture.md`](docs/architecture.md), [`docs/concepts.md`](docs/concepts.md), and [`docs/api.md`](docs/api.md).
+
+## 1. Purpose
+
+**Arcogine provides purpose-built ways to design, understand, simulate, verify, operate, monitor, and improve a production system, all grounded in the same executable model of the business.**
+
+Arcogine should ultimately support the full lifecycle of a production business: designing the system, understanding it, simulating it, verifying it, implementing and deploying changes, executing real operations, monitoring actual behavior, and improving the system continuously.
+
+Simulation is a major Arcogine capability, but **Arcogine is not fundamentally a simulation product**. The mature platform may operate as a modeling and design environment, a simulation engine, a digital twin, a verification environment, a decision-support system, an execution engine, an operational control surface, and a monitoring and analysis environment. These are modes of engagement with the same underlying business model, not necessarily separate applications.
+
+## 2. Central system thesis
+
+> **The system you design is the system you simulate is the system you verify is the system you execute is the system you monitor.**
+
+This does not mean one runtime instance, one database, one UI, one deployment, one copy of mutable state, or Arcogine being the authoritative source of every datum in the business. Simulation, replay, staging, and production may have different state, clocks, authority, permissions, side effects, safety constraints, and external integrations.
+
+What must remain continuous is the **semantic model of the business** — its lineage, policies, objectives, constraints, and executable meaning. External systems such as ERP, MES, CRM, financial systems, equipment, and sensors may continue to own authoritative external facts while participating in the Arcogine model; Arcogine does not need to become the source of truth for everything it touches.
+
+## 3. Business-change thesis
+
+> **A change to the business should be designable, testable against a faithful digital twin, verifiable against explicit objectives and constraints, and deployable to reality without translating it into an entirely different representation along the way.**
+
+Arcogine should resist architectures where one representation is used for design, another is manually recreated for simulation, another is used for operations, and yet another is used for monitoring. The value proposition is **semantic and executable continuity across the lifecycle** — not four disconnected tools that happen to share a brand.
+
+## 4. Product lifecycle
+
+The mature Arcogine lifecycle, conceptually:
+
+```text
+Design
+  ↓
+Understand
+  ↓
+Simulate
+  ↓
+Verify
+  ↓
+Deploy
+  ↓
+Execute
+  ↓
+Monitor
+  ↓
+Improve
+  └──────────────→ Design
+```
+
+This is a conceptual lifecycle, not a roadmap or a prescribed sequence of product releases. Users may enter at different points and move between stages as needed. An operating production system may be cloned into simulation to investigate a problem; validated changes may later be applied to production; actual outcomes may feed back into model improvement. No stage requires having built all the others first, and nothing here commits Arcogine to shipping these stages in this order or on any schedule.
+
+## 5. Modes of engagement, not personas
+
+Arcogine will serve many users with different responsibilities. The product is not built around one persona or one universal dashboard — it is built around **modes of engagement with the same system**.
+
+| Mode | Primary activity | Example users |
+|---|---|---|
+| **Design** | Define products, processes, resources, policies, constraints, and objectives | Industrial engineers, process designers, business architects |
+| **Understand** | Inspect behavior, dependencies, causes, current state, or history | Analysts, managers, auditors |
+| **Simulate** | Explore scenarios, interventions, uncertainty, and alternative policies | Analysts, researchers, planners, agent developers |
+| **Verify** | Establish whether a model, configuration, policy, or proposed change satisfies explicit requirements | Engineers, risk owners, compliance users, testers |
+| **Operate** | Execute and coordinate actual production and business processes | Operators, planners, supervisors, autonomous agents |
+| **Improve** | Compare intended and actual behavior and develop validated improvements | Engineers, managers, continuous-improvement teams |
+
+These modes are not required to become six applications.
+
+> **Roles do not receive separate versions of the business. They receive purpose-built projections and capabilities over the same model.**
+
+UX complexity, permissions, information density, and available actions should follow a user's task and authority, not a fork in the underlying model.
+
+## 6. Enduring product principles
+
+**One model, many views.** Purpose-built experiences should be projections over a coherent business model rather than independently maintained representations.
+
+**Lifecycle continuity.** Design, simulation, verification, execution, monitoring, and improvement should remain connected stages of one system lifecycle, not separately-maintained tools that happen to share a name.
+
+**Reality is explicit.** Simulation, replay, staging, hypothetical branches, and live production must never be ambiguously presented or confused. A user or agent should always be able to tell which one they are looking at.
+
+**Semantics survive deployment.** A validated model or policy should not need to be manually translated into an unrelated representation before it can govern reality.
+
+**Causality and provenance.** Arcogine should make it possible to understand what happened, why, under which model or configuration, based on what observations, because of which decision, and by which human, policy, agent, or external authority.
+
+**Humans and agents participate in the same governance model.** Human users and autonomous decision-makers should ultimately act through explicit capabilities, authority, constraints, and accountable decisions — neither is a special case exempt from the other's rules.
+
+**Safety scales with consequence.** Exploration in simulation can be permissive. Actions affecting real production require proportionate controls around authority, validation, approval, failure handling, auditability, and reversibility. This charter does not prescribe the concrete mechanisms — that is architecture and implementation work, done later, under this principle.
+
+**Complexity follows the task.** An operator should not need to understand the simulation kernel. A model designer may need deep access to system semantics. Expose complexity according to task and authority, not uniformly to everyone.
+
+**Reality improves the model.** Monitoring is not merely dashboarding. Observed behavior should make it possible to compare reality with modeled expectations, detect divergence, validate assumptions, and improve the model.
+
+## 7. Architectural implications
+
+These are consequences that follow from the thesis above, stated at the conceptual level only — none of this is a module design, schema, API, or class, and none of it is an implementation commitment:
+
+- Arcogine should not evolve separate simulation-only and production-only domain semantics.
+- Multiple execution contexts (simulation, replay, staging, production) must be distinguishable without losing model continuity.
+- Model, version, and provenance concepts become fundamental once changes can move from design to reality.
+- Once Arcogine can affect real systems, requested actions, accepted actions, resulting facts, failures, and authority boundaries cannot be conceptually collapsed into one another.
+- Purpose-specific observations and capabilities are preferable to exposing unrestricted mutable state.
+- Modeled state, observed external reality, and any reconciled digital-twin state are conceptually distinct.
+- Real execution introduces safety, authorization, auditability, failure, and operational consequence as architectural concerns, not optional add-ons.
+- Integrating external systems must not require pretending Arcogine is the physical source of truth for every domain it touches.
+
+## 8. Continuity with current architecture
+
+Arcogine's existing architectural philosophy —
+
+```text
+Events mutate State.
+State produces Observations.
+Observations inform Decisions.
+Decisions produce Events.
+```
+
+— is broadly compatible with this charter and is expected to remain a durable pattern as the system grows: explicit events, single-owner state, purpose-specific observations, and accountable decisions are exactly the shape a system needs to keep design, simulation, verification, and execution semantically continuous. Existing ideas the current implementation already applies — authoritative state ownership per subsystem, immutable observations, explicit decisions, deterministic simulation, provenance via an event log, the commercial/operational/financial truth distinction, and controlled agent capabilities — remain valuable and are not discarded by this charter. See [`docs/architecture.md`](docs/architecture.md) for how they work today; this charter does not freeze their current implementation as permanent, only affirms the direction they point in.
+
+One distinction matters enough to state explicitly: **determinism is a critical property of simulation, replay, and verification contexts — it is not a requirement that real-world execution itself somehow become deterministic.** Production operates in a non-deterministic world with real machines, real people, and real failures. What must stay continuous across contexts is the semantic model, not a claim that reality is repeatable the way a seeded simulation is. Language that treats simulation semantics as synonymous with Arcogine's entire future runtime model should be corrected wherever it appears.
+
+## 9. What Arcogine is not
+
+Arcogine is not fundamentally: a factory dashboard; a generic BI tool; only a discrete-event simulator; a game; an ERP clone; an MES clone; a collection of unrelated digital-twin integrations; or a separate model maintained per lifecycle stage.
+
+Arcogine is also not defined by: its current UI; Java; Spring; React; TOML scenarios; its current API; its current module names; or its current single-user, local-first deployment model. Those are implementation and current-state choices, evaluated and possibly changed over time — not product identity.
+
+Older ambitions such as "serious games" for training or "MMO-scale economic simulations" may remain possible applications built on the underlying engine, but they do not compete with the production-system/business-lifecycle thesis in Sections 1–3 as Arcogine's primary product identity.
+
+## 10. Documentation authority model
+
+```text
+PRODUCT_CHARTER.md
+Normative product destination and enduring principles
+        │
+        ▼
+docs/architecture.md
+Current architecture and enduring architectural principles
+        │
+        ├── docs/decisions/
+        │   Historical rationale for significant decisions
+        │
+        ├── docs/concepts.md / docs/api.md / UI docs
+        │   Current capability/reference documentation
+        │
+        └── devel/ and historical plans
+            Temporary analysis, proposals, assessments, and past plans
+```
+
+Repository documentation carries one of four statuses, applied where it materially helps a reader avoid confusing them:
+
+- **Normative** — enduring direction and principles. This charter, and the enduring-principle portions of `docs/architecture.md`.
+- **Current state** — what Arcogine implements now. `docs/concepts.md`, `docs/api.md`, `ui/README.md`, the current-implementation portions of `docs/architecture.md`.
+- **Proposed** — under consideration; not established. Proposed ADRs, `devel/` analyses.
+- **Historical** — retained for context but no longer authoritative. Superseded ADRs, past plans such as `docs/java-rewrite-plan.md`.
+
+A reader should never be left guessing whether a statement is mature product ambition, current implementation, an open proposal, or a historical artifact.
+
+## 11. Decision test
+
+A significant initiative — a feature proposal, an architecture change, an ADR — can be evaluated against this charter by asking:
+
+1. Does this strengthen or fragment the common executable model?
+2. Does it preserve continuity between design, simulation, verification, and execution?
+3. Does it make the distinction between hypothetical and real state clearer, or blur it?
+4. Does it preserve causality and provenance?
+5. Can multiple user roles interact through purpose-specific views without inventing competing business truths?
+6. Does it preserve a path from validated change to actual execution without manual semantic translation?
+7. Does it introduce authority or operational consequences that require explicit governance?
+8. Is it solving a real product need, or merely expanding Arcogine into an adjacent category?
+
+An initiative does not need a "yes" on every question to proceed — some are in tension by nature (e.g. exposing more capability vs. minimizing authority surface). The test is meant to surface the tradeoff explicitly, not to produce an automatic verdict.

--- a/PRODUCT_CHARTER.md
+++ b/PRODUCT_CHARTER.md
@@ -4,7 +4,7 @@
 
 ## What this document is
 
-This is the single normative source for Arcogine's enduring product direction. It sits above UX decisions, domain design, architecture, ADRs, API and UI design, implementation plans, and current-state documentation — those all operate under it, and a proposal that contradicts this charter should be treated as the thing that needs to change, not the charter.
+This is the highest-level normative source for Arcogine's product direction. It sits above UX decisions, domain design, architecture, ADRs, API and UI design, implementation plans, and current-state documentation. Product, architecture, domain, and UX decisions should align with it unless the charter itself is deliberately amended through an explicit product-level decision (see [Changing this charter](#12-changing-this-charter)) — an ordinary feature, implementation convenience, or architecture proposal must not silently override it. The charter is durable, not immutable: when the conflict is real, it is the charter that should be revisited on purpose, not quietly worked around.
 
 This document is **not**:
 
@@ -127,7 +127,9 @@ Observations inform Decisions.
 Decisions produce Events.
 ```
 
-— is broadly compatible with this charter and is expected to remain a durable pattern as the system grows: explicit events, single-owner state, purpose-specific observations, and accountable decisions are exactly the shape a system needs to keep design, simulation, verification, and execution semantically continuous. Existing ideas the current implementation already applies — authoritative state ownership per subsystem, immutable observations, explicit decisions, deterministic simulation, provenance via an event log, the commercial/operational/financial truth distinction, and controlled agent capabilities — remain valuable and are not discarded by this charter. See [`docs/architecture.md`](docs/architecture.md) for how they work today; this charter does not freeze their current implementation as permanent, only affirms the direction they point in.
+— is strongly compatible with this charter and provides a useful current realization of several of its principles: explicit events, single-owner state, purpose-specific observations, and accountable decisions are one good way to keep design, simulation, verification, and execution semantically continuous. Existing ideas the current implementation already applies — authoritative state ownership per subsystem, immutable observations, explicit decisions, deterministic simulation, provenance via an event log, the commercial/operational/financial truth distinction, and controlled agent capabilities — remain valuable and are not discarded by this charter.
+
+Whether Events–State–Observations remains an architectural invariant, and how it evolves, is a question for [`docs/architecture.md`](docs/architecture.md), not for this charter. This charter is satisfied by any architecture that upholds its principles — explicit state ownership, purpose-specific observations, causality, and provenance among them — and does not itself mandate this specific pattern as permanent.
 
 One distinction matters enough to state explicitly: **determinism is a critical property of simulation, replay, and verification contexts — it is not a requirement that real-world execution itself somehow become deterministic.** Production operates in a non-deterministic world with real machines, real people, and real failures. What must stay continuous across contexts is the semantic model, not a claim that reality is repeatable the way a seeded simulation is. Language that treats simulation semantics as synonymous with Arcogine's entire future runtime model should be corrected wherever it appears.
 
@@ -182,3 +184,7 @@ A significant initiative — a feature proposal, an architecture change, an ADR 
 8. Is it solving a real product need, or merely expanding Arcogine into an adjacent category?
 
 An initiative does not need a "yes" on every question to proceed — some are in tension by nature (e.g. exposing more capability vs. minimizing authority surface). The test is meant to surface the tradeoff explicitly, not to produce an automatic verdict.
+
+## 12. Changing this charter
+
+This charter is intended to be durable, not immutable. Changes should be deliberate and infrequent, and should reflect a real change in Arcogine's product thesis or enduring principles. A local feature, implementation constraint, or architecture convenience is not by itself sufficient reason to redefine the charter; such conflicts should be surfaced explicitly and resolved at the product level, rather than allowed to accumulate as quiet exceptions.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 [![CI](https://github.com/alaiba/arcogine/actions/workflows/ci.yml/badge.svg)](https://github.com/alaiba/arcogine/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/alaiba/arcogine/graph/badge.svg)](https://codecov.io/gh/alaiba/arcogine)
 
-Arcogine is a deterministic simulation engine for factory systems, economic dynamics, and agent-driven decision making.
+Arcogine is building toward purpose-built ways to design, understand, simulate, verify, operate, and improve a production system — all grounded in one executable model of the business. See [`PRODUCT_CHARTER.md`](PRODUCT_CHARTER.md) for the full product vision and enduring principles.
 
-## What is Arcogine?
+**The current implementation is an early, deterministic, simulation-focused slice of that vision.** It does not yet include digital-twin connectivity, live operational execution, or multi-user/production deployment — see [Security](SECURITY.md) and [Architecture](docs/architecture.md) for exactly what exists today.
 
-Arcogine is a **simulation-first platform** where you experiment with how pricing, capacity, and automated agents interact in a factory environment. Three systems feed back into each other:
+## What is Arcogine today?
+
+Today, Arcogine is a simulation platform where you experiment with how pricing, capacity, and automated agents interact in a factory environment. Three systems feed back into each other:
 
 ```text
      You set a price
@@ -104,7 +106,8 @@ java -jar java/sim-cli/build/libs/arcogine.jar run examples/basic_scenario.toml
 
 | Document | What it covers |
 |----------|----------------|
-| [Concepts](docs/concepts.md) | How the simulation works, KPIs, agents, scenarios |
+| [Product Charter](PRODUCT_CHARTER.md) | Enduring product vision and principles — start here to understand what Arcogine is ultimately becoming |
+| [Concepts](docs/concepts.md) | How the current simulation works, KPIs, agents, scenarios |
 | [API Reference](docs/api.md) | Every HTTP endpoint with curl examples |
 | [Architecture](docs/architecture.md) | Design philosophy, module structure, determinism contract |
 | [Full docs index](docs/README.md) | Everything else: testing, standards, vision, security |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@
 
 Arcogine is a simulation engine intended for local development and experimentation. The MVP does not include production-grade authentication, authorization, or data encryption.
 
+This document has two parts: the current security posture and limitations (below), which describe today's software honestly, and the [mature-product security principles](#mature-product-security-principles) implied by the [Product Charter](PRODUCT_CHARTER.md), which are conceptual expectations for a future that can execute real operations — not a description of anything implemented today. Adding TLS, CORS restrictions, or network hardening to the current software does not, by itself, make it suitable for operating a production business; that requires the concerns listed in that section, none of which are designed or implemented here.
+
 ## Reporting a Vulnerability
 
 If you discover a security issue, please report it by opening a GitHub issue with the label `security`. For sensitive issues, contact the maintainers directly.
@@ -44,9 +46,9 @@ If you expose Arcogine beyond localhost, apply at least:
 
 3. **TLS** — Arcogine does not terminate TLS. Place it behind a reverse proxy (nginx, Caddy, or a cloud load balancer) with TLS termination.
 
-4. **Dependency auditing** — Run `make rust-audit` and `make frontend-audit` before deployment. CI runs npm audit as part of `make ci-frontend` and scans container images via `make trivy-scan-api` / `make trivy-scan-ui`. Run `make quality-full` locally for the complete security suite including Rust audit.
+4. **Dependency auditing** — Run `make java-audit` and `make frontend-audit` before deployment. CI runs npm audit as part of `make ci-frontend` and scans container images via `make trivy-scan-api` / `make trivy-scan-ui`. Run `make quality-full` locally for the complete security suite including the Java dependency scan.
 
-5. **Log verbosity** — Set `RUST_LOG=warn` in production-like environments to reduce log noise.
+5. **Log verbosity** — Set `LOGGING_LEVEL_ROOT=WARN` in production-like environments to reduce log noise.
 
 ### Security scan ownership
 
@@ -59,3 +61,18 @@ Security execution follows the quality-gate contract:
   controls (`--exit-code`, report handling, fail-fast behavior) around those targets.
 
 For the full security verification test list, see `docs/TESTING.md`.
+
+## Mature-product security principles
+
+The [Product Charter](PRODUCT_CHARTER.md) describes a mature Arcogine that can eventually operate real production systems, not just simulate them. Real execution introduces concerns that today's local, single-user simulation tool does not need to address, and that are not designed or scoped here — this section names them conceptually so they aren't forgotten, not so they get built prematurely:
+
+- **Identity** — knowing who or what (human, agent, external system) is taking an action.
+- **Authority** — what that identity is permitted to do, and to what.
+- **Permissions** — enforceable boundaries around capability, not just UI-level hiding.
+- **Environment separation** — simulation, staging, and production must never be ambiguously distinguishable to a user or agent, per the Charter's "reality is explicit" principle.
+- **Auditability** — a durable, trustworthy record of what happened and why, extending the current event-log/provenance direction to real-world consequence.
+- **Safe failure** — real actions can fail partway; the system must have a defined, safe response rather than undefined behavior.
+- **Approvals where appropriate** — some actions should require confirmation or sign-off proportionate to their consequence, per the Charter's "safety scales with consequence" principle.
+- **Operational consequence** — real actions have effects outside Arcogine (money moves, machines run, orders ship) that cannot be undone by resetting simulation state.
+
+None of these are designed, scheduled, or committed to by this document. They are the conceptual boundary this security policy will need to grow into if and when Arcogine begins to execute real operations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,22 @@
 
 | Document | Who it's for | What it covers |
 |----------|-------------|----------------|
-| [Root README](../README.md) | Everyone | What Arcogine is, quick start, first session |
-| [Concepts](concepts.md) | New users | How the simulation works, KPIs, agents, scenarios |
+| [Product Charter](../PRODUCT_CHARTER.md) | Everyone | Arcogine's enduring product vision, system thesis, and principles — read this first |
+| [Root README](../README.md) | Everyone | What Arcogine is today, quick start, first session |
+| [Concepts](concepts.md) | New users | How the current simulation works, KPIs, agents, scenarios |
 | [API Reference](api.md) | Developers | Every HTTP endpoint with curl examples |
+
+## Documentation hierarchy
+
+Arcogine's documentation is layered, and each layer answers a different question:
+
+- **[`PRODUCT_CHARTER.md`](../PRODUCT_CHARTER.md)** — normative. What Arcogine is ultimately intended to become, and the principles future work is evaluated against. Not a roadmap, not a feature list.
+- **[`architecture.md`](architecture.md)** — current architecture plus the enduring architectural principles that follow from the Charter. Explains how the system is built today and which parts of that are expected to persist regardless of implementation.
+- **[`decisions/`](decisions/README.md)** (ADRs) — historical rationale for significant, hard-to-reverse decisions: *why* the system ended up the way it did, operating under the Charter and current architecture rather than setting product direction themselves.
+- **[`concepts.md`](concepts.md)**, **[`api.md`](api.md)**, [`../ui/README.md`](../ui/README.md) — current capability/reference documentation. Describe what exists now, honestly, without projecting future capability.
+- **[`../devel/`](../devel/)** and historical plans (e.g. [`java-rewrite-plan.md`](java-rewrite-plan.md)) — temporary analysis, proposals, assessments, and past plans. Useful for context; not authoritative for current or future direction.
+
+When documents disagree, the higher layer governs product direction; the lower layer remains authoritative for current implementation detail.
 
 ## Contributing
 
@@ -22,7 +35,7 @@
 |----------|----------------|
 | [Architecture](architecture.md) | Design philosophy (including the Events–State–Observations model), module structure, determinism contract, event dispatch, technology stack |
 | [Standards alignment](standards-alignment.md) | ISA-95, ISO 22400, DES, RAMI 4.0 mapping |
-| [Vision](vision.md) | Project identity, long-term directions, naming |
+| [Vision (superseded)](vision.md) | Pointer to the Product Charter; retains naming/etymology history only |
 | [Decision records](decisions/README.md) | Architecture/design decision history — why significant choices were made |
 | [SECURITY.md](../SECURITY.md) | Security policy, hardening posture, deployment constraints |
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,6 +2,8 @@
 
 This document covers all test categories in Arcogine, how to run them, and the rationale behind the testing architecture. **Make targets are the canonical quality-gate interface** — use `make <target>` from the repository root.
 
+This is about testing and quality-verifying Arcogine's own software — a different concept from the [Product Charter](../PRODUCT_CHARTER.md)'s "Verify" mode, which describes a future capability for verifying a *user's* production model or configuration against their own objectives and constraints. Don't conflate the two terminologically: this document is entirely about the former.
+
 ## Quick reference
 
 ```bash

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,7 @@
 # Arcogine — API Reference
 
+This document is strictly current-state: every endpoint below exists in the codebase today. It is not a preview of Arcogine's eventual platform API — see [`PRODUCT_CHARTER.md`](../PRODUCT_CHARTER.md) for the product direction this simulation API is one early step toward.
+
 The Arcogine API is an HTTP + SSE interface served by the `arcogine serve` command (default `127.0.0.1:3000`). The UI communicates exclusively through this API; you can also use it directly with curl or any HTTP client.
 
 All JSON request bodies are limited to 1 MiB. Error responses use the shape `{ "error": "description" }`.
@@ -229,5 +231,5 @@ The `SimSnapshot` returned by control and query endpoints:
 CORS is permissive by default (allows all origins). Set the `CORS_ALLOWED_ORIGIN` environment variable to restrict it:
 
 ```bash
-CORS_ALLOWED_ORIGIN=http://localhost:5173 cargo run --bin arcogine -- serve
+CORS_ALLOWED_ORIGIN=http://localhost:5173 java -jar java/sim-cli/build/libs/arcogine.jar serve
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,22 +1,38 @@
 # Arcogine — Architectural Overview
 
-This document describes the design philosophy and architectural principles that guide Arcogine's implementation. For the rationale behind specific significant decisions and their history, see [Architecture Decision Records](decisions/README.md).
+This document sits under the [Product Charter](../PRODUCT_CHARTER.md), which defines Arcogine's enduring product direction and principles. This document describes the design philosophy and architectural principles that guide Arcogine's implementation *today*, and distinguishes principles expected to persist regardless of implementation from constraints specific to the current MVP. For the rationale behind specific significant decisions and their history, see [Architecture Decision Records](decisions/README.md).
 
-## Non-Negotiable Constraints
+## Enduring architectural principles
+
+These are expected to hold regardless of how the implementation evolves, because they follow directly from the Product Charter:
+
+1. Repository must be reproducible, modular, testable, and collaboration-ready.
+2. Deterministic acceptance tests and scenario-level validation are mandatory for simulation, replay, and verification contexts (see the [Determinism Contract](#determinism-contract) below for scope).
+3. Agents only use approved command interfaces and never mutate simulation state directly — this is the same governance boundary the Charter asks of human and autonomous decision-makers alike.
+
+## Current implementation constraints (MVP)
+
+These describe today's implementation choices. They are not claims about Arcogine's permanent identity — see the Product Charter's [product boundaries](../PRODUCT_CHARTER.md#9-what-arcogine-is-not) for why Java, the current UI, and the current deployment model are implementation choices rather than product identity, subject to change as the product grows toward the full lifecycle described there.
 
 1. Core simulation is written in Java 25.
-2. Headless simulation core is primary; UI/API are additive.
-3. MVP must tie factory flow to economy loop.
-4. Repository must be reproducible, modular, testable, and collaboration-ready.
-5. UI is a single-user experiment console, not a game client.
-6. Support native and containerized local execution.
-7. Deterministic acceptance tests and scenario-level validation are mandatory.
-8. Agents only use approved command interfaces and never mutate simulation state directly.
-9. Security-sensitive defaults remain local-first by default; non-local exposure requires explicit hardening controls.
+2. The headless simulation core is the current implementation's primary layer; the UI and API are additive consumers of it. This describes today's layering, not a permanent claim that Arcogine's mature product surface is UI-secondary.
+3. MVP ties factory flow to the economy loop.
+4. Support native and containerized local execution.
+5. The current UI is a single-user experiment console — one current mode of engaging with Arcogine (see the Charter's [modes of engagement](../PRODUCT_CHARTER.md#5-modes-of-engagement-not-personas)), not "the Arcogine UX" in the mature-product sense, and not a game client.
+6. Security-sensitive defaults remain local-first by default; non-local exposure requires explicit hardening controls (see [SECURITY.md](../SECURITY.md)).
 
-## Simulation-First
+## Architectural implications of the Product Charter
 
-The system is built around a **headless simulation core**, not a game engine.
+Consequences of the Charter's thesis, stated at the conceptual level only — none of this is a module design, schema, or implementation commitment; see the Charter's [Architectural implications](../PRODUCT_CHARTER.md#7-architectural-implications) section for the full list:
+
+- Arcogine should not evolve separate simulation-only and production-only domain semantics.
+- Model, version, and provenance concepts become fundamental once changes can move from design to reality — today's `EventLog` and deterministic replay are an early, simulation-scoped instance of this, not the final answer.
+- Purpose-specific observations and capabilities (already the pattern for `AgentObservation`/`FinanceObservation`, see [Observations](#observations) below) are preferable to exposing unrestricted mutable state, and are expected to remain so as new consumers (human roles, external systems, execution surfaces) are added.
+- Real execution, when it exists, introduces safety, authorization, auditability, failure, and operational consequence as architectural concerns — the current implementation does not yet need to solve these because it does not yet execute anything real (see [SECURITY.md](../SECURITY.md)).
+
+## Simulation-First (current implementation)
+
+Today's system is built around a **headless simulation core**, not a game engine. This describes the current implementation's architecture — simulation is a major Arcogine capability (per the Product Charter), not the entirety of its identity.
 
 - No rendering dependency in the core
 - Deterministic execution — same inputs always produce the same outputs
@@ -458,6 +474,8 @@ The simulation guarantees deterministic execution:
 - No concurrent mutation of simulation state
 
 Given identical scenario TOML and the same seed, the simulation produces identical event logs, KPIs, and final state.
+
+This determinism contract is scoped to simulation, replay, and verification contexts, where it is a critical property. It is not a claim that real-world execution itself must be, or will be made, deterministic — production operates in a non-deterministic world of real machines, people, and failures. See the Product Charter's [continuity with current architecture](../PRODUCT_CHARTER.md#8-continuity-with-current-architecture) section for this distinction.
 
 ## API Layer
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,6 +2,8 @@
 
 This page explains what Arcogine simulates and how to interpret what you see in the UI. Read this before diving into scenarios.
 
+This document describes the **current factory-simulation experience** — one current mode of engaging with Arcogine, not the complete Arcogine product ontology. See [`PRODUCT_CHARTER.md`](../PRODUCT_CHARTER.md) for the enduring product vision.
+
 ## The big picture
 
 Arcogine models a simplified factory that makes products and sells them. Three systems interact in a feedback loop:
@@ -147,7 +149,7 @@ Same demand pressure as Overload, but with additional machines. Compare whether 
 You can run scenarios without the UI:
 
 ```bash
-cargo run --bin arcogine -- run --headless --scenario examples/basic_scenario.toml
+java -jar java/sim-cli/build/libs/arcogine.jar run examples/basic_scenario.toml
 ```
 
 This executes the full simulation and prints a summary to stdout. Useful for batch comparisons or scripted experiments.

--- a/docs/decisions/0000-template.md
+++ b/docs/decisions/0000-template.md
@@ -26,3 +26,9 @@ What credible alternatives were considered?
 ## Consequences
 
 What becomes easier, harder, constrained, or required as a result?
+
+## Charter alignment (optional)
+
+For consequential decisions, note which [Product Charter](../../PRODUCT_CHARTER.md)
+principles this decision supports, constrains, or intentionally departs from.
+Omit this section if the decision has no meaningful bearing on product direction.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -6,6 +6,13 @@ documentation (`architecture.md`, `concepts.md`, etc.) explains how Arcogine
 works today; ADRs explain *why* it ended up that way and preserve the history
 of that reasoning as the system evolves.
 
+ADRs operate under [`PRODUCT_CHARTER.md`](../../PRODUCT_CHARTER.md) and the
+current architecture — an ADR is not itself product vision, and it must not
+be written or read as though it sets Arcogine's product direction. Where a
+decision is consequential enough to interact with the Charter's principles,
+say so explicitly in the ADR (see the template's optional Charter-alignment
+note).
+
 See [ADR-0001](0001-use-architecture-decision-records.md) for the decision to
 use this mechanism.
 

--- a/docs/standards-alignment.md
+++ b/docs/standards-alignment.md
@@ -2,6 +2,8 @@
 
 Arcogine sits at the intersection of manufacturing systems, digital twins, simulation, industrial data integration, and agent-based decision making. This document maps relevant industry standards to Arcogine's architecture and defines the alignment strategy at each project phase.
 
+Per the [Product Charter](../PRODUCT_CHARTER.md), Arcogine's mature product identity spans the full design-simulate-verify-execute-monitor lifecycle, not simulation alone. That makes standards areas such as digital twins, enterprise/manufacturing integration (ISA-95), live operational data (OPC UA), asset identity, provenance, interoperability, and model verification more central to long-term architecture than a simulation-only framing would suggest — even though most of them remain "design for" or "note for later" tiers today, not current implementation commitments.
+
 ## Alignment Strategy
 
 Standards are categorized by when they influence design:
@@ -43,7 +45,7 @@ ISA-95 defines how ERP, MES, and shop-floor systems interact. It standardizes eq
 
 **Mapping to Arcogine MVP:**
 
-| ISA-95 Concept | Arcogine Equivalent | Crate |
+| ISA-95 Concept | Arcogine Equivalent | Module |
 |----------------|---------------------|-------|
 | Equipment (Work Unit) | Machine | `sim-factory` |
 | Material Definition | Product / SKU | `sim-factory` |

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,101 +1,16 @@
-# Arcogine — Vision & Identity
+# Arcogine — Vision (superseded)
 
-## What is Arcogine?
-
-Arcogine is a **simulation-first platform** designed to model and experiment with **factory systems, economic dynamics, and decision-making processes**.
-
-It is intentionally simulation-first, while still being enjoyable to use:
-
-> **A system for understanding how decisions shape complex industrial and economic behavior.**
-
-At its core, Arcogine bridges three domains:
-
-- **Operations** — production, capacity, bottlenecks
-- **Economics** — pricing, demand, revenue
-- **Decision systems** — agents, policies, incentives
-
-## Playful onboarding path
-
-You can also use Arcogine as a lightweight simulation challenge:
-
-- Run `Basic` first to learn controls and pacing.
-- Move to `Overload` to manage backlog and lead-time pressure.
-- Compare short-term tuning versus structural improvement in `Capacity Expansion`.
-
-### Suggested first session loop
-
-For a first run, the loop is:
-
-- load one of the scenarios,
-- run or step the simulation,
-- adjust product price and machine operating state,
-- toggle the agent off/on,
-- save at least one baseline snapshot,
-- compare outcomes with throughput, backlog, and revenue targets in view.
-
-This sequence keeps the first-session experience focused on control behavior before adding deeper tuning experiments.
-
-## Core Loop
-
-Arcogine is fundamentally a deterministic, event-driven system where decisions affect operations, and operations feed back into decisions:
-
-```text
-Pricing / Incentives
-        ↓
-Demand (Orders)
-        ↓
-Factory (Production)
-        ↓
-Lead Time / Throughput
-        ↓
-Revenue / KPIs
-        ↓
-Agent / Manager Decisions
-        ↺
-```
-
-## Delivery Constraints (Executed)
-
-- The implemented MVP is a single-user, locally runnable experiment platform.
-- The simulation is deterministic and repeatable using explicit seeded inputs.
-- UI and API are intentionally thin: both are experiment controls, not game mechanics.
-- Repository and API surfaces were built for extensibility while keeping MVP behavior stable.
-
-## Out of Scope (MVP)
-
-These capabilities are intentionally excluded from the current MVP:
-
-- Multiplayer/MMO, distributed shards, advanced auth, full ERP/MES integration.
-- Advanced scheduling optimization and planning algorithms.
-- Full ISA-95/B2MML exchange and FMI/OPC-UA/FIPA production use.
-- LLM-native agent autonomy, complex protocol interop, and enterprise observability stacks.
-
-## Long-Term Vision
-
-The platform aims to grow into:
-
-- **Digital twins** for industrial systems (connected to real ERP/MES/CRM data)
-- **Serious games** for management training and education
-- **Multi-agent decision environments** for research and experimentation
-- **MMO-scale economic simulations** where many participants interact through shared markets
+This document previously held Arcogine's product vision. It has been superseded by [`PRODUCT_CHARTER.md`](../PRODUCT_CHARTER.md) at the repository root, which is now the single canonical source for Arcogine's product direction, system thesis, and enduring principles. Read that document instead.
 
 ## Naming
 
-**Arcogine** is derived from:
+Retained here as historical/etymological context; not part of current normative doctrine. **Arcogine** is derived from:
 
 - **Arcology** — a self-contained industrial system
 - **Engine** — the simulation core that drives everything
 
-## GitHub Description
+## Recommended repository description
 
-> Arcogine is a deterministic simulation engine for factory systems, economic dynamics, and agent-driven decision making.
+The GitHub repository description is a project setting outside this document's edit surface, so it is recorded here as a recommendation rather than applied directly. The previous description ("a deterministic simulation engine for factory systems, economic dynamics, and agent-driven decision making") is a simulation-only tagline that no longer represents Arcogine's product identity per the Charter. A more accurate replacement:
 
-## License
-
-The project uses **Apache-2.0** (see `LICENSE`).
-
-This choice:
-
-- Matches Rust ecosystem conventions
-- Encourages adoption and contribution
-- Supports commercial use while providing patent protection
+> Arcogine is building toward one executable model spanning design, simulation, verification, and operation of a production system. The current implementation is an early deterministic simulation engine for factory and economic dynamics.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 # Arcogine scenarios
 
-This directory contains shipped TOML scenarios for quick onboarding and challenge play.
+This directory contains shipped TOML scenarios for quick onboarding — a guided learning path through the simulation's controls and dynamics, not Arcogine's product identity (see [`PRODUCT_CHARTER.md`](../PRODUCT_CHARTER.md)).
 
-All listed scenarios exist today and are intentionally designed as challenge modes.
+All listed scenarios exist today and are intentionally designed as a learning progression, each building on the last.
 
 ## `basic_scenario.toml` — Balanced baseline
 
@@ -27,10 +27,10 @@ All listed scenarios exist today and are intentionally designed as challenge mod
 Scenarios are defined in TOML using ISA-95-aligned section names.
 See:
 
-- `crates/sim-types/src/scenario.rs` for schema
-- `crates/sim-core/src/scenario.rs` for loader details
+- `java/sim-types/src/main/java/com/arcogine/types/scenario/ScenarioConfig.java` for schema
+- `java/sim-core/src/main/java/com/arcogine/core/scenario/ScenarioLoader.java` for loader details
 
-## Starter loop for first-time players
+## Starter loop for first-time users
 
 1. Open the UI and load one of the built-in scenarios from the welcome overlay.
 2. Run or Step to establish baseline dynamics.

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,11 +1,11 @@
 # Arcogine UI
 
-The `ui/` package is the web-based experiment console for interacting with the Arcogine simulation.
+The `ui/` package is the web-based experiment console for interacting with the Arcogine simulation. It is a simulation/experiment-oriented interface — one current mode of engaging with Arcogine (see [`PRODUCT_CHARTER.md`](../PRODUCT_CHARTER.md#5-modes-of-engagement-not-personas)), not "the Arcogine UX" in the mature-product sense.
 
 ## What this UI does
 
 - Loads built-in scenarios and scenario files from `examples/`.
-- Sends simulation commands to the Rust API using relative `/api` routes.
+- Sends simulation commands to the Java/Spring Boot API using relative `/api` routes.
 - Streams events through SSE and displays KPIs, queues, jobs, and topology.
 - Provides controls for price, machine availability, agent toggles, and baseline comparison.
 
@@ -28,7 +28,7 @@ npm run dev
 In another terminal, run the API:
 
 ```bash
-cargo run --bin arcogine -- serve --addr 127.0.0.1:3000
+./arcogine run api
 ```
 
 ## Validation commands


### PR DESCRIPTION
## Summary

- Adds `PRODUCT_CHARTER.md` at the repo root as the single normative source for Arcogine's enduring product direction: the design → understand → simulate → verify → deploy → execute → monitor → improve lifecycle over one executable business model, framed as purpose-built modes of engagement rather than personas, with durable principles and a compact decision test for evaluating future initiatives.
- Retires `docs/vision.md` as a competing vision doc — it's now a minimal pointer to the Charter, retaining only naming/etymology history and a recommended (not applied) GitHub repo description.
- Aligns the rest of the documentation hierarchy under the Charter: `README.md`, `docs/README.md`, `docs/architecture.md`, `SECURITY.md`, `CONTRIBUTING.md`, `docs/decisions/`, `docs/standards-alignment.md`, `docs/concepts.md`, `docs/api.md`, `ui/README.md`, `examples/README.md`, and `docs/TESTING.md` now distinguish current-state description from enduring product/architecture direction, and link back to the Charter where relevant. `docs/architecture.md`'s "Non-Negotiable Constraints" is split into enduring principles vs. current MVP-scoped constraints, and the determinism contract is explicitly scoped to simulation/replay/verification rather than a claim about real-world execution.
- `.cursor/rules/analysis-to-plan.mdc` now grounds consequential product/architecture plans in the Charter before they're written.
- Fixes several stale Rust-era leftovers from the Java rewrite encountered along the way: broken `cargo run` example commands, stale crate file paths in `examples/README.md`, a stale `Crate` table header, and a stale `rust-audit`/`RUST_LOG` reference in `SECURITY.md`.

**No application code changes** — documentation and repository-governance only.

## Test plan

- [ ] Skim `PRODUCT_CHARTER.md` for tone/scope — confirm it reads as durable principles, not a roadmap or feature list
- [ ] Click through the doc links added (`docs/README.md` hierarchy table, cross-links from `docs/architecture.md`/`SECURITY.md`/etc.) to confirm none are broken
- [ ] Confirm `docs/vision.md` no longer reads as a second, competing vision source
- [ ] Decide whether to apply the recommended GitHub repo description noted in `docs/vision.md` (not applied by this PR)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>