### PR TITLE
docs: define governance and conformance direction

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ The root [README](../README.md#quick-start) owns environment setup and local-run
 |----------|-----------------|
 | [Architecture](architecture/overview.md) | Current design philosophy (including Events–State–Observations), module structure, determinism contract, event dispatch, technology stack |
 | [Factory design architecture](architecture/factory-design.md) | Proposed cross-consumer factory-design semantics, scenario/model/runtime separation, publication boundary, spatial ownership, and design-lifecycle principles |
+| [Governance and conformance architecture](architecture/governance-conformance.md) | Proposed cross-domain model lineage, semantic change, requirements, conformance, evidence, governed change, and compliance-as-projection architecture |
 | [ADR-0003: Canonical factory model boundary](architecture/decisions/0003-canonical-factory-model-boundary.md) | Accepted decision that `ScenarioConfig` remains a run envelope while immutable published factory-model versions bridge design and runtime |
 | [Standards alignment](architecture/standards-alignment.md) | Standards influence and claim boundaries across ISA-95, ISO 22400, DES, RAMI 4.0, and future integrations |
 | [ISA-95 semantic mapping](architecture/isa-95-semantic-mapping.md) | Maintained Arcogine-to-ISA-95 concept mapping, deliberate divergences, structural gaps, and design-review policy |
@@ -57,5 +58,6 @@ These documents are internal planning artifacts, not user-facing guides:
 | Document | What it covers |
 |----------|-----------------|
 | [Factory design capability plan](planning/factory-design-capability.md) | Immediate upstream work: canonical model seam, validation, publication/provenance, and behavior-preserving runtime instantiation |
+| [Governance and conformance capability plan](planning/governance-conformance-capability.md) | Cross-cutting sequence after the model seam: durable lineage, semantic ChangeSets, generic conformance, evidence, Jira-backed governed change, framework mappings, and audit projections |
 | [Factory simulation engine readiness](planning/factory-simulation-engine-readiness.md) | Runtime gates after the model seam: explicit workload/work execution, deterministic dispatch, session control, observations/events, and spatial consequences |
 | [Factory-design game consumer initiative](planning/factory-design-game-consumer.md) | Downstream game vertical slice that depends on both factory-design D1–D4 and engine-readiness Gates 1–5 |

--- a/docs/architecture/governance-conformance.md
+++ b/docs/architecture/governance-conformance.md
@@ -1,0 +1,435 @@
+# Governance and Conformance Architecture
+
+> **Status:** Proposed architectural reference  
+> **Scope:** Cross-domain model history, semantic change, requirements, conformance, evidence, and governance over Arcogine's canonical business semantics  
+> **Authority:** Proposed architecture; this document does not claim current compliance, audit, or certification capability  
+> **Related:** [Product Charter](../product/charter.md), [Architecture Overview](overview.md), [Factory Design Architecture](factory-design.md), [ADR-0003](decisions/0003-canonical-factory-model-boundary.md), [Standards Alignment](standards-alignment.md), [Governance and Conformance Capability Plan](../planning/governance-conformance-capability.md)
+
+## 1. Architectural position
+
+Arcogine's Product Charter makes verification, provenance, governed change, and continuity between design and reality first-class concerns. Once Arcogine owns authoritative semantic models of a business and their history, governance and compliance can be derived from those models rather than maintained as disconnected checklists.
+
+The architectural direction is therefore broader than a compliance product:
+
+> **Arcogine should provide a generic conformance capability over authoritative business semantics, model history, and observations. Regulatory compliance, standards conformance, architecture governance, internal policy, contractual requirements, and operational assurance are projections over that capability.**
+
+This avoids turning the core model into a collection of framework-specific flags such as `soc2Compliant`. Business objects describe the business. Requirements, controls, assertions, evidence, and findings interpret those objects for a particular governance purpose.
+
+## 2. Authority: modeled truth and observed truth are different
+
+Arcogine should be authoritative for the business semantics it owns: intended structure, policy, responsibilities, constraints, model lineage, and governed changes. External systems may remain authoritative for operational facts that Arcogine observes.
+
+Conceptually:
+
+```text
+Arcogine model
+    "this account SHALL use MFA"
+
+External identity provider
+    "this account DID use MFA"
+
+Intended state + observed state
+              |
+              v
+          Conformance
+```
+
+A model assertion is therefore not automatically operational evidence. A requirement can depend on one or more evidence classes:
+
+```text
+Structural evidence
+    derived from authoritative Arcogine model state
+
+Operational evidence
+    observations from runtime systems, equipment, cloud providers, identity systems, etc.
+
+Human/process evidence
+    approvals, attestations, reviews, artifacts, and completed governed workflows
+```
+
+Arcogine should preserve the provenance and authority of each source rather than flattening them into one undifferentiated truth store.
+
+## 3. Compliance is a downstream projection
+
+The primitive dependency direction should be:
+
+```text
+Authoritative business semantics
+            |
+            v
+   Model history / lineage
+            |
+            v
+      Semantic changes
+            |
+            v
+       Requirements
+            |
+            v
+    Conformance assertions
+            |
+            v
+    Findings and evidence
+            |
+            v
+ Governance / risk / controls
+            |
+            v
+ Framework requirement mappings
+            |
+            +--> SOC 2
+            +--> ISO 27001
+            +--> ISO 9001
+            +--> internal policy
+            +--> customer commitments
+            +--> architecture standards
+```
+
+Framework content should not drive the shape of the business model. One underlying business fact or control may satisfy multiple framework requirements.
+
+## 4. Durable identity and lineage precede audit claims
+
+The current factory-model publication boundary proves that immutable semantic content can be validated, published, identified, and attributed to runtime behavior. A compliance- or audit-grade system requires a stronger durable lifecycle.
+
+Conceptually:
+
+```text
+ModelVersion
+    model identity
+    immutable semantic content
+    content hash
+    parent version(s)
+    schema/model version
+    created/published at
+    author/decision source
+    change set
+    external change request
+    approvals
+    provenance
+```
+
+A content hash answers whether semantic content is equal under a defined canonicalization policy. It does not by itself answer why a version exists, what changed, who authorized it, or which version preceded it. Those are lineage and governance concerns.
+
+The system should eventually be able to answer:
+
+```text
+What was true at time T?
+Which model version represented it?
+What changed from the previous version?
+Why was that change proposed?
+Who or what approved it?
+Which requirements were affected?
+Which observations or evidence supported the resulting state?
+```
+
+## 5. Semantic change is a first-class governance primitive
+
+Text, JSON, or serialized-object diffs are insufficient for business governance. Arcogine should represent consequential changes in domain terms when a concrete workflow requires shared change semantics.
+
+For example:
+
+```text
+DataStoreMoved
+    datastore: CustomerRecords
+    fromRegion: EU
+    toRegion: US
+```
+
+is more useful to governance than:
+
+```diff
+- "region": "EU"
++ "region": "US"
+```
+
+because the semantic change can drive impact analysis:
+
+```text
+ChangeSet
+   |
+   +--> affected business objects
+   +--> affected requirements
+   +--> affected controls
+   +--> required reviewers
+   +--> required evidence
+   +--> invalidated prior evidence
+```
+
+This extends the factory-design distinction between model-revision history and runtime event history. A design/change event is not a simulated or operational event merely because both describe changes.
+
+## 6. External change-management systems remain workflow authorities where appropriate
+
+Arcogine does not need to replace Jira or another enterprise change-management system. A change request may be initiated, assigned, discussed, approved, and tracked in Jira while Arcogine owns the semantic meaning and impact of the proposed business change.
+
+A target integration can look like:
+
+```text
+Jira Change Request
+        |
+        v
+Arcogine ChangeSet
+        |
+        +--> affected model entities
+        +--> affected requirements / controls
+        +--> required validation and reviewers
+        |
+        v
+Approval / authorization
+        |
+        v
+Model version N --> model version N+1
+        |
+        v
+Generated provenance / evidence
+```
+
+The external ticket identity should be retained as provenance. Arcogine should not duplicate ticket comments, workflow metadata, or project-management state unless those facts become necessary to a cross-system governance contract.
+
+## 7. Generic conformance model
+
+The core verification capability should answer whether a defined scope satisfies explicit requirements.
+
+Conceptually:
+
+```text
+Requirement
+    id
+    description
+    source/version
+
+Assertion
+    scope
+    expression/evaluator
+    evidence requirements
+
+Evaluation
+    requirement/assertion version
+    model version
+    observed-at / applicable period
+    result
+    evidence set
+
+Finding
+    affected entities
+    severity
+    explanation
+    remediation state
+```
+
+A simple structural example:
+
+```text
+Requirement:
+    Production resources require accountable ownership.
+
+Scope:
+    Resource where environment == Production
+
+Assertion:
+    owner != null
+
+Evidence:
+    authoritative Arcogine model version
+```
+
+An operational example may require external observation:
+
+```text
+Requirement:
+    Production databases are encrypted at rest.
+
+Intended state:
+    Arcogine policy/model
+
+Observed state:
+    cloud-provider configuration evidence
+
+Result:
+    PASS / FAIL / UNKNOWN
+```
+
+`UNKNOWN` is important: absence of evidence must not silently become either success or failure when the underlying fact is genuinely unobserved.
+
+## 8. Controls and frameworks are mappings, not business truth
+
+Controls should describe how requirements are implemented and verified without becoming properties of the underlying business objects.
+
+Conceptually:
+
+```text
+Framework
+    |
+    v
+Requirement
+    |
+ satisfied by
+    v
+Control
+    |
+ implemented by
+    +--> BusinessObject / Process / Policy
+    |
+ verified by
+    +--> Assertion(s)
+    |
+ evidenced by
+    +--> Evidence
+```
+
+One control can map to multiple requirements across multiple frameworks. Framework upgrades should therefore change mappings and requirement versions without forcing unrelated business objects to acquire new schema fields.
+
+## 9. Evidence must be attributable and temporal
+
+Evidence should be modeled with enough provenance to support historical reconstruction and audit review.
+
+Conceptually:
+
+```text
+Evidence
+    source
+    provenance
+    observedAt
+    applicableFrom / applicableUntil
+    modelVersion
+    assertion / control relationship
+    external identity or artifact reference
+    integrity metadata where required
+```
+
+Arcogine should distinguish evidence generated from its own authoritative state from evidence observed externally. Evidence reuse across requirements is valid only when scope, applicable period, provenance, and semantic meaning remain compatible.
+
+## 10. Findings, exceptions, and risk acceptance are explicit governance state
+
+Conformance is not always binary operational enforcement. A failed assertion may produce a finding that is remediated, accepted temporarily, or explicitly excepted.
+
+Conceptually:
+
+```text
+Finding
+    assertion
+    affected objects
+    severity
+    detected at
+    remediation
+
+Exception / RiskAcceptance
+    finding or control
+    rationale
+    owner/approver
+    effective period
+    expiration
+    compensating controls where applicable
+```
+
+An exception does not rewrite the underlying assertion into success. It records an authorized governance decision about a known non-conformance.
+
+## 11. Pre-change conformance is strategically important
+
+Continuous monitoring after a change is useful, but Arcogine's stronger opportunity is to evaluate a proposed semantic change before it becomes authoritative.
+
+```text
+Current model version
+        |
+ Proposed ChangeSet
+        |
+        v
+Impact analysis
+        |
+        +--> affected entities
+        +--> affected requirements
+        +--> evidence invalidation
+        +--> required approvals
+        |
+        v
+Pre-change conformance evaluation
+        |
+   approve / reject / revise
+```
+
+This connects design, verification, change management, and compliance through one semantic representation. It is also directly useful outside regulatory compliance: architecture standards, safety rules, production constraints, internal policy, and customer commitments can use the same mechanism.
+
+## 12. Audit snapshots are reproducible interpretations
+
+An audit view should be reconstructible from versioned inputs rather than stored only as an opaque dashboard state.
+
+Conceptually:
+
+```text
+AuditSnapshot
+    model version
+    framework / requirement version
+    control mappings
+    evaluation results
+    evidence set
+    exceptions / risk acceptances
+    generated at
+```
+
+The desired invariant is:
+
+> Given the relevant model version, requirement/control versions, observations, evidence, and governance decisions, Arcogine can explain how a historical conformance result was derived.
+
+## 13. Relationship to current factory-model work
+
+The factory model is the first implemented proving ground for this broader architecture, not yet a complete business model.
+
+Current factory work establishes useful primitives:
+
+```text
+canonical semantic model
+immutable publication
+structural validation
+content-derived identity
+runtime instantiation from a published model
+runtime provenance
+```
+
+The next cross-cutting needs are durable lineage, semantic changes, and generic conformance. These should be designed so other authoritative domain models can participate without being forced into one monolithic `BusinessModel` aggregate.
+
+Each domain should retain clear ownership of its facts while cross-domain identity, lineage, change impact, requirements, and evidence provide the governance graph over them.
+
+## 14. What this architecture does not claim
+
+This proposal does not mean that Arcogine currently:
+
+- implements SOC 2, ISO 27001, ISO 9001, GDPR, or another compliance framework;
+- provides auditor workflows or certification services;
+- continuously observes cloud, identity, HR, source-control, or ticketing systems;
+- owns all operational truth in connected systems;
+- replaces Jira or enterprise GRC workflow;
+- has durable model persistence or lineage today;
+- has a generic conformance engine today.
+
+Standards/reference alignment and semantic mappings remain distinct from tested conformance claims.
+
+## 15. Architectural review checklist
+
+When governance or compliance work is proposed, ask:
+
+1. Is the underlying fact authoritative Arcogine model state, external observed state, or a governance decision?
+2. Are we adding framework-specific fields to business objects instead of deriving compliance through requirements and controls?
+3. Can the result identify the exact model, requirement, assertion, and evidence versions that produced it?
+4. Is the change represented semantically enough to perform impact analysis?
+5. Does an external workflow system already own the ticket/change-management lifecycle?
+6. Are failures, exceptions, and risk acceptances distinguishable rather than collapsed into one status?
+7. Can one control/evidence fact support multiple frameworks without duplication?
+8. Are historical results reproducible rather than dependent on today's mutable mappings?
+9. Are modeled intent and observed reality explicit and independently attributable?
+10. Would the capability remain useful for internal policy or architecture governance even if no regulatory framework were mapped to it?
+
+## 16. ADR triggers
+
+Create or revise ADRs when implementation commits to hard-to-reverse choices about:
+
+- durable model identity and lineage semantics;
+- parent/branch/merge relationships between model versions;
+- canonical semantic change representation;
+- temporal semantics for modeled facts and observations;
+- requirement/assertion evaluation contracts;
+- control and framework versioning;
+- evidence integrity/retention semantics;
+- exception and risk-acceptance lifecycle;
+- authority boundaries with Jira or other external governance systems;
+- deployment of approved model changes into real operations.
+
+Do not create framework-specific ADRs merely to add content mappings when the generic governance architecture is unchanged.

--- a/docs/planning/governance-conformance-capability.md
+++ b/docs/planning/governance-conformance-capability.md
@@ -1,0 +1,504 @@
+# Governance and Conformance Capability Plan
+
+> **Status:** Proposed  
+> **Scope:** Establish the cross-domain substrate for durable model history, semantic change, requirements, conformance, evidence, and governed change  
+> **Authority:** Planning only; this document defines delivery dependencies and readiness criteria, not current product capability  
+> **Related:** [Governance and Conformance Architecture](../architecture/governance-conformance.md), [Product Charter](../product/charter.md), [Factory Design Capability Plan](factory-design-capability.md), [Factory Design Architecture](../architecture/factory-design.md), [Standards Alignment](../architecture/standards-alignment.md)
+
+## 1. Purpose
+
+Arcogine should not respond to the opportunity for compliance automation by building framework checklists first. The immediate product and architecture opportunity is to make governance a derived property of Arcogine's authoritative semantic models and their history.
+
+This plan therefore establishes a generic sequence:
+
+```text
+Canonical domain models
+        |
+        v
+Durable identity and lineage
+        |
+        v
+Semantic ChangeSets
+        |
+        v
+Requirements and assertions
+        |
+        v
+Conformance evaluation
+        |
+        v
+Evidence and findings
+        |
+        v
+Governed change / exceptions / risk
+        |
+        v
+Framework mappings and compliance projections
+```
+
+The work remains valuable even if Arcogine never competes directly with a compliance-automation vendor. The same primitives support design review, architecture governance, deployment approval, internal policy, safety constraints, customer commitments, auditability, digital-twin reconciliation, and agent governance.
+
+## 2. Relationship to current factory-model work
+
+The canonical factory-model work is the first implementation proving ground.
+
+D1-D4 of the [Factory Design Capability Plan](factory-design-capability.md) establish the initial seam:
+
+```text
+FactoryModel
+    -> structural validation
+    -> immutable publication
+    -> content-derived identity
+    -> runtime instantiation
+    -> provenance
+```
+
+That seam should complete without being blocked by a generic governance framework.
+
+However, the governance/compliance use case now provides a concrete cross-consumer reason to revisit work previously deferred in the factory plan:
+
+- durable model identity and lineage;
+- semantic comparison/diff;
+- shared change semantics;
+- review and approval integration;
+- requirement-based verification.
+
+The key refinement is:
+
+> **D5 semantic comparison is no longer only an editor convenience. It is an enabling primitive for governed change and impact analysis once the initial D1-D4 seam is stable.**
+
+This does not mean implementing arbitrary patch/merge infrastructure. The need is semantic change attribution, not generic collaborative text editing.
+
+## 3. Delivery principles
+
+The delivery sequence should preserve several constraints.
+
+First, framework-specific content must remain downstream of generic conformance. Do not add SOC 2, ISO 27001, GDPR, or other framework fields to core business objects.
+
+Second, do not create a monolithic `BusinessModel` merely to support cross-domain governance. Each domain keeps authoritative ownership of its facts. Cross-domain lineage, identity references, changes, requirements, and evidence provide the governance layer.
+
+Third, distinguish modeled intent from observed reality. Arcogine model state can prove structural facts it owns, but operational assertions may require external observations.
+
+Fourth, reuse external workflow systems where they already own process state. Jira can remain authoritative for ticket workflow while Arcogine owns the semantic meaning, affected entities, conformance impact, and resulting model lineage.
+
+## 4. Delivery sequence
+
+```text
+G1  Durable model identity and lineage
+    ↓
+G2  Semantic ChangeSet and impact model
+    ↓
+G3  Generic requirement/assertion contract
+    ↓
+G4  Conformance evaluation and findings
+    ↓
+G5  Evidence and observation provenance
+    ↓
+G6  Governed change and Jira integration
+    ↓
+G7  Exceptions and risk acceptance
+    ↓
+G8  Framework/control mappings
+    ↓
+G9  Audit snapshots and compliance projections
+```
+
+G1-G5 are architectural substrate. G6-G7 establish governance workflow. G8-G9 make conventional compliance automation possible without turning compliance into Arcogine's core ontology.
+
+## 5. G1 — Durable model identity and lineage
+
+### Goal
+
+Extend the initial in-memory publication identity into a durable lifecycle that can answer how one authoritative model version relates to another.
+
+The design should support concepts equivalent to:
+
+```text
+ModelIdentity
+ModelVersion
+ParentVersion / lineage relationship
+ContentHash
+SchemaVersion
+Publication provenance
+Created/published timestamp
+Author or decision source
+```
+
+The exact persistence technology and public identifiers are implementation decisions.
+
+### Required properties
+
+A content hash and a durable version identity must not be conflated. Equivalent semantic content may intentionally have the same content hash while appearing in different provenance contexts; conversely a durable version identifier represents a historical artifact and its lineage.
+
+The system should eventually support reconstructing the authoritative model state used by an evaluation, simulation, deployment, or audit.
+
+### Acceptance criteria
+
+G1 is ready when:
+
+1. Published versions have durable identities independent of process memory.
+2. Version lineage can identify predecessor/parent relationships under the chosen policy.
+3. Semantic content remains immutable after publication.
+4. Content equality/hash semantics are explicitly documented separately from version identity.
+5. Provenance records who or what caused publication and when.
+6. A downstream result can refer to a durable model version rather than only a transient runtime object/hash.
+
+### ADR trigger
+
+The identity/version/lineage scheme is hard to reverse and should be recorded in an ADR before it becomes a public persistence contract.
+
+## 6. G2 — Semantic ChangeSet and impact model
+
+### Goal
+
+Represent the meaningful transition between authoritative model versions in domain terms sufficient for review, impact analysis, and governance.
+
+A `ChangeSet` or equivalent should be able to identify:
+
+```text
+base model version
+proposed/resulting model version or draft
+semantic changes
+changed entities
+change source/reason
+external change-request reference
+```
+
+Changes should be typed or otherwise semantically classified where the domain has enough meaning to do so.
+
+### Non-goal
+
+Do not build generic JSON patching, arbitrary text merge, collaborative cursors, or a distributed source-control system for models merely to satisfy G2.
+
+### Impact analysis
+
+The first useful impact queries are:
+
+```text
+Which business objects are affected?
+Which requirements evaluate over those objects?
+Which existing evidence becomes stale or invalid?
+Which owners/reviewers have authority over the affected scope?
+Which runtime/deployment contexts would consume the changed model?
+```
+
+### Acceptance criteria
+
+G2 is ready when:
+
+1. Two relevant model versions can be compared semantically rather than only byte-for-byte.
+2. Changed entities can be identified with stable identity.
+3. At least one domain change has a meaningful typed/classified representation.
+4. Impact analysis can determine which registered requirements are potentially affected.
+5. ChangeSet provenance can retain an external ticket/change-request identifier.
+
+## 7. G3 — Generic requirement and assertion contract
+
+### Goal
+
+Define explicit requirements independently of any particular compliance framework.
+
+A minimal contract should distinguish:
+
+```text
+Requirement
+    stable identity
+    version/source
+    human meaning
+
+Scope
+    business objects to which it applies
+
+Assertion
+    deterministic evaluation rule or evaluator
+    required evidence class
+```
+
+The first requirement should be Arcogine-native and structurally evaluable from authoritative model state.
+
+Example:
+
+```text
+Production resources require accountable ownership.
+```
+
+This is preferable to beginning with a SOC 2 control because it tests the architecture without importing an external framework ontology prematurely.
+
+### Acceptance criteria
+
+G3 is ready when:
+
+1. A requirement can be versioned separately from the model it evaluates.
+2. Scope selection is explicit and deterministic.
+3. An assertion can declare whether model state alone is sufficient or external evidence is required.
+4. Requirement wording/source and executable assertion semantics are distinguishable.
+5. The contract is generic enough to represent internal policy and architecture rules.
+
+## 8. G4 — Conformance evaluation and findings
+
+### Goal
+
+Evaluate requirements against a specific authoritative model version and produce explainable results.
+
+A useful result model should support at least:
+
+```text
+PASS
+FAIL
+UNKNOWN
+NOT_APPLICABLE
+```
+
+where `UNKNOWN` represents insufficient authoritative evidence rather than silently passing or failing.
+
+An evaluation should retain:
+
+```text
+model version
+requirement/assertion version
+scope
+result
+explanation
+affected entities
+evaluation time / applicable period
+```
+
+A failed result produces a finding rather than mutating the underlying business model.
+
+### Acceptance criteria
+
+G4 is ready when:
+
+1. The same model/version and requirement/assertion versions produce deterministic structural results.
+2. Findings identify affected entities and the failed assertion.
+3. Results distinguish missing evidence from proven non-conformance.
+4. Evaluation output is immutable or historically attributable.
+5. A proposed ChangeSet can be evaluated before publication for at least one requirement.
+
+The last criterion is the first major strategic milestone: pre-change conformance rather than only post-change monitoring.
+
+## 9. G5 — Evidence and observation provenance
+
+### Goal
+
+Support assertions whose truth depends on observations outside Arcogine's authoritative semantic model.
+
+Evidence should capture concepts equivalent to:
+
+```text
+source
+provenance
+observedAt
+applicable period
+external identity/reference
+related assertion/control
+related model version
+integrity metadata where required
+```
+
+Initial adapters should be driven by a concrete requirement, not a desire to match a vendor's integration count.
+
+### First adapter selection
+
+Choose an external source only after one assertion requires it. Good candidates will be systems where the authority boundary is clear, such as source control, identity, cloud configuration, or Jira change records.
+
+### Acceptance criteria
+
+G5 is ready when:
+
+1. External evidence is distinguishable from Arcogine-derived structural evidence.
+2. Evidence is attributable to source and observation time.
+3. An assertion can combine intended model state with observed external state.
+4. Evidence can become stale/invalid when its scope, applicable period, or affected model semantics change.
+5. A historical evaluation can identify the evidence set it used.
+
+## 10. G6 — Governed change and Jira integration
+
+### Goal
+
+Connect semantic ChangeSets and conformance results to enterprise change-management workflows without recreating Jira inside Arcogine.
+
+Target relationship:
+
+```text
+Jira issue / change request
+        |
+        v
+Arcogine ChangeSet
+        |
+        +--> semantic impact
+        +--> pre-change conformance
+        +--> required approvals/owners
+        |
+        v
+external workflow decision
+        |
+        v
+authorized publication/deployment
+        |
+        v
+model lineage + evidence
+```
+
+### Authority boundary
+
+Jira may remain authoritative for issue workflow, assignments, discussions, and workflow transitions. Arcogine should retain only the ticket identity and governance facts required to explain why a semantic model transition was authorized.
+
+If Arcogine later owns an approval decision itself, that decision must be modeled explicitly with actor/authority/provenance rather than inferred from mutable UI state.
+
+### Acceptance criteria
+
+G6 is ready when:
+
+1. A ChangeSet can reference a Jira change request.
+2. Impact and conformance information can be surfaced into the change workflow.
+3. Publication/authorization provenance records the relevant external workflow identity/status or explicit Arcogine decision.
+4. Jira project-management metadata is not duplicated without semantic need.
+5. A reviewer can trace an authorized model transition back to the governing change request.
+
+## 11. G7 — Exceptions and risk acceptance
+
+### Goal
+
+Represent explicit governance decisions when a known non-conformance is tolerated temporarily or conditionally.
+
+The model should distinguish:
+
+```text
+Finding
+Remediation
+Exception
+RiskAcceptance
+CompensatingControl
+Expiration
+```
+
+An approved exception does not change a failed assertion into `PASS`. It changes the governance disposition of the finding.
+
+### Acceptance criteria
+
+G7 is ready when:
+
+1. Findings retain their factual conformance result independently of disposition.
+2. Exceptions have rationale, accountable owner/approver, and effective/expiration periods.
+3. Expired exceptions become visible without rewriting history.
+4. Compensating controls/evidence can be linked when used.
+
+## 12. G8 — Controls and framework mappings
+
+### Goal
+
+Introduce conventional compliance abstractions only after generic conformance and evidence are working.
+
+Conceptually:
+
+```text
+Framework
+  -> Requirement
+      -> satisfied by Control
+          -> implemented by business semantics/process/policy
+          -> verified by Assertions
+          -> supported by Evidence
+```
+
+One control may map to multiple frameworks. Framework versions and mappings must be historically attributable so an old audit is not silently reinterpreted through today's mapping.
+
+### First framework policy
+
+Do not attempt broad framework coverage. Select one small, legally permissible set of requirements sufficient to prove cross-framework mapping and evidence reuse. Framework content licensing and authoritative source terms must be reviewed before importing copyrighted or proprietary control text.
+
+### Acceptance criteria
+
+G8 is ready when:
+
+1. Requirements and controls are versioned independently of business model versions.
+2. One control can map to more than one requirement/framework.
+3. Business objects do not acquire framework-specific compliance booleans.
+4. Framework/mapping changes do not mutate historical evaluations.
+5. Evidence reuse respects scope, time, and semantic compatibility.
+
+## 13. G9 — Audit snapshots and compliance projections
+
+### Goal
+
+Produce a reproducible audit/compliance view over versioned model state, requirements, controls, evidence, findings, and exceptions.
+
+An audit snapshot should identify:
+
+```text
+model version
+framework/requirement versions
+control mappings
+assertion results
+supporting evidence
+findings
+exceptions/risk acceptances
+generation time
+```
+
+The first useful UX can be headless/export-oriented. Do not build a large GRC dashboard before the underlying historical semantics work.
+
+### Acceptance criteria
+
+G9 is ready when:
+
+1. A historical compliance result can be reconstructed from explicit versioned inputs.
+2. The system can explain why a control passed, failed, or was unknown.
+3. Evidence and exceptions are traceable to their sources and applicable periods.
+4. A change in today's framework mapping does not silently alter a previous audit snapshot.
+5. An auditor/reviewer can traverse from a requirement to control, assertion, affected business objects, evidence, and change history.
+
+## 14. First end-to-end milestone
+
+The first milestone should deliberately avoid a full external compliance framework:
+
+> **Take a proposed semantic change to a versioned Arcogine model, determine which explicit Arcogine-native requirement it affects, evaluate the requirement before publication, link the change to a Jira change request or equivalent provenance, record the authorized transition to the next model version, and reconstruct why the resulting state was considered conformant.**
+
+A concrete example could be an ownership requirement once the relevant owner/authority semantics exist.
+
+Definition of done:
+
+```text
+Durable model version identity exists
+Base -> proposed ChangeSet is attributable
+Affected entity is identified
+One versioned requirement applies
+Pre-change assertion evaluates deterministically
+Finding is produced if violated
+External change-request provenance can be linked
+Authorized publication creates a new immutable version
+Historical evaluation remains attributable after later changes
+No framework-specific field exists on the business object
+```
+
+This milestone proves the architecture that later compliance automation depends on.
+
+## 15. What not to build yet
+
+Do not prioritize:
+
+- dozens of compliance frameworks;
+- hundreds of SaaS integrations;
+- auditor marketplaces or certification workflow;
+- questionnaire automation;
+- generic policy-document generation;
+- trust-center marketing surfaces;
+- broad vendor-risk management;
+- a monolithic cross-domain business object graph;
+- generic model Git semantics (branch/merge/rebase) without a concrete workflow;
+- a replacement for Jira.
+
+Those may become valid product capabilities later, but they should not distract from the semantic substrate that differentiates Arcogine.
+
+## 16. Documentation and ADR updates as work lands
+
+As implementation progresses:
+
+- update [`../architecture/overview.md`](../architecture/overview.md) only with established current-state behavior;
+- update [`../architecture/governance-conformance.md`](../architecture/governance-conformance.md) when the proposed architectural direction changes materially;
+- update factory/domain architecture docs when semantic identity/change requirements alter those models;
+- update [`../architecture/standards-alignment.md`](../architecture/standards-alignment.md) when Arcogine moves from reference/mapping toward an actual tested conformance profile;
+- create ADRs for durable identity/lineage, semantic ChangeSet contracts, temporal evidence semantics, and external authority boundaries when implementation commits to them;
+- update product/reference docs only for capabilities that actually ship.
+
+Once this initiative is complete or superseded, retain durable decisions in ADR/current architecture and retire or reduce this planning artifact.


### PR DESCRIPTION
## Summary

Captures the architectural and planning consequences of treating Arcogine's authoritative semantic model and history as the substrate for governance, conformance, auditability, and eventually compliance automation.

### What changed

- add a proposed cross-domain governance/conformance architecture reference
  - distinguishes modeled intent from observed external truth
  - treats compliance as a downstream projection over generic requirements, assertions, evidence, controls, and findings
  - makes durable model identity/lineage and semantic ChangeSets prerequisites for audit-grade claims
  - defines Jira as a likely external change-workflow authority while Arcogine owns semantic impact and model lineage
  - separates findings from exceptions/risk acceptance
  - emphasizes pre-change conformance and reproducible audit snapshots
- add a governance/conformance capability plan
  - G1 durable identity and lineage
  - G2 semantic ChangeSets and impact analysis
  - G3 generic requirements/assertions
  - G4 conformance evaluation/findings
  - G5 evidence/observation provenance
  - G6 Jira-backed governed change
  - G7 exceptions/risk acceptance
  - G8 framework/control mappings
  - G9 audit/compliance projections
- update the documentation index to make both documents discoverable

## Key refinement to existing factory work

The current FactoryModel/FactoryModelVersion work remains the first proving ground and should not be blocked by generic governance machinery. However, the governance use case now provides a concrete reason to revisit semantic comparison after D1-D4: D5 is no longer merely an editor convenience; semantic change attribution becomes an enabling primitive for impact analysis and governed change.

## First end-to-end milestone

Take a proposed semantic change to a versioned Arcogine model, identify the Arcogine-native requirement it affects, evaluate that requirement before publication, link the change to Jira (or equivalent provenance), record the authorized transition to the next immutable model version, and reconstruct why the resulting state was considered conformant.

## Scope boundaries

This does **not** claim current SOC 2 / ISO / GDPR compliance capability, and it deliberately does not prioritize broad framework catalogs, integration counts, auditor workflows, or GRC dashboards before the underlying semantic and historical substrate exists.

Documentation-only change; no runtime behavior changes.