### PR TITLE
Introduce canonical FactoryModel with validation and publication

### DIFF
--- a/infra/dev/claude-cloud.sh
+++ b/infra/dev/claude-cloud.sh
@@ -50,25 +50,6 @@ echo "==> Changing to repository directory: $REPO_DIR"
 cd "$REPO_DIR"
 
 # ---------------------------------------------------------------------------
-# 0. Clean up stale pre-reorg directories.
-# Repository structure was reorganized (java/ -> product/, ui/ ->
-# product/interfaces/web/) in PR #142. Environment snapshots captured
-# before that reorg ran can still carry a top-level java/ and/or ui/
-# directory left behind by an earlier provisioning run (npm ci /
-# gradlew executed against those old paths populated ui/node_modules and
-# java/.gradle). Those directories are untracked and no longer meaningful
-# under the current layout, so remove them before provisioning proceeds
-# to avoid confusing leftover build/dependency caches.
-# ---------------------------------------------------------------------------
-
-for stale_dir in java ui; do
-  if [ -d "$REPO_DIR/$stale_dir" ]; then
-    echo "==> Removing stale pre-reorg directory: $REPO_DIR/$stale_dir"
-    rm -rf "${REPO_DIR:?}/$stale_dir"
-  fi
-done
-
-# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/infra/dev/claude-cloud.sh
+++ b/infra/dev/claude-cloud.sh
@@ -50,6 +50,25 @@ echo "==> Changing to repository directory: $REPO_DIR"
 cd "$REPO_DIR"
 
 # ---------------------------------------------------------------------------
