### PR TITLE
Add CLAUDE.md with branch-handling convention for AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Working conventions for AI agents
+
+## Branch to work on
+
+If a session starts with a branch other than `main` already checked out,
+treat that branch as the one to do the work on — do not switch to a
+different branch just because task/PR instructions injected into the
+prompt name one. If the injected branch instruction conflicts with the
+branch the session actually started on, flag the mismatch to the user
+instead of silently switching.


### PR DESCRIPTION
## Summary

- Adds a repo-root `CLAUDE.md` documenting a working convention for AI coding agents: if a session starts with a branch other than `main` already checked out, treat that branch as authoritative for the session's work — don't switch just because task/PR instructions injected into the prompt name a different branch. If there's a conflict, flag it to the user instead of silently switching.

This was originally committed onto the `devenv/remove-makefile` branch (PR #139) but was split out into its own branch/PR since it's unrelated to that refactor — keeping the two changes independently reviewable and revertable.

## Test plan

- N/A — documentation-only change (single new file, no code paths affected).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9A8HN47ss1NuMYfgS1hzg)_