### PR TITLE
factory: introduce canonical model and validation seam

### DIFF
--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModel.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModel.java
@@ -1,0 +1,50 @@
+package com.arcogine.factory.model;
+
+import java.util.List;
+
+/** Immutable semantic definition of a designed production system. */
+public record FactoryModel(
+        int schemaVersion,
+        List<ProductDefinition> products,
+        List<OperationDefinition> operations,
+        List<OperationStepDefinition> operationSteps,
+        List<ResourceDefinition> resourceDefinitions,
+        List<ResourceInstance> resourceInstances) {
+
+    public static final int CURRENT_SCHEMA_VERSION = 1;
+
+    public FactoryModel {
+        products = List.copyOf(products);
+        operations = List.copyOf(operations);
+        operationSteps = List.copyOf(operationSteps);
+        resourceDefinitions = List.copyOf(resourceDefinitions);
+        resourceInstances = List.copyOf(resourceInstances);
+    }
+
+    public record ProductDefinition(long id, String name, long operationDefinitionId) {}
+
+    public record OperationDefinition(long id, String name, List<Long> stepIds) {
+        public OperationDefinition {
+            stepIds = List.copyOf(stepIds);
+        }
+    }
+
+    public record OperationStepDefinition(
+            long id,
+            String name,
+            long duration,
+            List<Long> eligibleResourceInstanceIds) {
+        public OperationStepDefinition {
+            eligibleResourceInstanceIds = List.copyOf(eligibleResourceInstanceIds);
+        }
+    }
+
+    public record ResourceDefinition(
+            long id,
+            String name,
+            int concurrency,
+            Double capacityLiters,
+            long setupTime) {}
+
+    public record ResourceInstance(long id, long resourceDefinitionId) {}
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapter.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapter.java
@@ -1,0 +1,56 @@
+package com.arcogine.factory.model.scenario;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.FactoryModel.OperationDefinition;
+import com.arcogine.factory.model.FactoryModel.OperationStepDefinition;
+import com.arcogine.factory.model.FactoryModel.ProductDefinition;
+import com.arcogine.factory.model.FactoryModel.ResourceDefinition;
+import com.arcogine.factory.model.FactoryModel.ResourceInstance;
+import com.arcogine.types.scenario.ScenarioConfig;
+
+/** Adapts factory semantics out of the broader scenario/run input envelope. */
+public final class ScenarioFactoryModelAdapter {
+
+    private ScenarioFactoryModelAdapter() {}
+
+    public static FactoryModel fromScenario(ScenarioConfig config) {
+        var products = config.material().stream()
+                .map(material -> new ProductDefinition(
+                        material.id(), material.name(), material.routingId()))
+                .toList();
+
+        var operations = config.operationsDefinition().stream()
+                .map(operation -> new OperationDefinition(
+                        operation.id(), operation.name(), operation.steps()))
+                .toList();
+
+        var operationSteps = config.processSegment().stream()
+                .map(segment -> new OperationStepDefinition(
+                        segment.id(),
+                        segment.name(),
+                        segment.duration(),
+                        java.util.List.of(segment.equipmentId())))
+                .toList();
+
+        var resourceDefinitions = config.equipment().stream()
+                .map(equipment -> new ResourceDefinition(
+                        equipment.id(),
+                        equipment.name(),
+                        equipment.effectiveConcurrency(),
+                        equipment.capacityLiters(),
+                        equipment.effectiveSetupTime()))
+                .toList();
+
+        var resourceInstances = config.equipment().stream()
+                .map(equipment -> new ResourceInstance(equipment.id(), equipment.id()))
+                .toList();
+
+        return new FactoryModel(
+                FactoryModel.CURRENT_SCHEMA_VERSION,
+                products,
+                operations,
+                operationSteps,
+                resourceDefinitions,
+                resourceInstances);
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidator.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidator.java
@@ -1,0 +1,289 @@
+package com.arcogine.factory.model.validation;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.FactoryModel.OperationDefinition;
+import com.arcogine.factory.model.FactoryModel.OperationStepDefinition;
+import com.arcogine.factory.model.FactoryModel.ProductDefinition;
+import com.arcogine.factory.model.FactoryModel.ResourceDefinition;
+import com.arcogine.factory.model.FactoryModel.ResourceInstance;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Deterministic executability validation for canonical factory models. */
+public final class FactoryModelValidator {
+
+    private FactoryModelValidator() {}
+
+    public enum Severity {
+        ERROR,
+        WARNING
+    }
+
+    public record Finding(
+            String code,
+            Severity severity,
+            String message,
+            String entityType,
+            long entityId,
+            String path,
+            List<Long> relatedIds) {
+        public Finding {
+            relatedIds = List.copyOf(relatedIds);
+        }
+    }
+
+    public record Result(List<Finding> findings) {
+        public Result {
+            findings = List.copyOf(findings);
+        }
+
+        public boolean isValid() {
+            return findings.stream().noneMatch(finding -> finding.severity() == Severity.ERROR);
+        }
+    }
+
+    public static Result validate(FactoryModel model) {
+        List<Finding> findings = new ArrayList<>();
+
+        validateProductIds(model.products(), findings);
+        validateOperationIds(model.operations(), findings);
+        validateOperationStepIds(model.operationSteps(), findings);
+        validateResourceDefinitionIds(model.resourceDefinitions(), findings);
+        validateResourceInstanceIds(model.resourceInstances(), findings);
+        validateResourceValues(model.resourceDefinitions(), findings);
+        validateOperationStepValues(model.operationSteps(), findings);
+        validateReferences(model, findings);
+
+        return new Result(findings);
+    }
+
+    private static void validateProductIds(List<ProductDefinition> products, List<Finding> findings) {
+        Set<Long> seen = new HashSet<>();
+        for (ProductDefinition product : products) {
+            if (!seen.add(product.id())) {
+                findings.add(error(
+                        "DUPLICATE_PRODUCT_ID",
+                        "product",
+                        product.id(),
+                        "id",
+                        "Duplicate product identifier",
+                        List.of(product.id())));
+            }
+        }
+    }
+
+    private static void validateOperationIds(List<OperationDefinition> operations, List<Finding> findings) {
+        Set<Long> seen = new HashSet<>();
+        for (OperationDefinition operation : operations) {
+            if (!seen.add(operation.id())) {
+                findings.add(error(
+                        "DUPLICATE_OPERATION_ID",
+                        "operation",
+                        operation.id(),
+                        "id",
+                        "Duplicate operation identifier",
+                        List.of(operation.id())));
+            }
+        }
+    }
+
+    private static void validateOperationStepIds(
+            List<OperationStepDefinition> operationSteps, List<Finding> findings) {
+        Set<Long> seen = new HashSet<>();
+        for (OperationStepDefinition step : operationSteps) {
+            if (!seen.add(step.id())) {
+                findings.add(error(
+                        "DUPLICATE_OPERATION_STEP_ID",
+                        "operation_step",
+                        step.id(),
+                        "id",
+                        "Duplicate operation-step identifier",
+                        List.of(step.id())));
+            }
+        }
+    }
+
+    private static void validateResourceDefinitionIds(
+            List<ResourceDefinition> resourceDefinitions, List<Finding> findings) {
+        Set<Long> seen = new HashSet<>();
+        for (ResourceDefinition definition : resourceDefinitions) {
+            if (!seen.add(definition.id())) {
+                findings.add(error(
+                        "DUPLICATE_RESOURCE_DEFINITION_ID",
+                        "resource_definition",
+                        definition.id(),
+                        "id",
+                        "Duplicate resource-definition identifier",
+                        List.of(definition.id())));
+            }
+        }
+    }
+
+    private static void validateResourceInstanceIds(
+            List<ResourceInstance> resourceInstances, List<Finding> findings) {
+        Set<Long> seen = new HashSet<>();
+        for (ResourceInstance instance : resourceInstances) {
+            if (!seen.add(instance.id())) {
+                findings.add(error(
+                        "DUPLICATE_RESOURCE_INSTANCE_ID",
+                        "resource_instance",
+                        instance.id(),
+                        "id",
+                        "Duplicate resource-instance identifier",
+                        List.of(instance.id())));
+            }
+        }
+    }
+
+    private static void validateResourceValues(
+            List<ResourceDefinition> resourceDefinitions, List<Finding> findings) {
+        for (ResourceDefinition definition : resourceDefinitions) {
+            if (definition.concurrency() <= 0) {
+                findings.add(error(
+                        "INVALID_RESOURCE_CONCURRENCY",
+                        "resource_definition",
+                        definition.id(),
+                        "concurrency",
+                        "Resource concurrency must be greater than zero",
+                        List.of()));
+            }
+            if (definition.capacityLiters() != null && definition.capacityLiters() <= 0.0) {
+                findings.add(error(
+                        "INVALID_RESOURCE_CAPACITY",
+                        "resource_definition",
+                        definition.id(),
+                        "capacityLiters",
+                        "Resource capacity must be greater than zero when specified",
+                        List.of()));
+            }
+            if (definition.setupTime() < 0) {
+                findings.add(error(
+                        "INVALID_RESOURCE_SETUP_TIME",
+                        "resource_definition",
+                        definition.id(),
+                        "setupTime",
+                        "Resource setup time must not be negative",
+                        List.of()));
+            }
+        }
+    }
+
+    private static void validateOperationStepValues(
+            List<OperationStepDefinition> operationSteps, List<Finding> findings) {
+        for (OperationStepDefinition step : operationSteps) {
+            if (step.duration() <= 0) {
+                findings.add(error(
+                        "INVALID_OPERATION_DURATION",
+                        "operation_step",
+                        step.id(),
+                        "duration",
+                        "Operation-step duration must be greater than zero",
+                        List.of()));
+            }
+            if (step.eligibleResourceInstanceIds().isEmpty()) {
+                findings.add(error(
+                        "NO_ELIGIBLE_RESOURCE",
+                        "operation_step",
+                        step.id(),
+                        "eligibleResourceInstanceIds",
+                        "Operation step must have at least one eligible resource instance",
+                        List.of()));
+            }
+        }
+    }
+
+    private static void validateReferences(FactoryModel model, List<Finding> findings) {
+        Set<Long> operationIds = idsOfOperations(model.operations());
+        Set<Long> operationStepIds = idsOfOperationSteps(model.operationSteps());
+        Set<Long> resourceDefinitionIds = idsOfResourceDefinitions(model.resourceDefinitions());
+        Set<Long> resourceInstanceIds = idsOfResourceInstances(model.resourceInstances());
+
+        for (ProductDefinition product : model.products()) {
+            if (!operationIds.contains(product.operationDefinitionId())) {
+                findings.add(error(
+                        "UNKNOWN_OPERATION",
+                        "product",
+                        product.id(),
+                        "operationDefinitionId",
+                        "Product references an unknown operation definition",
+                        List.of(product.operationDefinitionId())));
+            }
+        }
+
+        for (OperationDefinition operation : model.operations()) {
+            for (Long stepId : operation.stepIds()) {
+                if (!operationStepIds.contains(stepId)) {
+                    findings.add(error(
+                            "UNKNOWN_OPERATION_STEP",
+                            "operation",
+                            operation.id(),
+                            "stepIds",
+                            "Operation references an unknown operation step",
+                            List.of(stepId)));
+                }
+            }
+        }
+
+        for (ResourceInstance instance : model.resourceInstances()) {
+            if (!resourceDefinitionIds.contains(instance.resourceDefinitionId())) {
+                findings.add(error(
+                        "UNKNOWN_RESOURCE_DEFINITION",
+                        "resource_instance",
+                        instance.id(),
+                        "resourceDefinitionId",
+                        "Resource instance references an unknown resource definition",
+                        List.of(instance.resourceDefinitionId())));
+            }
+        }
+
+        for (OperationStepDefinition step : model.operationSteps()) {
+            for (Long resourceId : step.eligibleResourceInstanceIds()) {
+                if (!resourceInstanceIds.contains(resourceId)) {
+                    findings.add(error(
+                            "UNKNOWN_ELIGIBLE_RESOURCE",
+                            "operation_step",
+                            step.id(),
+                            "eligibleResourceInstanceIds",
+                            "Operation step references an unknown eligible resource instance",
+                            List.of(resourceId)));
+                }
+            }
+        }
+    }
+
+    private static Set<Long> idsOfOperations(List<OperationDefinition> operations) {
+        Set<Long> ids = new HashSet<>();
+        operations.forEach(operation -> ids.add(operation.id()));
+        return ids;
+    }
+
+    private static Set<Long> idsOfOperationSteps(List<OperationStepDefinition> steps) {
+        Set<Long> ids = new HashSet<>();
+        steps.forEach(step -> ids.add(step.id()));
+        return ids;
+    }
+
+    private static Set<Long> idsOfResourceDefinitions(List<ResourceDefinition> definitions) {
+        Set<Long> ids = new HashSet<>();
+        definitions.forEach(definition -> ids.add(definition.id()));
+        return ids;
+    }
+
+    private static Set<Long> idsOfResourceInstances(List<ResourceInstance> instances) {
+        Set<Long> ids = new HashSet<>();
+        instances.forEach(instance -> ids.add(instance.id()));
+        return ids;
+    }
+
+    private static Finding error(
+            String code,
+            String entityType,
+            long entityId,
+            String path,
+            String message,
+            List<Long> relatedIds) {
+        return new Finding(code, Severity.ERROR, message, entityType, entityId, path, relatedIds);
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapterTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapterTest.java
@@ -1,0 +1,75 @@
+package com.arcogine.factory.model.scenario;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.types.scenario.AgentConfig;
+import com.arcogine.types.scenario.EconomyConfig;
+import com.arcogine.types.scenario.EquipmentConfig;
+import com.arcogine.types.scenario.MaterialConfig;
+import com.arcogine.types.scenario.OperationsDefinitionConfig;
+import com.arcogine.types.scenario.ProcessSegmentConfig;
+import com.arcogine.types.scenario.ScenarioConfig;
+import com.arcogine.types.scenario.SimulationParams;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ScenarioFactoryModelAdapterTest {
+
+    @Test
+    void adaptsOnlyFactorySemanticsAndPreservesCurrentResourceBinding() {
+        ScenarioConfig first = scenario(
+                new SimulationParams(42, 100, null, null),
+                new EconomyConfig(5.0, 3.0, 0.3, 0.05),
+                new AgentConfig(false, "sales"));
+        ScenarioConfig differentRunContext = scenario(
+                new SimulationParams(99, 999, 1L, 2L),
+                new EconomyConfig(50.0, 30.0, 3.0, 0.5),
+                new AgentConfig(true, "other"));
+
+        FactoryModel model = ScenarioFactoryModelAdapter.fromScenario(first);
+        FactoryModel sameFactory = ScenarioFactoryModelAdapter.fromScenario(differentRunContext);
+
+        assertEquals(sameFactory, model);
+        assertEquals(FactoryModel.CURRENT_SCHEMA_VERSION, model.schemaVersion());
+        assertEquals(1, model.products().size());
+        assertEquals(30L, model.products().getFirst().operationDefinitionId());
+        assertEquals(List.of(40L), model.operations().getFirst().stepIds());
+        assertEquals(List.of(10L), model.operationSteps().getFirst().eligibleResourceInstanceIds());
+        assertEquals(2, model.resourceDefinitions().getFirst().concurrency());
+        assertEquals(10L, model.resourceInstances().getFirst().resourceDefinitionId());
+    }
+
+    @Test
+    void producesAnImmutableSnapshotOfScenarioLists() {
+        List<Long> mutableSteps = new ArrayList<>(List.of(40L));
+        ScenarioConfig config = new ScenarioConfig(
+                new SimulationParams(42, 100, null, null),
+                List.of(new EquipmentConfig(10, "Mill", 2, 15.0, 3L)),
+                List.of(new MaterialConfig(20, "Widget", 30)),
+                List.of(new ProcessSegmentConfig(40, "Milling", 10, 5)),
+                List.of(new OperationsDefinitionConfig(30, "Widget routing", mutableSteps)),
+                null,
+                null);
+
+        FactoryModel model = ScenarioFactoryModelAdapter.fromScenario(config);
+        mutableSteps.add(41L);
+
+        assertEquals(List.of(40L), model.operations().getFirst().stepIds());
+        assertNotSame(mutableSteps, model.operations().getFirst().stepIds());
+    }
+
+    private static ScenarioConfig scenario(
+            SimulationParams simulation, EconomyConfig economy, AgentConfig agent) {
+        return new ScenarioConfig(
+                simulation,
+                List.of(new EquipmentConfig(10, "Mill", 2, 15.0, 3L)),
+                List.of(new MaterialConfig(20, "Widget", 30)),
+                List.of(new ProcessSegmentConfig(40, "Milling", 10, 5)),
+                List.of(new OperationsDefinitionConfig(30, "Widget routing", List.of(40L))),
+                economy,
+                agent);
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/FactoryModelValidatorTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/FactoryModelValidatorTest.java
@@ -1,0 +1,107 @@
+package com.arcogine.factory.model.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.FactoryModel.OperationDefinition;
+import com.arcogine.factory.model.FactoryModel.OperationStepDefinition;
+import com.arcogine.factory.model.FactoryModel.ProductDefinition;
+import com.arcogine.factory.model.FactoryModel.ResourceDefinition;
+import com.arcogine.factory.model.FactoryModel.ResourceInstance;
+import com.arcogine.factory.model.validation.FactoryModelValidator.Finding;
+import com.arcogine.factory.model.validation.FactoryModelValidator.Result;
+import com.arcogine.factory.model.validation.FactoryModelValidator.Severity;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FactoryModelValidatorTest {
+
+    @Test
+    void acceptsAValidCurrentSemanticsModel() {
+        Result result = FactoryModelValidator.validate(validModel());
+
+        assertTrue(result.isValid());
+        assertTrue(result.findings().isEmpty());
+    }
+
+    @Test
+    void reportsStructuredReferenceErrorsInDeterministicOrder() {
+        FactoryModel invalid = new FactoryModel(
+                FactoryModel.CURRENT_SCHEMA_VERSION,
+                List.of(new ProductDefinition(20, "Widget", 999)),
+                List.of(new OperationDefinition(30, "Widget routing", List.of(888L))),
+                List.of(new OperationStepDefinition(40, "Milling", 5, List.of(777L))),
+                List.of(new ResourceDefinition(10, "Mill", 1, null, 0)),
+                List.of(new ResourceInstance(10, 666)));
+
+        Result first = FactoryModelValidator.validate(invalid);
+        Result second = FactoryModelValidator.validate(invalid);
+
+        assertFalse(first.isValid());
+        assertEquals(first, second);
+        assertEquals(
+                List.of(
+                        "UNKNOWN_OPERATION",
+                        "UNKNOWN_OPERATION_STEP",
+                        "UNKNOWN_RESOURCE_DEFINITION",
+                        "UNKNOWN_ELIGIBLE_RESOURCE"),
+                first.findings().stream().map(Finding::code).toList());
+        assertEquals(Severity.ERROR, first.findings().getFirst().severity());
+        assertEquals("product", first.findings().getFirst().entityType());
+        assertEquals(20L, first.findings().getFirst().entityId());
+        assertEquals("operationDefinitionId", first.findings().getFirst().path());
+        assertEquals(List.of(999L), first.findings().getFirst().relatedIds());
+    }
+
+    @Test
+    void rejectsDuplicateIdentifiersAndInvalidExecutableValues() {
+        FactoryModel invalid = new FactoryModel(
+                FactoryModel.CURRENT_SCHEMA_VERSION,
+                List.of(
+                        new ProductDefinition(20, "Widget", 30),
+                        new ProductDefinition(20, "Duplicate", 30)),
+                List.of(new OperationDefinition(30, "Widget routing", List.of(40L))),
+                List.of(new OperationStepDefinition(40, "Milling", 0, List.of())),
+                List.of(new ResourceDefinition(10, "Mill", 0, 0.0, -1)),
+                List.of(new ResourceInstance(10, 10)));
+
+        Result result = FactoryModelValidator.validate(invalid);
+        List<String> codes = result.findings().stream().map(Finding::code).toList();
+
+        assertFalse(result.isValid());
+        assertTrue(codes.contains("DUPLICATE_PRODUCT_ID"));
+        assertTrue(codes.contains("INVALID_RESOURCE_CONCURRENCY"));
+        assertTrue(codes.contains("INVALID_RESOURCE_CAPACITY"));
+        assertTrue(codes.contains("INVALID_RESOURCE_SETUP_TIME"));
+        assertTrue(codes.contains("INVALID_OPERATION_DURATION"));
+        assertTrue(codes.contains("NO_ELIGIBLE_RESOURCE"));
+    }
+
+    @Test
+    void resultAndFindingsDefensivelyCopyTheirLists() {
+        Finding finding = new Finding(
+                "TEST",
+                Severity.WARNING,
+                "warning",
+                "resource",
+                1,
+                "field",
+                List.of(2L));
+        Result result = new Result(List.of(finding));
+
+        assertEquals(List.of(2L), result.findings().getFirst().relatedIds());
+        assertEquals(List.of(finding), result.findings());
+    }
+
+    private static FactoryModel validModel() {
+        return new FactoryModel(
+                FactoryModel.CURRENT_SCHEMA_VERSION,
+                List.of(new ProductDefinition(20, "Widget", 30)),
+                List.of(new OperationDefinition(30, "Widget routing", List.of(40L))),
+                List.of(new OperationStepDefinition(40, "Milling", 5, List.of(10L))),
+                List.of(new ResourceDefinition(10, "Mill", 1, null, 0)),
+                List.of(new ResourceInstance(10, 10)));
+    }
+}


### PR DESCRIPTION
## Summary

Begins the accepted canonical factory-model migration with the smallest behavior-preserving model-side slice.

- add an immutable `FactoryModel` aggregate inside the existing `:factory` module
- distinguish resource definitions from installed resource instances while preserving the current one-to-one equipment mapping
- represent each existing process segment as an operation step with a singleton eligible-resource set, preserving current direct-equipment semantics without introducing capability dispatch
- add a `ScenarioConfig -> FactoryModel` adapter that excludes simulation, economy, and agent run-context concerns
- add deterministic structured executability validation with stable codes, severity, entity/path context, and related identifiers
- add focused tests for run-context separation, defensive immutability, legacy resource binding, valid models, structured reference errors, duplicate identifiers, and invalid executable values

## Architectural scope

This is intentionally a D1/D2 foundation slice only. It does **not** introduce publication/version/hash policy, runtime instantiation from a published model, `ProductionOrder`/`WorkItem`, capability-based dispatch, spatial behavior, session APIs, or game concerns.

The next slice can build D3/D4 on this model boundary: validate/publish an immutable identified version, derive the existing runtime stores from it, retain model provenance, and run the existing scenario baselines through the seam.

## Validation

A local `./arcogine check` could not be executed in this environment because the runtime container cannot resolve GitHub to clone the repository; the changes were applied through the connected GitHub repository API. This PR's CI should therefore be treated as the executable validation gate, in addition to review of the focused tests included here.