+# 0. Clean up stale pre-reorg directories.
+# Repository structure was reorganized (java/ -> product/, ui/ ->
+# product/interfaces/web/) in PR #142. Environment snapshots captured
+# before that reorg ran can still carry a top-level java/ and/or ui/
+# directory left behind by an earlier provisioning run (npm ci /
+# gradlew executed against those old paths populated ui/node_modules and
+# java/.gradle). Those directories are untracked and no longer meaningful
+# under the current layout, so remove them before provisioning proceeds
+# to avoid confusing leftover build/dependency caches.
+# ---------------------------------------------------------------------------
+
+for stale_dir in java ui; do
+  if [ -d "$REPO_DIR/$stale_dir" ]; then
+    echo "==> Removing stale pre-reorg directory: $REPO_DIR/$stale_dir"
+    rm -rf "${REPO_DIR:?}/$stale_dir"
+  fi
+done
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/product/domains/factory/build.gradle.kts
+++ b/product/domains/factory/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 dependencies {
     implementation(project(":types"))
     implementation(project(":simulation"))
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.22")
 }
 
 // Coverage gate: fails the build if sim-factory line coverage drops below the

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModel.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModel.java
@@ -1,0 +1,24 @@
+package com.arcogine.factory.model;
+
+import java.util.List;
+
+/**
+ * The canonical, consumer-neutral semantic definition of a designed production system: its
+ * resources, operations, and products.
+ *
+ * <p>This is deliberately narrow. Simulation configuration, RNG seed, economy configuration,
+ * agents, workload, and any other execution/run concern are never part of this type -- see
+ * ADR-0003 (canonical factory model boundary). {@link FactoryModel} is a plain, immutable value;
+ * it has no dependency on Spring, scenario parsing, or any runtime/mutable state.
+ */
+public record FactoryModel(
+        List<ResourceDefinition> resources,
+        List<OperationDefinition> operations,
+        List<ProductDefinition> products) {
+
+    public FactoryModel {
+        resources = resources == null ? List.of() : List.copyOf(resources);
+        operations = operations == null ? List.of() : List.copyOf(operations);
+        products = products == null ? List.of() : List.copyOf(products);
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelPublisher.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelPublisher.java
@@ -1,10 +1,12 @@
 package com.arcogine.factory.model;
 
 import com.arcogine.factory.model.validation.FactoryModelValidator;
+import com.arcogine.types.MachineId;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.List;
 
 /**
  * Publishes a validated {@link FactoryModel} as an immutable {@link FactoryModelVersion}.
@@ -51,11 +53,18 @@ public final class FactoryModelPublisher {
         for (OperationDefinition op : model.operations()) {
             sb.append(op.id()).append(':').append(op.name()).append(":[");
             for (OperationStepDefinition step : op.steps()) {
+                // eligibleResources is a Set: its iteration order isn't a defined canonical
+                // ordering, so two semantically-equal steps could otherwise hash differently.
+                // Sort by MachineId value explicitly rather than depending on Set/toString order.
+                List<Long> sortedEligible = step.eligibleResources().stream()
+                        .map(MachineId::value)
+                        .sorted()
+                        .toList();
                 sb.append(step.stepId())
                         .append(':')
                         .append(step.name())
                         .append(':')
-                        .append(step.eligibleResources())
+                        .append(sortedEligible)
                         .append(':')
                         .append(step.duration())
                         .append(';');

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelPublisher.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelPublisher.java
@@ -1,19 +1,14 @@
 package com.arcogine.factory.model;
 
 import com.arcogine.factory.model.validation.FactoryModelValidator;
-import com.arcogine.types.MachineId;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
-import java.util.List;
 
 /**
  * Publishes a validated {@link FactoryModel} as an immutable {@link FactoryModelVersion}.
  *
  * <p>Publication validates the model first (see {@link FactoryModelValidator}) and never returns
  * a version for a structurally invalid model, so a runtime is never constructed from a partially
- * valid design.
+ * valid design. {@link FactoryModelVersion} itself derives its content hash from the model rather
+ * than accepting one, so publication cannot produce a version with a mismatched identity either.
  */
 public final class FactoryModelPublisher {
 
@@ -21,66 +16,6 @@ public final class FactoryModelPublisher {
 
     public static FactoryModelVersion publish(FactoryModel model) {
         FactoryModelValidator.requireValid(model);
-        return new FactoryModelVersion(model, contentHash(model));
-    }
-
-    private static String contentHash(FactoryModel model) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(canonicalRepresentation(model).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 not available", e);
-        }
-    }
-
-    private static String canonicalRepresentation(FactoryModel model) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("resources=[");
-        for (ResourceDefinition r : model.resources()) {
-            sb.append(r.id().value())
-                    .append(':')
-                    .append(r.name())
-                    .append(':')
-                    .append(r.concurrency())
-                    .append(':')
-                    .append(r.capacityLiters())
-                    .append(':')
-                    .append(r.setupTime())
-                    .append(';');
-        }
-        sb.append("]operations=[");
-        for (OperationDefinition op : model.operations()) {
-            sb.append(op.id()).append(':').append(op.name()).append(":[");
-            for (OperationStepDefinition step : op.steps()) {
-                // eligibleResources is a Set: its iteration order isn't a defined canonical
-                // ordering, so two semantically-equal steps could otherwise hash differently.
-                // Sort by MachineId value explicitly rather than depending on Set/toString order.
-                List<Long> sortedEligible = step.eligibleResources().stream()
-                        .map(MachineId::value)
-                        .sorted()
-                        .toList();
-                sb.append(step.stepId())
-                        .append(':')
-                        .append(step.name())
-                        .append(':')
-                        .append(sortedEligible)
-                        .append(':')
-                        .append(step.duration())
-                        .append(';');
-            }
-            sb.append("];");
-        }
-        sb.append("]products=[");
-        for (ProductDefinition p : model.products()) {
-            sb.append(p.id().value())
-                    .append(':')
-                    .append(p.name())
-                    .append(':')
-                    .append(p.operationId())
-                    .append(';');
-        }
-        sb.append(']');
-        return sb.toString();
+        return new FactoryModelVersion(model);
     }
 }

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelPublisher.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelPublisher.java
@@ -1,0 +1,77 @@
+package com.arcogine.factory.model;
+
+import com.arcogine.factory.model.validation.FactoryModelValidator;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Publishes a validated {@link FactoryModel} as an immutable {@link FactoryModelVersion}.
+ *
+ * <p>Publication validates the model first (see {@link FactoryModelValidator}) and never returns
+ * a version for a structurally invalid model, so a runtime is never constructed from a partially
+ * valid design.
+ */
+public final class FactoryModelPublisher {
+
+    private FactoryModelPublisher() {}
+
+    public static FactoryModelVersion publish(FactoryModel model) {
+        FactoryModelValidator.requireValid(model);
+        return new FactoryModelVersion(model, contentHash(model));
+    }
+
+    private static String contentHash(FactoryModel model) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(canonicalRepresentation(model).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static String canonicalRepresentation(FactoryModel model) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("resources=[");
+        for (ResourceDefinition r : model.resources()) {
+            sb.append(r.id().value())
+                    .append(':')
+                    .append(r.name())
+                    .append(':')
+                    .append(r.concurrency())
+                    .append(':')
+                    .append(r.capacityLiters())
+                    .append(':')
+                    .append(r.setupTime())
+                    .append(';');
+        }
+        sb.append("]operations=[");
+        for (OperationDefinition op : model.operations()) {
+            sb.append(op.id()).append(':').append(op.name()).append(":[");
+            for (OperationStepDefinition step : op.steps()) {
+                sb.append(step.stepId())
+                        .append(':')
+                        .append(step.name())
+                        .append(':')
+                        .append(step.eligibleResources())
+                        .append(':')
+                        .append(step.duration())
+                        .append(';');
+            }
+            sb.append("];");
+        }
+        sb.append("]products=[");
+        for (ProductDefinition p : model.products()) {
+            sb.append(p.id().value())
+                    .append(':')
+                    .append(p.name())
+                    .append(':')
+                    .append(p.operationId())
+                    .append(';');
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelVersion.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelVersion.java
@@ -1,16 +1,24 @@
 package com.arcogine.factory.model;
 
 import com.arcogine.factory.model.validation.FactoryModelValidator;
+import com.arcogine.types.MachineId;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
 
 /**
  * An immutable, published identity of a {@link FactoryModel}.
  *
- * <p>{@code contentHash} is a deterministic digest of the model's semantic content: two
- * publications of an equal model produce the same hash. This is an internal, in-memory identity
- * policy sufficient to let a runtime/result attribute itself to the exact model it was
- * instantiated from -- it is not a persisted, public, or cross-process compatibility guarantee.
- * A durable model repository/lineage/versioning scheme is out of scope for this milestone; see
- * ADR-0003.
+ * <p>{@link #contentHash()} is a deterministic digest of the model's semantic content, derived
+ * entirely from {@code model} itself: two publications of an equal model always produce the same
+ * hash, and there is no way to construct a version whose hash does not identify its model -- the
+ * hash is not a constructor parameter a caller could forge or mismatch, it is computed here. This
+ * is an internal, in-memory identity policy sufficient to let a runtime/result attribute itself to
+ * the exact model it was instantiated from -- it is not a persisted, public, or cross-process
+ * compatibility guarantee. A durable model repository/lineage/versioning scheme is out of scope
+ * for this milestone; see ADR-0003.
  *
  * <p>{@link FactoryModelPublisher#publish(FactoryModel)} is the intended way to obtain an
  * instance, but the D2/D4 invariant that an invalid model can never be published or instantiated
@@ -18,17 +26,87 @@ import com.arcogine.factory.model.validation.FactoryModelValidator;
  * convention: constructing a {@code FactoryModelVersion} directly from an invalid model throws
  * {@link com.arcogine.factory.model.validation.FactoryModelValidationException} exactly as
  * {@code publish} does, so there is no construction path -- public API misuse included -- that
- * produces a version wrapping an unvalidated model.
+ * produces a version wrapping an unvalidated model or a forged identity.
  */
-public record FactoryModelVersion(FactoryModel model, String contentHash) {
+public record FactoryModelVersion(FactoryModel model) {
 
     public FactoryModelVersion {
         if (model == null) {
             throw new NullPointerException("model");
         }
-        if (contentHash == null) {
-            throw new NullPointerException("contentHash");
-        }
         FactoryModelValidator.requireValid(model);
+    }
+
+    public String contentHash() {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(canonicalRepresentation(model).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    /**
+     * Builds an unambiguous canonical encoding of {@code model}'s semantic content.
+     *
+     * <p>Every variable-length field (names, id lists) is framed with an explicit
+     * length-then-colon-then-content token (netstring-style), and every collection is
+     * length-prefixed with its element count. This makes the encoding injective: unlike a naive
+     * concatenation with fixed delimiters such as {@code ':'}/{@code ';'}, a value that happens to
+     * contain a delimiter character cannot make two semantically different models collide onto the
+     * same encoded string, because a decimal digit-only length prefix can never be confused with
+     * delimiter-bearing content.
+     */
+    private static String canonicalRepresentation(FactoryModel model) {
+        StringBuilder sb = new StringBuilder();
+
+        List<ResourceDefinition> resources = model.resources();
+        frame(sb, resources.size());
+        for (ResourceDefinition r : resources) {
+            frame(sb, r.id().value());
+            frame(sb, r.name());
+            frame(sb, r.concurrency());
+            frame(sb, r.capacityLiters());
+            frame(sb, r.setupTime());
+        }
+
+        List<OperationDefinition> operations = model.operations();
+        frame(sb, operations.size());
+        for (OperationDefinition op : operations) {
+            frame(sb, op.id());
+            frame(sb, op.name());
+            List<OperationStepDefinition> steps = op.steps();
+            frame(sb, steps.size());
+            for (OperationStepDefinition step : steps) {
+                frame(sb, step.stepId());
+                frame(sb, step.name());
+                frame(sb, step.duration());
+                // eligibleResources is a Set: its iteration order isn't a defined canonical
+                // ordering, so two semantically-equal steps could otherwise hash differently.
+                // Sort by MachineId value explicitly rather than depending on Set/toString order.
+                List<Long> sortedEligible =
+                        step.eligibleResources().stream().map(MachineId::value).sorted().toList();
+                frame(sb, sortedEligible.size());
+                for (Long resourceId : sortedEligible) {
+                    frame(sb, resourceId);
+                }
+            }
+        }
+
+        List<ProductDefinition> products = model.products();
+        frame(sb, products.size());
+        for (ProductDefinition p : products) {
+            frame(sb, p.id().value());
+            frame(sb, p.name());
+            frame(sb, p.operationId());
+        }
+
+        return sb.toString();
+    }
+
+    private static void frame(StringBuilder sb, Object value) {
+        String s = String.valueOf(value);
+        sb.append(s.length()).append(':').append(s);
     }
 }

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelVersion.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelVersion.java
@@ -1,0 +1,23 @@
+package com.arcogine.factory.model;
+
+/**
+ * An immutable, published identity of a {@link FactoryModel}.
+ *
+ * <p>{@code contentHash} is a deterministic digest of the model's semantic content: two
+ * publications of an equal model produce the same hash. This is an internal, in-memory identity
+ * policy sufficient to let a runtime/result attribute itself to the exact model it was
+ * instantiated from -- it is not a persisted, public, or cross-process compatibility guarantee.
+ * A durable model repository/lineage/versioning scheme is out of scope for this milestone; see
+ * ADR-0003.
+ */
+public record FactoryModelVersion(FactoryModel model, String contentHash) {
+
+    public FactoryModelVersion {
+        if (model == null) {
+            throw new NullPointerException("model");
+        }
+        if (contentHash == null) {
+            throw new NullPointerException("contentHash");
+        }
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelVersion.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelVersion.java
@@ -1,5 +1,7 @@
 package com.arcogine.factory.model;
 
+import com.arcogine.factory.model.validation.FactoryModelValidator;
+
 /**
  * An immutable, published identity of a {@link FactoryModel}.
  *
@@ -9,6 +11,14 @@ package com.arcogine.factory.model;
  * instantiated from -- it is not a persisted, public, or cross-process compatibility guarantee.
  * A durable model repository/lineage/versioning scheme is out of scope for this milestone; see
  * ADR-0003.
+ *
+ * <p>{@link FactoryModelPublisher#publish(FactoryModel)} is the intended way to obtain an
+ * instance, but the D2/D4 invariant that an invalid model can never be published or instantiated
+ * is enforced here, in the canonical constructor itself, rather than relied upon merely by
+ * convention: constructing a {@code FactoryModelVersion} directly from an invalid model throws
+ * {@link com.arcogine.factory.model.validation.FactoryModelValidationException} exactly as
+ * {@code publish} does, so there is no construction path -- public API misuse included -- that
+ * produces a version wrapping an unvalidated model.
  */
 public record FactoryModelVersion(FactoryModel model, String contentHash) {
 
@@ -19,5 +29,6 @@ public record FactoryModelVersion(FactoryModel model, String contentHash) {
         if (contentHash == null) {
             throw new NullPointerException("contentHash");
         }
+        FactoryModelValidator.requireValid(model);
     }
 }

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryRuntimeAssembler.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryRuntimeAssembler.java
@@ -17,7 +17,10 @@ import java.util.List;
  *
  * <p>This is the runtime-construction half of the model boundary: runtime state is instantiated
  * from the canonical model, never assembled directly from scenario/consumer input. The model
- * itself is never mutated by this process.
+ * itself is never mutated by this process. No re-validation happens here: {@link
+ * FactoryModelVersion}'s own canonical constructor already guarantees {@code version.model()} is
+ * valid, since there is no way to construct a {@code FactoryModelVersion} wrapping an invalid
+ * model in the first place.
  */
 public final class FactoryRuntimeAssembler {
 

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryRuntimeAssembler.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryRuntimeAssembler.java
@@ -1,0 +1,61 @@
+package com.arcogine.factory.model;
+
+import com.arcogine.factory.machines.Machine;
+import com.arcogine.factory.machines.MachineStore;
+import com.arcogine.factory.process.FactoryHandler;
+import com.arcogine.factory.routing.Routing;
+import com.arcogine.factory.routing.RoutingStep;
+import com.arcogine.factory.routing.RoutingStore;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Constructs factory runtime state ({@link MachineStore}, {@link RoutingStore}, {@link
+ * FactoryHandler}) from one published {@link FactoryModelVersion}.
+ *
+ * <p>This is the runtime-construction half of the model boundary: runtime state is instantiated
+ * from the canonical model, never assembled directly from scenario/consumer input. The model
+ * itself is never mutated by this process.
+ */
+public final class FactoryRuntimeAssembler {
+
+    private FactoryRuntimeAssembler() {}
+
+    public static Assembled assemble(FactoryModelVersion version) {
+        FactoryModel model = version.model();
+
+        MachineStore machines = new MachineStore();
+        for (ResourceDefinition resource : model.resources()) {
+            machines.add(new Machine(
+                    resource.id(),
+                    resource.name(),
+                    resource.concurrency(),
+                    resource.capacityLiters(),
+                    resource.setupTime()));
+        }
+
+        RoutingStore routings = new RoutingStore();
+        for (OperationDefinition operation : model.operations()) {
+            List<RoutingStep> steps = new ArrayList<>();
+            for (OperationStepDefinition step : operation.steps()) {
+                MachineId equipmentId = step.eligibleResources().iterator().next();
+                steps.add(new RoutingStep(step.stepId(), step.name(), equipmentId, step.duration()));
+            }
+            routings.addRouting(new Routing(operation.id(), operation.name(), steps));
+        }
+
+        List<ProductId> productIds = new ArrayList<>();
+        for (ProductDefinition product : model.products()) {
+            productIds.add(product.id());
+            routings.addProductRouting(product.id(), product.operationId());
+        }
+
+        FactoryHandler factory = new FactoryHandler(machines, routings, productIds);
+        return new Assembled(factory, List.copyOf(productIds));
+    }
+
+    /** The runtime factory handler and the product ids it was assembled for. */
+    public record Assembled(FactoryHandler factory, List<ProductId> productIds) {}
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/OperationDefinition.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/OperationDefinition.java
@@ -1,0 +1,14 @@
+package com.arcogine.factory.model;
+
+import java.util.List;
+
+/** An ordered sequence of {@link OperationStepDefinition}s a product may be routed through. */
+public record OperationDefinition(long id, String name, List<OperationStepDefinition> steps) {
+
+    public OperationDefinition {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        steps = steps == null ? List.of() : List.copyOf(steps);
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/OperationStepDefinition.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/OperationStepDefinition.java
@@ -1,0 +1,28 @@
+package com.arcogine.factory.model;
+
+import com.arcogine.types.MachineId;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * One step of an {@link OperationDefinition}.
+ *
+ * <p>{@code eligibleResources} represents which installed resources may perform this step. Today
+ * a scenario's {@code process_segment} binds to exactly one {@code equipment_id}, so the set
+ * always has a single member; the set shape is used so a future capability-based eligibility
+ * representation does not require changing this type's identity, without this milestone actually
+ * implementing multi-resource dispatch.
+ */
+public record OperationStepDefinition(
+        long stepId, String name, Set<MachineId> eligibleResources, long duration) {
+
+    public OperationStepDefinition {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        eligibleResources =
+                eligibleResources == null
+                        ? Set.of()
+                        : Set.copyOf(new LinkedHashSet<>(eligibleResources));
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/ProductDefinition.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/ProductDefinition.java
@@ -1,0 +1,16 @@
+package com.arcogine.factory.model;
+
+import com.arcogine.types.ProductId;
+
+/** A product/material that is produced by routing it through one {@link OperationDefinition}. */
+public record ProductDefinition(ProductId id, String name, long operationId) {
+
+    public ProductDefinition {
+        if (id == null) {
+            throw new NullPointerException("id");
+        }
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/ResourceDefinition.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/ResourceDefinition.java
@@ -1,0 +1,24 @@
+package com.arcogine.factory.model;
+
+import com.arcogine.types.MachineId;
+
+/**
+ * A resource (piece of equipment) that can be installed in a factory design.
+ *
+ * <p>Current scenarios do not distinguish a reusable resource "type" from an installed
+ * instance -- each configured resource is a single concrete, uniquely identified unit. This
+ * type therefore represents both facts at once; splitting definition from instance is deferred
+ * until a scenario/consumer actually needs a resource type installed more than once.
+ */
+public record ResourceDefinition(
+        MachineId id, String name, int concurrency, Double capacityLiters, long setupTime) {
+
+    public ResourceDefinition {
+        if (id == null) {
+            throw new NullPointerException("id");
+        }
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapter.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapter.java
@@ -1,0 +1,70 @@
+package com.arcogine.factory.model.scenario;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.OperationDefinition;
+import com.arcogine.factory.model.OperationStepDefinition;
+import com.arcogine.factory.model.ProductDefinition;
+import com.arcogine.factory.model.ResourceDefinition;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import com.arcogine.types.scenario.EquipmentConfig;
+import com.arcogine.types.scenario.MaterialConfig;
+import com.arcogine.types.scenario.OperationsDefinitionConfig;
+import com.arcogine.types.scenario.ScenarioConfig;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Adapts a {@link ScenarioConfig} (today's TOML-derived scenario/run input envelope) into a
+ * canonical {@link FactoryModel}.
+ *
+ * <p>This is deliberately a narrow, faithful translation: it preserves today's semantics exactly
+ * and does not introduce broader behavior the current scenario shape does not express. In
+ * particular, a {@code process_segment} binds to exactly one {@code equipment_id}, so each
+ * resulting {@link OperationStepDefinition} has a single-member eligibility set -- this is not
+ * capability-based dispatch.
+ *
+ * <p>Only factory-design concerns are read from the scenario: equipment, material, process
+ * segments, and operations definitions. Simulation, economy, and agent configuration are
+ * execution/run concerns and are never mapped into the model (see ADR-0003).
+ */
+public final class ScenarioFactoryModelAdapter {
+
+    private ScenarioFactoryModelAdapter() {}
+
+    public static FactoryModel adapt(ScenarioConfig config) {
+        List<ResourceDefinition> resources = new ArrayList<>();
+        for (EquipmentConfig eq : config.equipment()) {
+            resources.add(new ResourceDefinition(
+                    new MachineId(eq.id()),
+                    eq.name(),
+                    eq.effectiveConcurrency(),
+                    eq.capacityLiters(),
+                    eq.effectiveSetupTime()));
+        }
+
+        List<OperationDefinition> operations = new ArrayList<>();
+        for (OperationsDefinitionConfig od : config.operationsDefinition()) {
+            List<OperationStepDefinition> steps = new ArrayList<>();
+            for (Long segId : od.steps()) {
+                config.processSegment().stream()
+                        .filter(s -> s.id() == segId)
+                        .findFirst()
+                        .ifPresent(s -> steps.add(new OperationStepDefinition(
+                                s.id(),
+                                s.name(),
+                                Set.of(new MachineId(s.equipmentId())),
+                                s.duration())));
+            }
+            operations.add(new OperationDefinition(od.id(), od.name(), steps));
+        }
+
+        List<ProductDefinition> products = new ArrayList<>();
+        for (MaterialConfig mat : config.material()) {
+            products.add(new ProductDefinition(new ProductId(mat.id()), mat.name(), mat.routingId()));
+        }
+
+        return new FactoryModel(resources, operations, products);
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidationException.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidationException.java
@@ -1,0 +1,18 @@
+package com.arcogine.factory.model.validation;
+
+/** Thrown when a {@code FactoryModel} fails structural validation before publication. */
+public class FactoryModelValidationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final transient ModelValidationResult result;
+
+    public FactoryModelValidationException(ModelValidationResult result) {
+        super("factory model failed validation: " + result.errors());
+        this.result = result;
+    }
+
+    public ModelValidationResult result() {
+        return result;
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidator.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidator.java
@@ -1,0 +1,101 @@
+package com.arcogine.factory.model.validation;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.OperationDefinition;
+import com.arcogine.factory.model.OperationStepDefinition;
+import com.arcogine.factory.model.ProductDefinition;
+import com.arcogine.factory.model.ResourceDefinition;
+import com.arcogine.types.MachineId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Deterministic structural validation of a {@link FactoryModel}, performed before the model may
+ * be published or used to construct runtime state.
+ *
+ * <p>This checks only structural/referential invariants (uniqueness, resolvable references,
+ * coherent resource/operation relationships) -- it does not partially construct or mutate any
+ * runtime state.
+ */
+public final class FactoryModelValidator {
+
+    private FactoryModelValidator() {}
+
+    public static ModelValidationResult validate(FactoryModel model) {
+        List<ModelValidationError> errors = new ArrayList<>();
+
+        Set<MachineId> resourceIds = new HashSet<>();
+        for (ResourceDefinition resource : model.resources()) {
+            if (!resourceIds.add(resource.id())) {
+                errors.add(new ModelValidationError(
+                        "resources", "duplicate resource id: " + resource.id()));
+            }
+            if (resource.concurrency() <= 0) {
+                errors.add(new ModelValidationError(
+                        "resources[" + resource.id() + "].concurrency", "must be > 0"));
+            }
+        }
+
+        Set<Long> operationIds = new HashSet<>();
+        for (OperationDefinition operation : model.operations()) {
+            if (!operationIds.add(operation.id())) {
+                errors.add(new ModelValidationError(
+                        "operations", "duplicate operation id: " + operation.id()));
+            }
+            if (operation.steps().isEmpty()) {
+                errors.add(new ModelValidationError(
+                        "operations[" + operation.id() + "].steps", "must not be empty"));
+            }
+            for (OperationStepDefinition step : operation.steps()) {
+                if (step.duration() <= 0) {
+                    errors.add(new ModelValidationError(
+                            "operations[" + operation.id() + "].steps[" + step.stepId() + "].duration",
+                            "must be > 0"));
+                }
+                if (step.eligibleResources().isEmpty()) {
+                    errors.add(new ModelValidationError(
+                            "operations[" + operation.id() + "].steps[" + step.stepId()
+                                    + "].eligibleResources",
+                            "must reference at least one resource"));
+                    continue;
+                }
+                for (MachineId resourceId : step.eligibleResources()) {
+                    if (!resourceIds.contains(resourceId)) {
+                        errors.add(new ModelValidationError(
+                                "operations[" + operation.id() + "].steps[" + step.stepId()
+                                        + "].eligibleResources",
+                                "references nonexistent resource id: " + resourceId));
+                    }
+                }
+            }
+        }
+
+        Set<com.arcogine.types.ProductId> productIds = new HashSet<>();
+        for (ProductDefinition product : model.products()) {
+            if (!productIds.add(product.id())) {
+                errors.add(new ModelValidationError(
+                        "products", "duplicate product id: " + product.id()));
+            }
+            if (!operationIds.contains(product.operationId())) {
+                errors.add(new ModelValidationError(
+                        "products[" + product.id() + "].operationId",
+                        "references nonexistent operation id: " + product.operationId()));
+            }
+        }
+
+        return new ModelValidationResult(errors);
+    }
+
+    /**
+     * Validates {@code model} and throws {@link FactoryModelValidationException} if it is
+     * structurally invalid.
+     */
+    public static void requireValid(FactoryModel model) {
+        ModelValidationResult result = validate(model);
+        if (!result.isValid()) {
+            throw new FactoryModelValidationException(result);
+        }
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidator.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidator.java
@@ -61,6 +61,20 @@ public final class FactoryModelValidator {
                             "must reference at least one resource"));
                     continue;
                 }
+                // Runtime dispatch in this milestone binds a step to exactly one concrete
+                // resource (see ADR-0003 / ScenarioFactoryModelAdapter) -- it does not implement
+                // capability-based dispatch across a multi-resource eligibility set. A model
+                // publishing more than one eligible resource per step therefore cannot be
+                // faithfully instantiated by the current runtime and must be rejected here,
+                // rather than silently collapsed to one resource at assembly time.
+                if (step.eligibleResources().size() > 1) {
+                    errors.add(new ModelValidationError(
+                            "operations[" + operation.id() + "].steps[" + step.stepId()
+                                    + "].eligibleResources",
+                            "must reference exactly one resource in this milestone "
+                                    + "(multi-resource dispatch is not yet supported by the runtime)"));
+                    continue;
+                }
                 for (MachineId resourceId : step.eligibleResources()) {
                     if (!resourceIds.contains(resourceId)) {
                         errors.add(new ModelValidationError(

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/ModelValidationError.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/ModelValidationError.java
@@ -1,0 +1,19 @@
+package com.arcogine.factory.model.validation;
+
+/** One structural violation found while validating a {@code FactoryModel}. */
+public record ModelValidationError(String field, String message) {
+
+    public ModelValidationError {
+        if (field == null) {
+            throw new NullPointerException("field");
+        }
+        if (message == null) {
+            throw new NullPointerException("message");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return field + ": " + message;
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/ModelValidationResult.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/ModelValidationResult.java
@@ -1,0 +1,19 @@
+package com.arcogine.factory.model.validation;
+
+import java.util.List;
+
+/** Deterministic, structured result of validating a {@code FactoryModel}. */
+public record ModelValidationResult(List<ModelValidationError> errors) {
+
+    public ModelValidationResult {
+        errors = errors == null ? List.of() : List.copyOf(errors);
+    }
+
+    public static ModelValidationResult valid() {
+        return new ModelValidationResult(List.of());
+    }
+
+    public boolean isValid() {
+        return errors.isEmpty();
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelImmutabilityTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelImmutabilityTest.java
@@ -1,0 +1,90 @@
+package com.arcogine.factory.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves the publication invariant that a {@link FactoryModel}/{@link FactoryModelVersion} cannot
+ * be mutated after construction, either by writing back through an accessor or by mutating a
+ * mutable collection the caller passed in.
+ */
+class FactoryModelImmutabilityTest {
+
+    @Test
+    void resourcesListRejectsMutationThroughTheAccessor() {
+        FactoryModel model = new FactoryModel(
+                new ArrayList<>(List.of(new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0))),
+                List.of(),
+                List.of());
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> model.resources().add(new ResourceDefinition(new MachineId(2), "Lathe", 1, null, 0)));
+    }
+
+    @Test
+    void constructorDefensivelyCopiesTheResourcesList() {
+        List<ResourceDefinition> mutableResources =
+                new ArrayList<>(List.of(new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0)));
+        FactoryModel model = new FactoryModel(mutableResources, List.of(), List.of());
+
+        mutableResources.add(new ResourceDefinition(new MachineId(2), "Lathe", 1, null, 0));
+
+        assertEquals(1, model.resources().size(), "model must not observe mutation of the source list");
+    }
+
+    @Test
+    void operationStepsListIsDefensivelyCopiedAndUnmodifiable() {
+        List<OperationStepDefinition> mutableSteps = new ArrayList<>(
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)));
+        OperationDefinition operation = new OperationDefinition(100, "Widget routing", mutableSteps);
+
+        mutableSteps.add(new OperationStepDefinition(2, "Extra step", Set.of(new MachineId(1)), 5));
+
+        assertEquals(1, operation.steps().size(), "operation must not observe mutation of the source list");
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> operation.steps().add(new OperationStepDefinition(3, "x", Set.of(new MachineId(1)), 1)));
+    }
+
+    @Test
+    void eligibleResourcesSetIsDefensivelyCopiedAndUnmodifiable() {
+        Set<MachineId> mutableEligible = new HashSet<>(Set.of(new MachineId(1)));
+        OperationStepDefinition step = new OperationStepDefinition(1, "Rough milling", mutableEligible, 5);
+
+        mutableEligible.add(new MachineId(2));
+
+        assertEquals(1, step.eligibleResources().size(), "step must not observe mutation of the source set");
+        assertThrows(
+                UnsupportedOperationException.class, () -> step.eligibleResources().add(new MachineId(3)));
+    }
+
+    @Test
+    void mutatingTheSourceModelAfterPublicationDoesNotAffectThePublishedVersion() {
+        List<ResourceDefinition> mutableResources =
+                new ArrayList<>(List.of(new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0)));
+        List<OperationDefinition> operations = List.of(new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5))));
+        List<ProductDefinition> products = List.of(new ProductDefinition(new ProductId(10), "Widget", 100));
+
+        FactoryModel model = new FactoryModel(mutableResources, operations, products);
+        FactoryModelVersion version = FactoryModelPublisher.publish(model);
+        String hashBeforeMutation = version.contentHash();
+
+        // A source collection can only be mutated before construction (it's defensively copied),
+        // so this exercises that the already-published version is unaffected by any further
+        // change to the model instance itself: there is no setter to mutate it through.
+        assertEquals(hashBeforeMutation, version.contentHash());
+        assertEquals(1, version.model().resources().size());
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelPublisherTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelPublisherTest.java
@@ -65,4 +65,34 @@ class FactoryModelPublisherTest {
 
         assertEquals(model, version.model());
     }
+
+    @Test
+    void namesContainingDelimiterCharactersDoNotCauseHashCollisions() {
+        // Regression for a naive ':'/';'-delimited canonical representation: a two-product model
+        // and a one-product model whose single product name happens to contain those delimiter
+        // characters could otherwise serialize to the identical string and hash identically, even
+        // though they are different designs (different product counts, different operation
+        // references). The canonical representation must use unambiguous length-framing instead.
+        ResourceDefinition mill = new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0);
+        OperationDefinition op10 = new OperationDefinition(
+                10, "Op10", List.of(new OperationStepDefinition(1, "Step", Set.of(new MachineId(1)), 5)));
+        OperationDefinition op20 = new OperationDefinition(
+                20, "Op20", List.of(new OperationStepDefinition(2, "Step", Set.of(new MachineId(1)), 5)));
+
+        FactoryModel twoProducts = new FactoryModel(
+                List.of(mill),
+                List.of(op10, op20),
+                List.of(
+                        new ProductDefinition(new ProductId(1), "A", 10),
+                        new ProductDefinition(new ProductId(2), "B", 20)));
+        FactoryModel oneProductWithDelimiterLadenName = new FactoryModel(
+                List.of(mill),
+                List.of(op10, op20),
+                List.of(new ProductDefinition(new ProductId(1), "A:10;2:B", 20)));
+
+        FactoryModelVersion a = FactoryModelPublisher.publish(twoProducts);
+        FactoryModelVersion b = FactoryModelPublisher.publish(oneProductWithDelimiterLadenName);
+
+        assertNotEquals(a.contentHash(), b.contentHash());
+    }
 }

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelPublisherTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelPublisherTest.java
@@ -1,0 +1,68 @@
+package com.arcogine.factory.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.arcogine.factory.model.validation.FactoryModelValidationException;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class FactoryModelPublisherTest {
+
+    private static FactoryModel validModel() {
+        ResourceDefinition mill = new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0);
+        OperationDefinition routing = new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)));
+        ProductDefinition widget = new ProductDefinition(new ProductId(10), "Widget", 100);
+        return new FactoryModel(List.of(mill), List.of(routing), List.of(widget));
+    }
+
+    @Test
+    void publishRejectsInvalidModel() {
+        FactoryModel invalid = new FactoryModel(
+                List.of(new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0)),
+                List.of(new OperationDefinition(100, "Empty", List.of())),
+                List.of());
+
+        assertThrows(FactoryModelValidationException.class, () -> FactoryModelPublisher.publish(invalid));
+    }
+
+    @Test
+    void equalModelsProduceTheSameContentHash() {
+        FactoryModelVersion a = FactoryModelPublisher.publish(validModel());
+        FactoryModelVersion b = FactoryModelPublisher.publish(validModel());
+
+        assertEquals(a.contentHash(), b.contentHash());
+        assertEquals(a.model(), b.model());
+    }
+
+    @Test
+    void differentModelsProduceDifferentContentHashes() {
+        FactoryModelVersion a = FactoryModelPublisher.publish(validModel());
+
+        ResourceDefinition otherMill = new ResourceDefinition(new MachineId(1), "Other Mill", 1, null, 0);
+        OperationDefinition routing = new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)));
+        ProductDefinition widget = new ProductDefinition(new ProductId(10), "Widget", 100);
+        FactoryModelVersion b = FactoryModelPublisher.publish(
+                new FactoryModel(List.of(otherMill), List.of(routing), List.of(widget)));
+
+        assertNotEquals(a.contentHash(), b.contentHash());
+    }
+
+    @Test
+    void publishedModelCarriesTheOriginalModelUnmodified() {
+        FactoryModel model = validModel();
+        FactoryModelVersion version = FactoryModelPublisher.publish(model);
+
+        assertEquals(model, version.model());
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelRecordsTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelRecordsTest.java
@@ -1,0 +1,81 @@
+package com.arcogine.factory.model;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the null-rejection and null-defaulting branches of the model value types' compact
+ * constructors, which the higher-level adapter/validator/publisher tests never happen to exercise
+ * because they always build well-formed values.
+ */
+class FactoryModelRecordsTest {
+
+    @Test
+    void resourceDefinitionRejectsNullId() {
+        assertThrows(
+                NullPointerException.class, () -> new ResourceDefinition(null, "Mill", 1, null, 0));
+    }
+
+    @Test
+    void resourceDefinitionRejectsNullName() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new ResourceDefinition(new MachineId(1), null, 1, null, 0));
+    }
+
+    @Test
+    void operationDefinitionRejectsNullName() {
+        assertThrows(NullPointerException.class, () -> new OperationDefinition(1, null, List.of()));
+    }
+
+    @Test
+    void operationDefinitionDefaultsNullStepsToEmpty() {
+        OperationDefinition operation = new OperationDefinition(1, "Op", null);
+
+        assertTrue(operation.steps().isEmpty());
+    }
+
+    @Test
+    void operationStepDefinitionRejectsNullName() {
+        assertThrows(
+                NullPointerException.class, () -> new OperationStepDefinition(1, null, Set.of(), 5));
+    }
+
+    @Test
+    void operationStepDefinitionDefaultsNullEligibleResourcesToEmpty() {
+        OperationStepDefinition step = new OperationStepDefinition(1, "Step", null, 5);
+
+        assertTrue(step.eligibleResources().isEmpty());
+    }
+
+    @Test
+    void productDefinitionRejectsNullId() {
+        assertThrows(NullPointerException.class, () -> new ProductDefinition(null, "Widget", 1));
+    }
+
+    @Test
+    void productDefinitionRejectsNullName() {
+        assertThrows(
+                NullPointerException.class, () -> new ProductDefinition(new ProductId(1), null, 1));
+    }
+
+    @Test
+    void factoryModelDefaultsNullCollectionsToEmpty() {
+        FactoryModel model = new FactoryModel(null, null, null);
+
+        assertTrue(model.resources().isEmpty());
+        assertTrue(model.operations().isEmpty());
+        assertTrue(model.products().isEmpty());
+    }
+
+    @Test
+    void factoryModelVersionRejectsNullModel() {
+        assertThrows(NullPointerException.class, () -> new FactoryModelVersion(null));
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryRuntimeAssemblerTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryRuntimeAssemblerTest.java
@@ -47,8 +47,6 @@ class FactoryRuntimeAssemblerTest {
                 List.of(new OperationDefinition(100, "Empty", List.of())),
                 List.of());
 
-        assertThrows(
-                FactoryModelValidationException.class,
-                () -> new FactoryModelVersion(invalid, "not-a-real-hash"));
+        assertThrows(FactoryModelValidationException.class, () -> new FactoryModelVersion(invalid));
     }
 }

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryRuntimeAssemblerTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryRuntimeAssemblerTest.java
@@ -1,7 +1,9 @@
 package com.arcogine.factory.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.arcogine.factory.model.validation.FactoryModelValidationException;
 import com.arcogine.factory.process.FactoryHandler;
 import com.arcogine.types.MachineId;
 import com.arcogine.types.ProductId;
@@ -33,5 +35,20 @@ class FactoryRuntimeAssemblerTest {
                         .findFirst()
                         .orElseThrow()
                         .concurrency());
+    }
+
+    @Test
+    void cannotConstructAFactoryModelVersionWrappingAnInvalidModelEvenBypassingThePublisher() {
+        // FactoryModelVersion's own canonical constructor validates, not just
+        // FactoryModelPublisher.publish -- so there is no construction path, direct or otherwise,
+        // that lets assemble() ever see an invalid model.
+        FactoryModel invalid = new FactoryModel(
+                List.of(new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0)),
+                List.of(new OperationDefinition(100, "Empty", List.of())),
+                List.of());
+
+        assertThrows(
+                FactoryModelValidationException.class,
+                () -> new FactoryModelVersion(invalid, "not-a-real-hash"));
     }
 }

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryRuntimeAssemblerTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryRuntimeAssemblerTest.java
@@ -1,0 +1,37 @@
+package com.arcogine.factory.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.arcogine.factory.process.FactoryHandler;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class FactoryRuntimeAssemblerTest {
+
+    @Test
+    void assemblesFactoryHandlerMatchingThePublishedModel() {
+        ResourceDefinition mill = new ResourceDefinition(new MachineId(1), "Mill", 2, 100.0, 3);
+        OperationDefinition routing = new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)));
+        ProductDefinition widget = new ProductDefinition(new ProductId(10), "Widget", 100);
+        FactoryModelVersion version =
+                FactoryModelPublisher.publish(new FactoryModel(List.of(mill), List.of(routing), List.of(widget)));
+
+        FactoryRuntimeAssembler.Assembled assembled = FactoryRuntimeAssembler.assemble(version);
+
+        FactoryHandler factory = assembled.factory();
+        assertEquals(List.of(new ProductId(10)), assembled.productIds());
+        assertEquals(
+                2,
+                factory.machinesView().stream()
+                        .filter(m -> m.id().equals(new MachineId(1)))
+                        .findFirst()
+                        .orElseThrow()
+                        .concurrency());
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapterTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapterTest.java
@@ -1,0 +1,66 @@
+package com.arcogine.factory.model.scenario;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.OperationDefinition;
+import com.arcogine.factory.model.OperationStepDefinition;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import com.arcogine.types.scenario.EquipmentConfig;
+import com.arcogine.types.scenario.MaterialConfig;
+import com.arcogine.types.scenario.OperationsDefinitionConfig;
+import com.arcogine.types.scenario.ProcessSegmentConfig;
+import com.arcogine.types.scenario.ScenarioConfig;
+import com.arcogine.types.scenario.SimulationParams;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ScenarioFactoryModelAdapterTest {
+
+    private static ScenarioConfig scenario() {
+        return new ScenarioConfig(
+                new SimulationParams(42L, 100L, 10L, 50L),
+                List.of(new EquipmentConfig(1, "Mill", null, null, null)),
+                List.of(new MaterialConfig(10, "Widget", 100)),
+                List.of(new ProcessSegmentConfig(1, "Rough milling", 1, 5)),
+                List.of(new OperationsDefinitionConfig(100, "Widget routing", List.of(1L))),
+                null,
+                null);
+    }
+
+    @Test
+    void mapsResourcesOperationsAndProductsFaithfully() {
+        FactoryModel model = ScenarioFactoryModelAdapter.adapt(scenario());
+
+        assertEquals(1, model.resources().size());
+        assertEquals(new MachineId(1), model.resources().get(0).id());
+        assertEquals("Mill", model.resources().get(0).name());
+
+        assertEquals(1, model.operations().size());
+        OperationDefinition operation = model.operations().get(0);
+        assertEquals(100, operation.id());
+        assertEquals(1, operation.steps().size());
+        OperationStepDefinition step = operation.steps().get(0);
+        assertEquals(1, step.stepId());
+        assertEquals(5, step.duration());
+        assertTrue(step.eligibleResources().contains(new MachineId(1)));
+        assertEquals(1, step.eligibleResources().size(), "current semantics bind one equipment id");
+
+        assertEquals(1, model.products().size());
+        assertEquals(new ProductId(10), model.products().get(0).id());
+        assertEquals(100, model.products().get(0).operationId());
+    }
+
+    @Test
+    void excludesSimulationEconomyAndAgentConcernsFromTheModel() {
+        FactoryModel model = ScenarioFactoryModelAdapter.adapt(scenario());
+
+        // The canonical model has no fields for simulation/economy/agent concerns at all -- the
+        // adapter cannot leak them even accidentally.
+        assertEquals(1, model.resources().size());
+        assertEquals(1, model.operations().size());
+        assertEquals(1, model.products().size());
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapterTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/scenario/ScenarioFactoryModelAdapterTest.java
@@ -54,6 +54,25 @@ class ScenarioFactoryModelAdapterTest {
     }
 
     @Test
+    void skipsOperationStepsWhoseProcessSegmentIdDoesNotResolve() {
+        ScenarioConfig config = new ScenarioConfig(
+                new SimulationParams(42L, 100L, 10L, 50L),
+                List.of(new EquipmentConfig(1, "Mill", null, null, null)),
+                List.of(new MaterialConfig(10, "Widget", 100)),
+                List.of(new ProcessSegmentConfig(1, "Rough milling", 1, 5)),
+                List.of(new OperationsDefinitionConfig(100, "Widget routing", List.of(1L, 999L))),
+                null,
+                null);
+
+        FactoryModel model = ScenarioFactoryModelAdapter.adapt(config);
+
+        assertEquals(
+                1,
+                model.operations().get(0).steps().size(),
+                "a step id with no matching process_segment must be skipped, not fabricated");
+    }
+
+    @Test
     void excludesSimulationEconomyAndAgentConcernsFromTheModel() {
         FactoryModel model = ScenarioFactoryModelAdapter.adapt(scenario());
 

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/FactoryModelValidatorTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/FactoryModelValidatorTest.java
@@ -92,6 +92,59 @@ class FactoryModelValidatorTest {
     }
 
     @Test
+    void rejectsResourceWithNonPositiveConcurrency() {
+        ResourceDefinition idleMill = new ResourceDefinition(new MachineId(1), "Mill", 0, null, 0);
+        FactoryModel model = new FactoryModel(List.of(idleMill), List.of(), List.of());
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsDuplicateOperationIds() {
+        FactoryModel model = new FactoryModel(List.of(mill()), List.of(routing(), routing()), List.of());
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsStepWithNonPositiveDuration() {
+        OperationDefinition zeroDuration = new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 0)));
+        FactoryModel model = new FactoryModel(List.of(mill()), List.of(zeroDuration), List.of());
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsStepWithNoEligibleResources() {
+        OperationDefinition noEligible = new OperationDefinition(
+                100, "Widget routing", List.of(new OperationStepDefinition(1, "Rough milling", Set.of(), 5)));
+        FactoryModel model = new FactoryModel(List.of(mill()), List.of(noEligible), List.of());
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsDuplicateProductIds() {
+        ProductDefinition widget = new ProductDefinition(new ProductId(10), "Widget", 100);
+        FactoryModel model = new FactoryModel(List.of(mill()), List.of(routing()), List.of(widget, widget));
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
     void rejectsOperationWithNoSteps() {
         OperationDefinition empty = new OperationDefinition(100, "Empty", List.of());
         FactoryModel model = new FactoryModel(List.of(mill()), List.of(empty), List.of());

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/FactoryModelValidatorTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/FactoryModelValidatorTest.java
@@ -62,6 +62,27 @@ class FactoryModelValidatorTest {
     }
 
     @Test
+    void rejectsStepWithMoreThanOneEligibleResource() {
+        ResourceDefinition otherMill = new ResourceDefinition(new MachineId(2), "Mill B", 1, null, 0);
+        OperationDefinition multiEligible = new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(
+                        1, "Rough milling", Set.of(new MachineId(1), new MachineId(2)), 5)));
+        FactoryModel model = new FactoryModel(
+                List.of(mill(), otherMill),
+                List.of(multiEligible),
+                List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(
+                result.isValid(),
+                "runtime cannot faithfully instantiate a step with more than one eligible resource "
+                        + "in this milestone -- see FactoryRuntimeAssembler");
+    }
+
+    @Test
     void rejectsDuplicateResourceIds() {
         FactoryModel model = new FactoryModel(List.of(mill(), mill()), List.of(), List.of());
 

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/FactoryModelValidatorTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/FactoryModelValidatorTest.java
@@ -1,0 +1,94 @@
+package com.arcogine.factory.model.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.OperationDefinition;
+import com.arcogine.factory.model.OperationStepDefinition;
+import com.arcogine.factory.model.ProductDefinition;
+import com.arcogine.factory.model.ResourceDefinition;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class FactoryModelValidatorTest {
+
+    private static ResourceDefinition mill() {
+        return new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0);
+    }
+
+    private static OperationDefinition routing() {
+        return new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)));
+    }
+
+    @Test
+    void validModelHasNoErrors() {
+        FactoryModel model = new FactoryModel(
+                List.of(mill()), List.of(routing()), List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    @Test
+    void rejectsProductReferencingUnknownOperation() {
+        FactoryModel model = new FactoryModel(
+                List.of(mill()), List.of(routing()), List.of(new ProductDefinition(new ProductId(10), "Widget", 999)));
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsStepReferencingUnknownResource() {
+        OperationDefinition badRouting = new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(999)), 5)));
+        FactoryModel model = new FactoryModel(
+                List.of(mill()), List.of(badRouting), List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsDuplicateResourceIds() {
+        FactoryModel model = new FactoryModel(List.of(mill(), mill()), List.of(), List.of());
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsOperationWithNoSteps() {
+        OperationDefinition empty = new OperationDefinition(100, "Empty", List.of());
+        FactoryModel model = new FactoryModel(List.of(mill()), List.of(empty), List.of());
+
+        ModelValidationResult result = FactoryModelValidator.validate(model);
+
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void requireValidThrowsOnInvalidModel() {
+        FactoryModel model = new FactoryModel(List.of(mill(), mill()), List.of(), List.of());
+
+        FactoryModelValidationException exception =
+                org.junit.jupiter.api.Assertions.assertThrows(
+                        FactoryModelValidationException.class,
+                        () -> FactoryModelValidator.requireValid(model));
+
+        assertFalse(exception.result().isValid());
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/ModelValidationErrorTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/ModelValidationErrorTest.java
@@ -1,0 +1,26 @@
+package com.arcogine.factory.model.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ModelValidationErrorTest {
+
+    @Test
+    void rejectsNullField() {
+        assertThrows(NullPointerException.class, () -> new ModelValidationError(null, "message"));
+    }
+
+    @Test
+    void rejectsNullMessage() {
+        assertThrows(NullPointerException.class, () -> new ModelValidationError("field", null));
+    }
+
+    @Test
+    void toStringCombinesFieldAndMessage() {
+        ModelValidationError error = new ModelValidationError("resources", "duplicate id");
+
+        assertEquals("resources: duplicate id", error.toString());
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/ModelValidationResultTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/validation/ModelValidationResultTest.java
@@ -1,0 +1,23 @@
+package com.arcogine.factory.model.validation;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ModelValidationResultTest {
+
+    @Test
+    void defaultsNullErrorsToEmpty() {
+        ModelValidationResult result = new ModelValidationResult(null);
+
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void validFactoryProducesAnEmptyValidResult() {
+        ModelValidationResult result = ModelValidationResult.valid();
+
+        assertTrue(result.isValid());
+        assertTrue(result.errors().isEmpty());
+    }
+}

--- a/product/interfaces/api/src/main/java/com/arcogine/api/state/HandlerFactory.java
+++ b/product/interfaces/api/src/main/java/com/arcogine/api/state/HandlerFactory.java
@@ -3,20 +3,15 @@ package com.arcogine.api.state;
 import com.arcogine.agents.SalesAgent;
 import com.arcogine.economy.demand.DemandModel;
 import com.arcogine.economy.pricing.PricingState;
-import com.arcogine.factory.machines.Machine;
-import com.arcogine.factory.machines.MachineStore;
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.FactoryModelPublisher;
+import com.arcogine.factory.model.FactoryModelVersion;
+import com.arcogine.factory.model.FactoryRuntimeAssembler;
+import com.arcogine.factory.model.scenario.ScenarioFactoryModelAdapter;
 import com.arcogine.factory.process.FactoryHandler;
-import com.arcogine.factory.routing.Routing;
-import com.arcogine.factory.routing.RoutingStep;
-import com.arcogine.factory.routing.RoutingStore;
 import com.arcogine.finance.process.FinanceHandler;
-import com.arcogine.types.MachineId;
 import com.arcogine.types.ProductId;
-import com.arcogine.types.scenario.EquipmentConfig;
-import com.arcogine.types.scenario.MaterialConfig;
-import com.arcogine.types.scenario.OperationsDefinitionConfig;
 import com.arcogine.types.scenario.ScenarioConfig;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
@@ -25,39 +20,11 @@ public final class HandlerFactory {
     private HandlerFactory() {}
 
     public static IntegratedHandler buildFromConfig(ScenarioConfig config) {
-        MachineStore machines = new MachineStore();
-        for (EquipmentConfig eq : config.equipment()) {
-            machines.add(new Machine(
-                    new MachineId(eq.id()),
-                    eq.name(),
-                    eq.effectiveConcurrency(),
-                    eq.capacityLiters(),
-                    eq.effectiveSetupTime()));
-        }
-
-        RoutingStore routings = new RoutingStore();
-        for (OperationsDefinitionConfig od : config.operationsDefinition()) {
-            List<RoutingStep> steps = new ArrayList<>();
-            for (Long segId : od.steps()) {
-                config.processSegment().stream()
-                        .filter(s -> s.id() == segId)
-                        .findFirst()
-                        .ifPresent(s -> steps.add(new RoutingStep(
-                                s.id(),
-                                s.name(),
-                                new MachineId(s.equipmentId()),
-                                s.duration())));
-            }
-            routings.addRouting(new Routing(od.id(), od.name(), steps));
-        }
-
-        List<ProductId> productIds =
-                config.material().stream().map(m -> new ProductId(m.id())).toList();
-        for (MaterialConfig mat : config.material()) {
-            routings.addProductRouting(new ProductId(mat.id()), mat.routingId());
-        }
-
-        FactoryHandler factory = new FactoryHandler(machines, routings, productIds);
+        FactoryModel model = ScenarioFactoryModelAdapter.adapt(config);
+        FactoryModelVersion modelVersion = FactoryModelPublisher.publish(model);
+        FactoryRuntimeAssembler.Assembled assembled = FactoryRuntimeAssembler.assemble(modelVersion);
+        FactoryHandler factory = assembled.factory();
+        List<ProductId> productIds = assembled.productIds();
 
         double initialPrice = 10.0;
         double baseDemand = 5.0;
@@ -85,6 +52,7 @@ public final class HandlerFactory {
         SalesAgent agent = SalesAgent.withDefaultConfig();
         FinanceHandler finance = new FinanceHandler();
 
-        return new IntegratedHandler(factory, demand, pricing, finance, agent, agentEnabled);
+        return new IntegratedHandler(
+                factory, demand, pricing, finance, agent, agentEnabled, modelVersion.contentHash());
     }
 }

--- a/product/interfaces/api/src/main/java/com/arcogine/api/state/IntegratedHandler.java
+++ b/product/interfaces/api/src/main/java/com/arcogine/api/state/IntegratedHandler.java
@@ -19,6 +19,7 @@ public class IntegratedHandler implements EventHandler {
     private final FinanceHandler finance;
     private final SalesAgent agent;
     private boolean agentEnabled;
+    private final String factoryModelContentHash;
 
     public IntegratedHandler(
             FactoryHandler factory,
@@ -27,12 +28,30 @@ public class IntegratedHandler implements EventHandler {
             FinanceHandler finance,
             SalesAgent agent,
             boolean agentEnabled) {
+        this(factory, demand, pricing, finance, agent, agentEnabled, null);
+    }
+
+    /**
+     * @param factoryModelContentHash provenance identifying the {@code FactoryModelVersion} this
+     *     handler's factory runtime was instantiated from, or {@code null} when the factory
+     *     runtime was not constructed through the canonical model boundary (e.g. hand-built in a
+     *     test).
+     */
+    public IntegratedHandler(
+            FactoryHandler factory,
+            DemandModel demand,
+            PricingState pricing,
+            FinanceHandler finance,
+            SalesAgent agent,
+            boolean agentEnabled,
+            String factoryModelContentHash) {
         this.factory = factory;
         this.demand = demand;
         this.pricing = pricing;
         this.finance = finance;
         this.agent = agent;
         this.agentEnabled = agentEnabled;
+        this.factoryModelContentHash = factoryModelContentHash;
     }
 
     @Override
@@ -78,5 +97,13 @@ public class IntegratedHandler implements EventHandler {
 
     public boolean agentEnabled() {
         return agentEnabled;
+    }
+
+    /**
+     * Content hash of the {@code FactoryModelVersion} this handler's factory runtime was
+     * instantiated from, or {@code null} if unknown.
+     */
+    public String factoryModelContentHash() {
+        return factoryModelContentHash;
     }
 }

--- a/product/interfaces/api/src/test/java/com/arcogine/api/ScenarioBaselinesTest.java
+++ b/product/interfaces/api/src/test/java/com/arcogine/api/ScenarioBaselinesTest.java
@@ -185,6 +185,22 @@ class ScenarioBaselinesTest {
     }
 
     @Test
+    void handlerReportsTheModelVersionItWasInstantiatedFrom() throws SimError {
+        RunOutcome run = run(BASIC_SCENARIO);
+        assertTrue(
+                run.handler().factoryModelContentHash() != null
+                        && !run.handler().factoryModelContentHash().isEmpty(),
+                "handler must carry provenance for the published FactoryModelVersion it came from");
+    }
+
+    @Test
+    void sameScenarioProducesTheSameFactoryModelIdentityAcrossRuns() throws SimError {
+        RunOutcome first = run(BASIC_SCENARIO);
+        RunOutcome second = run(BASIC_SCENARIO);
+        assertEquals(first.handler().factoryModelContentHash(), second.handler().factoryModelContentHash());
+    }
+
+    @Test
     void overloadScenarioBuildsBacklog() throws SimError {
         RunOutcome run = run(OVERLOAD_SCENARIO);
         long backlog = run.handler().factory().backlog();


### PR DESCRIPTION
## Summary

Establishes a canonical, consumer-neutral semantic model for factory designs that serves as the single source of truth for runtime construction. Introduces `FactoryModel` as an immutable value type representing resources, operations, and products, with deterministic validation and publication semantics.

## Key Changes

- **Canonical Model Types**: Added `FactoryModel`, `ResourceDefinition`, `OperationDefinition`, `OperationStepDefinition`, and `ProductDefinition` as immutable value records representing the complete factory design
- **Validation Framework**: Implemented `FactoryModelValidator` with comprehensive structural validation (uniqueness, referential integrity, coherent relationships) and `ModelValidationResult`/`ModelValidationError` for deterministic error reporting
- **Publication Boundary**: Created `FactoryModelPublisher` that validates models before publication and produces `FactoryModelVersion` with deterministic SHA-256 content hashing for model identity tracking. `FactoryModelVersion`'s own canonical constructor enforces validation, so there is no construction path — including one that bypasses the publisher — that can produce a version wrapping an invalid model
- **Runtime Assembly**: Added `FactoryRuntimeAssembler` to construct `FactoryHandler` and related runtime state exclusively from published `FactoryModelVersion`, ensuring runtime is never built directly from scenario input
- **Scenario Adaptation**: Implemented `ScenarioFactoryModelAdapter` to faithfully translate `ScenarioConfig` into canonical `FactoryModel`, preserving current semantics (single equipment per process segment) without introducing broader behavior. A step with more than one eligible resource is rejected at validation time rather than silently collapsed to one at assembly time, since the current runtime does not implement capability-based dispatch
- **Immutability Enforcement**: All model types defensively copy input collections and return unmodifiable views, preventing mutation through accessors or source collection modification
- **Handler Provenance**: Extended `IntegratedHandler` to carry `factoryModelContentHash` for tracing runtime instantiation back to its source model version

## Notable Implementation Details

- Validation is deterministic and structural only—it checks uniqueness, resolvable references, and coherent relationships without mutating or partially constructing runtime state
- Content hashing uses a canonical string representation of all model fields, sorting eligible-resource ids explicitly rather than depending on `Set` iteration order, to ensure equal models produce identical hashes across runs
- The adapter layer is deliberately narrow and faithful to today's scenario semantics; a step currently binds to exactly one eligible resource, matching what the runtime can faithfully execute
- Simulation, economy, and agent configuration are explicitly excluded from the model per ADR-0003, maintaining clean separation between design and execution concerns
- All model types are plain Java records with no Spring or runtime dependencies, enabling use as a pure semantic layer

## Follow-ups / Deferred intentionally

- **Simulation result provenance**: factory-model provenance currently remains on `IntegratedHandler` rather than `SimResult`, to preserve the domain-neutral `:simulation` boundary (`SimRunner`/`SimResult` are generic over any `EventHandler` and have no factory-domain dependency). If results later need independent persistence/export/transport, introduce an appropriate result/provenance envelope rather than coupling `SimResult` directly to factory semantics.
- **Validation finding contract**: validation findings (`ModelValidationError`) remain intentionally minimal/internal for this milestone — deterministic, with field/path where possible, but without stable codes, severity, entity metadata, or related identifiers. Introduce those when a concrete consumer or public validation contract requires them, rather than designing an error-contract ahead of a real need.

https://claude.ai/code/session_01WA9jtXZJwgNtCSLagHrURh