### PR TITLE
Clarify ISA-95 / IEC 62264 provenance and conformance references

### DIFF
--- a/docs/architecture/governance-conformance.md
+++ b/docs/architecture/governance-conformance.md
@@ -194,6 +194,7 @@ The core verification capability should answer whether a defined scope satisfies
 ```text
 Requirement
     stable identity
+    version
     description
     source authority
     source designation
@@ -202,12 +203,15 @@ Requirement
     adoption/profile, when applicable
 
 Assertion
+    stable identity
+    version
     scope
     expression/evaluator
     evidence requirements
 
 Evaluation
-    requirement/assertion version
+    requirement identity/version
+    assertion identity/version
     model fingerprint
     controlled revision ID, when available
     observed-at / applicable period
@@ -222,6 +226,8 @@ Finding
 ```
 
 A requirement's provenance must identify the exact normative or governing source when its meaning depends on an external standard, regulation, contract, or policy. Family-level labels such as `ISA-95 / IEC 62264` are insufficient for an auditable requirement because closely aligned standards, editions, and national adoptions can differ. The requirement must retain enough source identity to determine what text and obligations governed a historical evaluation.
+
+External source identity is separate from Arcogine's own requirement and assertion identities and versions. The same external clause or policy source may support multiple Arcogine requirement versions as scope, interpretation, or executable semantics evolve; source provenance therefore augments rather than replaces Arcogine versioning.
 
 A structural requirement can be evaluated solely from authoritative model state; an operational requirement may need external observation. `UNKNOWN` is important: absence of evidence must not silently become success or failure when the underlying fact is genuinely unobserved.
 
@@ -337,7 +343,9 @@ An audit view should be reconstructible from versioned inputs rather than stored
 AuditSnapshot
     model fingerprint
     controlled revision ID
-    requirement source identity and version
+    requirement identity / version
+    assertion identity / version
+    requirement source identity / version
     framework / mapping version, when applicable
     control mappings
     evaluation results
@@ -348,7 +356,7 @@ AuditSnapshot
 
 The desired invariant is:
 
-> Given the relevant semantic fingerprint, controlled revision, exact requirement source/version, control/framework versions, observations, evidence, and governance decisions, Arcogine can explain how a historical conformance result was derived.
+> Given the relevant semantic fingerprint, controlled revision, Arcogine requirement and assertion identities/versions, exact external requirement source identity/version when applicable, framework/mapping versions, observations, evidence, and governance decisions, Arcogine can explain how a historical conformance result was derived.
 
 ## 13. Relationship to current factory-model work
 

--- a/docs/architecture/governance-conformance.md
+++ b/docs/architecture/governance-conformance.md
@@ -193,9 +193,13 @@ The core verification capability should answer whether a defined scope satisfies
 
 ```text
 Requirement
-    id
+    stable identity
     description
-    source/version
+    source authority
+    source designation
+    source edition/version
+    source locator
+    adoption/profile, when applicable
 
 Assertion
     scope
@@ -216,6 +220,8 @@ Finding
     explanation
     remediation state
 ```
+
+A requirement's provenance must identify the exact normative or governing source when its meaning depends on an external standard, regulation, contract, or policy. Family-level labels such as `ISA-95 / IEC 62264` are insufficient for an auditable requirement because closely aligned standards, editions, and national adoptions can differ. The requirement must retain enough source identity to determine what text and obligations governed a historical evaluation.
 
 A structural requirement can be evaluated solely from authoritative model state; an operational requirement may need external observation. `UNKNOWN` is important: absence of evidence must not silently become success or failure when the underlying fact is genuinely unobserved.
 
@@ -331,7 +337,8 @@ An audit view should be reconstructible from versioned inputs rather than stored
 AuditSnapshot
     model fingerprint
     controlled revision ID
-    framework / requirement version
+    requirement source identity and version
+    framework / mapping version, when applicable
     control mappings
     evaluation results
     evidence set
@@ -341,7 +348,7 @@ AuditSnapshot
 
 The desired invariant is:
 
-> Given the relevant semantic fingerprint, controlled revision, requirement/control versions, observations, evidence, and governance decisions, Arcogine can explain how a historical conformance result was derived.
+> Given the relevant semantic fingerprint, controlled revision, exact requirement source/version, control/framework versions, observations, evidence, and governance decisions, Arcogine can explain how a historical conformance result was derived.
 
 ## 13. Relationship to current factory-model work
 
@@ -394,13 +401,14 @@ When governance or compliance work is proposed, ask:
 1. Is the underlying fact authoritative Arcogine model state, external observed state, or a governance decision?
 2. Are framework-specific fields being added to business objects instead of deriving compliance through requirements and controls?
 3. Can the result identify the exact semantic fingerprint, controlled revision, requirement/assertion versions, and evidence that produced it?
-4. Is semantic identity being confused with historical revision identity?
-5. Is the change represented semantically enough to perform impact analysis?
-6. Does an external workflow system already own the ticket/change-management lifecycle?
-7. Are approval and deployment modeled as records referencing a revision rather than as revision identity itself?
-8. Are failures, exceptions, and risk acceptances distinguishable rather than collapsed into one status?
-9. Are modeled intent and observed reality explicit and independently attributable?
-10. Are historical results reproducible rather than dependent on today's mutable mappings?
+4. If a requirement comes from an external source, can it identify the exact authority, designation, edition/version, locator, and applicable adoption/profile rather than only a standards-family name?
+5. Is semantic identity being confused with historical revision identity?
+6. Is the change represented semantically enough to perform impact analysis?
+7. Does an external workflow system already own the ticket/change-management lifecycle?
+8. Are approval and deployment modeled as records referencing a revision rather than as revision identity itself?
+9. Are failures, exceptions, and risk acceptances distinguishable rather than collapsed into one status?
+10. Are modeled intent and observed reality explicit and independently attributable?
+11. Are historical results reproducible rather than dependent on today's mutable mappings?
 
 ## 16. ADR triggers
 
@@ -414,6 +422,7 @@ Create or revise ADRs when implementation commits to hard-to-reverse choices abo
 - canonical semantic `ChangeSet` representation;
 - temporal semantics for modeled facts and observations;
 - requirement/assertion evaluation contracts;
+- requirement source-identity and versioning semantics;
 - control and framework versioning;
 - evidence integrity/retention semantics;
 - exception and risk-acceptance lifecycle;

--- a/docs/architecture/isa-95-semantic-mapping.md
+++ b/docs/architecture/isa-95-semantic-mapping.md
@@ -7,7 +7,7 @@
 
 ## 1. Purpose
 
-Arcogine uses ISA-95 as a semantic reference for manufacturing-domain modeling and enterprise/manufacturing integration. This document records:
+Arcogine uses ISA-95 / IEC 62264 as a semantic reference for manufacturing-domain modeling and enterprise/manufacturing integration. This document records:
 
 - how current Arcogine concepts correspond to ISA-95 concepts;
 - where the correspondence is exact, approximate, absent, or deliberately different;
@@ -28,7 +28,9 @@ This document is **not**:
 
 ## 2. Reference boundary
 
-ISA-95, also published internationally as IEC 62264, defines models, terminology, activities, object attributes, and information exchanges for integrating manufacturing operations with enterprise functions. Arcogine uses the series as a reference rather than claiming to implement it.
+ISA-95 and IEC 62264 are closely harmonized standards families with shared lineage, concepts, and terminology for enterprise-control system integration. They should not, however, be treated as automatically identical documents: individual parts, editions, modified adoptions, and national adoptions can differ and can move on different publication cycles. Arcogine uses the family as a semantic reference rather than claiming to implement any specific edition or conformance profile.
+
+For architectural discussion, this document uses `ISA-95 / IEC 62264` as a family-level label. Any future normative requirement, interoperability profile, conformance claim, contractual dependency, or audit record must identify the exact source authority, designation, part, edition/year, source locator, and applicable adoption/profile rather than relying on the family label alone.
 
 The parts most relevant to this mapping are:
 
@@ -40,7 +42,7 @@ The parts most relevant to this mapping are:
 | Part 4 — Objects and Attributes for Manufacturing Operations Management Integration | MOM object models and attributes, including definition, schedule, execution, and performance concerns |
 | Part 5 — Business-to-Manufacturing Transactions | Transactions and information exchanges between applications |
 
-The latest ISA Part 1 publication is ANSI/ISA-95.00.01-2025. Other parts have independent publication dates. A newer Part 1 does not imply that Arcogine automatically conforms to the series or that every term below has a one-to-one mapping.
+At the time of this document's review, ISA Part 1 is published as ANSI/ISA-95.00.01-2025, while IEC 62264-1 remains a separately versioned IEC publication. The ISA designation identifies a modified IEC adoption rather than proving textual identity with the IEC edition. Other parts have independent publication dates. A newer publication in one standards family does not automatically update the corresponding document in another, establish Arcogine conformance, or make every term below a one-to-one mapping.
 
 ## 3. Alignment vocabulary
 
@@ -465,7 +467,7 @@ Any adapter or exchange profile must state:
 - Arcogine extensions;
 - lossy conversions;
 - version and compatibility rules;
-- which ISA-95 parts and profiles it actually supports.
+- the exact source authority, designation, part, edition/version, and adoption/profile it supports.
 
 Only such a defined and tested profile could justify an interoperability or conformance claim.
 
@@ -498,5 +500,6 @@ Keep this document current rather than chronological:
 - [ISA-95 Series of Standards](https://www.isa.org/standards-and-publications/isa-standards/isa-95-standard)
 - [ISA95 Standards Committee scope and purpose](https://www.isa.org/standards-and-publications/isa-standards/isa-standards-committees/isa95)
 - [ISA announcement for ANSI/ISA-95.00.01-2025](https://www.isa.org/news-press-releases/2025/april/update-to-isa-95-standard-addresses-integration-of)
+- [IEC 62264-1 publication page](https://webstore.iec.ch/en/publication/6675)
 
-These links provide public summaries. The normative standards themselves remain the authoritative source for formal definitions and conformance requirements.
+These links provide public summaries and publication metadata. The normative standards themselves remain the authoritative source for formal definitions and conformance requirements.

--- a/docs/architecture/standards-alignment.md
+++ b/docs/architecture/standards-alignment.md
@@ -24,6 +24,8 @@ Conformance
 
 Unless a section explicitly says otherwise, Arcogine claims only **reference** or **semantic mapping**. It currently makes no standards-conformance claim.
 
+When this repository refers to a standards family or shared conceptual model, a family-level label such as `ISA-95 / IEC 62264` is appropriate. When a requirement, conformance claim, interoperability profile, audit record, contractual obligation, or other normative dependency relies on a standard, identify the exact source authority, designation, part, edition or year, and applicable adoption/profile. Closely aligned standards families and national adoptions must not be assumed to be textually or normatively identical across editions.
+
 ## Alignment strategy
 
 | Tier | Meaning | Action |
@@ -38,7 +40,7 @@ Romania's national standards body is ASRO. Relevant IEC and ISO standards may be
 
 | International standard or framework | Common Romanian / EU context |
 |---|---|
-| IEC 62264 / ISA-95 | SR EN IEC 62264 family |
+| IEC 62264 (closely aligned with ISA-95) | SR EN IEC 62264 family |
 | ISO 22400 | SR EN ISO 22400 family |
 | ISO 9001 | SR EN ISO 9001 |
 | ISO 10303 / STEP | SR EN ISO 10303 family |
@@ -51,7 +53,7 @@ Romania's national standards body is ASRO. Relevant IEC and ISO standards may be
 
 ### ISA-95 / IEC 62264 — Enterprise-control system integration
 
-ISA-95 provides models, terminology, activities, object attributes, and information-exchange concepts for integrating manufacturing operations with enterprise functions. Arcogine uses it as a **semantic reference**, not as an implemented information model or conformance profile.
+ISA-95 and IEC 62264 are closely harmonized standards families with shared lineage and semantics for enterprise-control system integration, but individual parts and editions are not automatically identical. Arcogine uses the family as a **semantic reference**, not as an implemented information model or conformance profile.
 
 **Current status:**
 
@@ -76,6 +78,7 @@ ISA-95 provides models, terminology, activities, object attributes, and informat
 - Preserve definition/request/execution/performance distinctions when concrete features require them.
 - Retain approachable Arcogine terminology where it is clearer, with documented aliases.
 - Keep equipment/resource hierarchy distinct from spatial factory layout.
+- Use `ISA-95 / IEC 62264` for family-level architectural discussion, but identify the exact normative source and edition when a requirement, profile, or conformance claim depends on one.
 - Do not claim ISA-95 compatibility or conformance without a defined and tested interchange profile.
 
 See [ISA-95 Semantic Mapping](isa-95-semantic-mapping.md) for the maintained concept register, current structural gaps, naming policy, review checklist, and future adapter path.
@@ -229,7 +232,7 @@ These are not standards conformance targets but remain central to Arcogine's cre
 
 | Standard or framework | Tier | Arcogine position |
 |---|---|---|
-| ISA-95 / IEC 62264 | Align now | Maintained semantic mapping; no interchange or conformance claim |
+| ISA-95 / IEC 62264 | Align now | Maintained semantic mapping; exact normative source required for profiles or conformance claims |
 | ISO 22400 | Align now | KPI terminology/formula reference; map only verified equivalents |
 | DES methodology | Align now | Core simulation architecture |
 | Queueing theory / Little's Law | Align now | Operational analysis and validation foundation |

--- a/docs/architecture/standards-alignment.md
+++ b/docs/architecture/standards-alignment.md
@@ -24,7 +24,7 @@ Conformance
 
 Unless a section explicitly says otherwise, Arcogine claims only **reference** or **semantic mapping**. It currently makes no standards-conformance claim.
 
-When this repository refers to a standards family or shared conceptual model, a family-level label such as `ISA-95 / IEC 62264` is appropriate. When a requirement, conformance claim, interoperability profile, audit record, contractual obligation, or other normative dependency relies on a standard, identify the exact source authority, designation, part, edition or year, and applicable adoption/profile. Closely aligned standards families and national adoptions must not be assumed to be textually or normatively identical across editions.
+When this repository refers to a standards family or shared conceptual model, a family-level label such as `ISA-95 / IEC 62264` is appropriate. When a requirement, conformance claim, interoperability profile, audit record, contractual obligation, or other normative dependency relies on a standard, identify the exact source authority, designation, part, edition or year, source locator when applicable, and applicable adoption/profile. Closely aligned standards families and national adoptions must not be assumed to be textually or normatively identical across editions.
 
 ## Alignment strategy
 

--- a/docs/planning/governance-conformance-capability.md
+++ b/docs/planning/governance-conformance-capability.md
@@ -80,6 +80,7 @@ This does not imply generic patch/merge infrastructure. The need is semantic cha
 3. Distinguish modeled intent from observed reality. Structural facts may be provable from Arcogine state; operational assertions may require external evidence.
 4. Reuse external workflow systems where they already own organizational process state. Jira may remain authoritative for issue workflow while Arcogine owns semantic impact, evidence, and controlled revision lineage.
 5. Keep semantic identity and controlled revision identity separate as required by [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md).
+6. Treat external requirement provenance as versioned input. A standards-family label is not sufficient when an evaluation depends on a specific issuing authority, designation, edition/version, clause/locator, or adoption/profile.
 
 ## 4. Delivery sequence
 
@@ -205,12 +206,16 @@ G2 is ready when:
 
 ### Goal
 
-Define explicit requirements independently of any particular compliance framework.
+Define explicit requirements independently of any particular compliance framework while preserving enough source identity to reproduce the requirement that actually governed an evaluation.
 
 ```text
 Requirement
     stable identity
-    version/source
+    source authority, when external
+    source designation, when external
+    source edition/version
+    source locator
+    adoption/profile, when applicable
     human meaning
 
 Scope
@@ -220,6 +225,8 @@ Assertion
     deterministic evaluation rule or evaluator
     required evidence class
 ```
+
+For an Arcogine-native requirement, the source may be an internal policy or architecture authority rather than an external standard. For an external requirement, a family-level reference such as `ISA-95 / IEC 62264` is insufficient if the obligation depends on a specific publication. The contract must be able to distinguish, for example, an IEC publication from a modified ANSI/ISA adoption or a national adoption without assuming that aligned editions are textually or normatively identical.
 
 The first requirement should be Arcogine-native and structurally evaluable from authoritative model state rather than imported from an external framework.
 
@@ -231,7 +238,8 @@ G3 is ready when:
 2. Scope selection is explicit and deterministic.
 3. An assertion can declare whether model state alone is sufficient or external evidence is required.
 4. Requirement wording/source and executable assertion semantics are distinguishable.
-5. The contract is generic enough to represent internal policy and architecture rules.
+5. An external requirement can identify its exact source authority, designation, edition/version, locator, and applicable adoption/profile where those facts affect meaning.
+6. The contract is generic enough to represent internal policy and architecture rules.
 
 ## 8. G4 — Conformance evaluation and findings
 
@@ -428,7 +436,8 @@ An audit snapshot should identify:
 ```text
 model fingerprint
 controlled revision ID
-framework/requirement versions
+requirement source identity and version
+framework/mapping version, when applicable
 control mappings
 assertion results
 supporting evidence
@@ -443,11 +452,11 @@ The first useful UX can be headless/export-oriented. Do not build a large GRC da
 
 G9 is ready when:
 
-1. A historical compliance result can be reconstructed from explicit versioned inputs.
+1. A historical compliance result can be reconstructed from explicit versioned inputs, including the exact requirement source identity that governed the evaluation.
 2. The system can explain why a control passed, failed, or was unknown.
 3. Evidence and exceptions are traceable to sources and applicable periods.
-4. A change in today's framework mapping does not silently alter a previous audit snapshot.
-5. A reviewer can traverse from a requirement to control, assertion, affected business objects, semantic fingerprint, controlled revision, evidence, and change history.
+4. A change in today's framework mapping or source standard edition does not silently alter a previous audit snapshot.
+5. A reviewer can traverse from a requirement to its governing source, control, assertion, affected business objects, semantic fingerprint, controlled revision, evidence, and change history.
 
 ## 14. First end-to-end milestone
 

--- a/docs/planning/governance-conformance-capability.md
+++ b/docs/planning/governance-conformance-capability.md
@@ -80,7 +80,7 @@ This does not imply generic patch/merge infrastructure. The need is semantic cha
 3. Distinguish modeled intent from observed reality. Structural facts may be provable from Arcogine state; operational assertions may require external evidence.
 4. Reuse external workflow systems where they already own organizational process state. Jira may remain authoritative for issue workflow while Arcogine owns semantic impact, evidence, and controlled revision lineage.
 5. Keep semantic identity and controlled revision identity separate as required by [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md).
-6. Treat external requirement provenance as versioned input. A standards-family label is not sufficient when an evaluation depends on a specific issuing authority, designation, edition/version, clause/locator, or adoption/profile.
+6. Treat external requirement provenance as versioned input in addition to Arcogine's own requirement and assertion versioning. A standards-family label is not sufficient when an evaluation depends on a specific issuing authority, designation, edition/version, clause/locator, or adoption/profile.
 
 ## 4. Delivery sequence
 
@@ -206,11 +206,12 @@ G2 is ready when:
 
 ### Goal
 
-Define explicit requirements independently of any particular compliance framework while preserving enough source identity to reproduce the requirement that actually governed an evaluation.
+Define explicit requirements independently of any particular compliance framework while preserving both Arcogine's own requirement/assertion versions and enough external source identity to reproduce the requirement that actually governed an evaluation.
 
 ```text
 Requirement
     stable identity
+    version
     source authority, when external
     source designation, when external
     source edition/version
@@ -222,11 +223,15 @@ Scope
     business objects to which it applies
 
 Assertion
+    stable identity
+    version
     deterministic evaluation rule or evaluator
     required evidence class
 ```
 
 For an Arcogine-native requirement, the source may be an internal policy or architecture authority rather than an external standard. For an external requirement, a family-level reference such as `ISA-95 / IEC 62264` is insufficient if the obligation depends on a specific publication. The contract must be able to distinguish, for example, an IEC publication from a modified ANSI/ISA adoption or a national adoption without assuming that aligned editions are textually or normatively identical.
+
+External source identity does not replace Arcogine's requirement or assertion version. The same external clause may support multiple Arcogine requirement versions as scope, interpretation, or executable semantics evolve.
 
 The first requirement should be Arcogine-native and structurally evaluable from authoritative model state rather than imported from an external framework.
 
@@ -234,12 +239,13 @@ The first requirement should be Arcogine-native and structurally evaluable from 
 
 G3 is ready when:
 
-1. A requirement can be versioned separately from the model it evaluates.
-2. Scope selection is explicit and deterministic.
-3. An assertion can declare whether model state alone is sufficient or external evidence is required.
-4. Requirement wording/source and executable assertion semantics are distinguishable.
-5. An external requirement can identify its exact source authority, designation, edition/version, locator, and applicable adoption/profile where those facts affect meaning.
-6. The contract is generic enough to represent internal policy and architecture rules.
+1. A requirement has stable identity and can be versioned separately from both the model it evaluates and the edition/version of any external source it cites.
+2. An assertion has stable identity and version independently of the requirement and model revision it evaluates.
+3. Scope selection is explicit and deterministic.
+4. An assertion can declare whether model state alone is sufficient or external evidence is required.
+5. Requirement wording/source and executable assertion semantics are distinguishable.
+6. An external requirement can identify its exact source authority, designation, edition/version, locator, and applicable adoption/profile where those facts affect meaning.
+7. The contract is generic enough to represent internal policy and architecture rules.
 
 ## 8. G4 — Conformance evaluation and findings
 
@@ -261,7 +267,8 @@ An evaluation retains:
 ```text
 model fingerprint
 controlled revision ID, when available
-requirement/assertion version
+requirement identity/version
+assertion identity/version
 scope
 result
 explanation
@@ -275,7 +282,7 @@ A failed result produces a finding rather than mutating the underlying business 
 
 G4 is ready when:
 
-1. The same semantic fingerprint/revision and requirement/assertion versions produce deterministic structural results.
+1. The same semantic fingerprint/revision and requirement/assertion identities and versions produce deterministic structural results.
 2. Findings identify affected entities and the failed assertion.
 3. Results distinguish missing evidence from proven non-conformance.
 4. Evaluation output is immutable or historically attributable.
@@ -436,7 +443,9 @@ An audit snapshot should identify:
 ```text
 model fingerprint
 controlled revision ID
-requirement source identity and version
+requirement identity/version
+assertion identity/version
+requirement source identity/version
 framework/mapping version, when applicable
 control mappings
 assertion results
@@ -452,11 +461,11 @@ The first useful UX can be headless/export-oriented. Do not build a large GRC da
 
 G9 is ready when:
 
-1. A historical compliance result can be reconstructed from explicit versioned inputs, including the exact requirement source identity that governed the evaluation.
+1. A historical compliance result can be reconstructed from explicit versioned inputs, including the Arcogine requirement/assertion identities and versions and the exact external requirement source identity that governed the evaluation, when applicable.
 2. The system can explain why a control passed, failed, or was unknown.
 3. Evidence and exceptions are traceable to sources and applicable periods.
-4. A change in today's framework mapping or source standard edition does not silently alter a previous audit snapshot.
-5. A reviewer can traverse from a requirement to its governing source, control, assertion, affected business objects, semantic fingerprint, controlled revision, evidence, and change history.
+4. A change in today's Arcogine requirement/assertion versions, framework mapping, or source standard edition does not silently alter a previous audit snapshot.
+5. A reviewer can traverse from a versioned requirement and assertion to the governing source, control, affected business objects, semantic fingerprint, controlled revision, evidence, and change history.
 
 ## 14. First end-to-end milestone
 


### PR DESCRIPTION
## Summary

Clarifies how Arcogine refers to ISA-95 and IEC 62264 and tightens requirement provenance for future conformance/audit work.

## Changes

- distinguish `ISA-95 / IEC 62264` as a closely harmonized standards family from exact normative publications and editions;
- clarify Romanian/EU adoption wording around `SR EN IEC 62264`;
- establish a repository-wide rule to retain exact source authority, designation, part, edition/year, source locator when applicable, and adoption/profile for normative dependencies;
- expand governance requirement provenance to retain exact external source identity without replacing Arcogine's own requirement/assertion identity and versioning;
- update audit snapshot and planning semantics so historical results retain:
  - requirement identity/version;
  - assertion identity/version;
  - requirement source identity/version;
  - framework/mapping version, when applicable.

## Scope

Documentation only. No runtime, domain-model, API, or simulation changes.

## Review notes

A prior review caught an architectural regression where external source versioning had accidentally replaced Arcogine requirement/assertion versioning. This PR now models those identities separately and treats external provenance as additive.
