### PR TITLE
Add topology routing edges and expand ID type test coverage

### DIFF
--- a/product/interfaces/api/src/test/java/com/arcogine/api/ApiSmokeTest.java
+++ b/product/interfaces/api/src/test/java/com/arcogine/api/ApiSmokeTest.java
@@ -234,6 +234,71 @@ class ApiSmokeTest {
     }
 
     @Test
+    void topologyWithMultiStepRoutingReturnsEdges() {
+        String multiStepToml =
+                """
+                [simulation]
+                rng_seed = 42
+                max_ticks = 100
+                demand_eval_interval = 10
+
+                [[equipment]]
+                id = 1
+                name = "Mill"
+
+                [[equipment]]
+                id = 2
+                name = "Lathe"
+
+                [[material]]
+                id = 1
+                name = "Widget"
+                routing_id = 1
+
+                [[process_segment]]
+                id = 1
+                name = "Milling"
+                equipment_id = 1
+                duration = 5
+
+                [[process_segment]]
+                id = 2
+                name = "Turning"
+                equipment_id = 2
+                duration = 5
+
+                [[operations_definition]]
+                id = 1
+                name = "Widget routing"
+                steps = [1, 2]
+
+                [economy]
+                initial_price = 10.0
+                base_demand = 3.0
+                price_elasticity = 0.3
+                lead_time_sensitivity = 0.0
+                """;
+
+        loadScenario(multiStepToml);
+        sleepQuietly(100);
+
+        JsonNode body = client.get()
+                .uri("/api/factory/topology")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(JsonNode.class)
+                .returnResult()
+                .getResponseBody();
+        assertNotNull(body);
+        assertTrue(body.path("edges").isArray() && body.path("edges").size() > 0,
+                "topology should contain routing edges for a multi-step routing");
+        JsonNode edge = body.path("edges").get(0);
+        assertEquals(1L, edge.path("from_machine_id").asLong());
+        assertEquals(2L, edge.path("to_machine_id").asLong());
+    }
+
+    @Test
     void exportEventsReturnsLog() {
         loadScenario(BASIC_SCENARIO_TOML);
         sleepQuietly(100);
@@ -447,6 +512,24 @@ class ApiSmokeTest {
                 .exchange()
                 .expectStatus()
                 .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void resetAfterStepReturnsSnapshot() {
+        loadScenario(BASIC_SCENARIO_TOML);
+        sleepQuietly(100);
+
+        client.post().uri("/api/sim/step").exchange().expectStatus().isOk();
+        sleepQuietly(100);
+
+        client.post()
+                .uri("/api/sim/reset")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.events_processed")
+                .isEqualTo(0);
     }
 
     @Test

--- a/product/interfaces/api/src/test/java/com/arcogine/api/ApiSmokeTest.java
+++ b/product/interfaces/api/src/test/java/com/arcogine/api/ApiSmokeTest.java
@@ -520,7 +520,16 @@ class ApiSmokeTest {
         sleepQuietly(100);
 
         client.post().uri("/api/sim/step").exchange().expectStatus().isOk();
-        sleepQuietly(100);
+
+        boolean stepped = false;
+        for (int i = 0; i < 20; i++) {
+            if (snapshot().path("events_processed").asLong() > 0) {
+                stepped = true;
+                break;
+            }
+            sleepQuietly(50);
+        }
+        assertTrue(stepped, "step should process at least one event before reset");
 
         client.post()
                 .uri("/api/sim/reset")

--- a/product/types/src/test/java/com/arcogine/types/BatchIdTest.java
+++ b/product/types/src/test/java/com/arcogine/types/BatchIdTest.java
@@ -1,0 +1,21 @@
+package com.arcogine.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class BatchIdTest {
+
+    @Test
+    void compareToOrdersByValue() {
+        assertTrue(new BatchId(1).compareTo(new BatchId(2)) < 0);
+        assertTrue(new BatchId(2).compareTo(new BatchId(1)) > 0);
+        assertEquals(0, new BatchId(1).compareTo(new BatchId(1)));
+    }
+
+    @Test
+    void toStringIncludesValue() {
+        assertEquals("Batch(7)", new BatchId(7).toString());
+    }
+}

--- a/product/types/src/test/java/com/arcogine/types/JobIdTest.java
+++ b/product/types/src/test/java/com/arcogine/types/JobIdTest.java
@@ -1,0 +1,21 @@
+package com.arcogine.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class JobIdTest {
+
+    @Test
+    void compareToOrdersByValue() {
+        assertTrue(new JobId(1).compareTo(new JobId(2)) < 0);
+        assertTrue(new JobId(2).compareTo(new JobId(1)) > 0);
+        assertEquals(0, new JobId(1).compareTo(new JobId(1)));
+    }
+
+    @Test
+    void toStringIncludesValue() {
+        assertEquals("Job(7)", new JobId(7).toString());
+    }
+}

--- a/product/types/src/test/java/com/arcogine/types/MachineIdTest.java
+++ b/product/types/src/test/java/com/arcogine/types/MachineIdTest.java
@@ -1,0 +1,21 @@
+package com.arcogine.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MachineIdTest {
+
+    @Test
+    void compareToOrdersByValue() {
+        assertTrue(new MachineId(1).compareTo(new MachineId(2)) < 0);
+        assertTrue(new MachineId(2).compareTo(new MachineId(1)) > 0);
+        assertEquals(0, new MachineId(1).compareTo(new MachineId(1)));
+    }
+
+    @Test
+    void toStringIncludesValue() {
+        assertEquals("Machine(7)", new MachineId(7).toString());
+    }
+}

--- a/product/types/src/test/java/com/arcogine/types/ProductIdTest.java
+++ b/product/types/src/test/java/com/arcogine/types/ProductIdTest.java
@@ -1,0 +1,21 @@
+package com.arcogine.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ProductIdTest {
+
+    @Test
+    void compareToOrdersByValue() {
+        assertTrue(new ProductId(1).compareTo(new ProductId(2)) < 0);
+        assertTrue(new ProductId(2).compareTo(new ProductId(1)) > 0);
+        assertEquals(0, new ProductId(1).compareTo(new ProductId(1)));
+    }
+
+    @Test
+    void toStringIncludesValue() {
+        assertEquals("Product(7)", new ProductId(7).toString());
+    }
+}

--- a/product/types/src/test/java/com/arcogine/types/SimErrorTest.java
+++ b/product/types/src/test/java/com/arcogine/types/SimErrorTest.java
@@ -53,4 +53,40 @@ class SimErrorTest {
     void otherMessage() {
         assertEquals("oops", new SimError.Other("oops").getMessage());
     }
+
+    @Test
+    void invalidStateTransitionExposesContext() {
+        assertEquals("test", new SimError.InvalidStateTransition("test").context());
+    }
+
+    @Test
+    void unknownIdExposesKindAndId() {
+        SimError.UnknownId error = new SimError.UnknownId("machine", 5);
+        assertEquals("machine", error.kind());
+        assertEquals(5L, error.id());
+    }
+
+    @Test
+    void eventOrderingViolationExposesTimes() {
+        SimError.EventOrderingViolation error =
+            new SimError.EventOrderingViolation(SimTime.of(10), SimTime.of(5));
+        assertEquals(SimTime.of(10), error.expectedMin());
+        assertEquals(SimTime.of(5), error.actual());
+    }
+
+    @Test
+    void outOfRangeExposesField() {
+        assertEquals("price", new SimError.OutOfRange("price", "must be positive").field());
+    }
+
+    @Test
+    void unbalancedJournalEntryMessageAndAccessors() {
+        SimError.UnbalancedJournalEntry error =
+            new SimError.UnbalancedJournalEntry("10", "5", "misc entry");
+        assertEquals(
+            "unbalanced journal entry \"misc entry\": debits=10, credits=5",
+            error.getMessage());
+        assertEquals("10", error.debits());
+        assertEquals("5", error.credits());
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds test coverage for multi-step routing topology edges and expands test coverage for ID types and error handling. It also adds a test for the reset endpoint behavior after simulation steps.

## Key Changes
- **Topology routing edges**: Added `topologyWithMultiStepRoutingReturnsEdges()` test to verify that the topology API correctly returns routing edges between machines for multi-step operations, validating the `from_machine_id` and `to_machine_id` fields
- **Reset endpoint behavior**: Added `resetAfterStepReturnsSnapshot()` test to verify that the reset endpoint returns a snapshot with `events_processed` reset to 0 after simulation steps
- **SimError test expansion**: Extended `SimErrorTest` with accessor tests for error types:
  - `InvalidStateTransition.context()`
  - `UnknownId.kind()` and `UnknownId.id()`
  - `EventOrderingViolation.expectedMin()` and `EventOrderingViolation.actual()`
  - `OutOfRange.field()`
  - `UnbalancedJournalEntry` message format and accessors
- **ID type test coverage**: Added new test classes for ID types with consistent test patterns:
  - `BatchIdTest`: Tests `compareTo()` ordering and `toString()` format
  - `JobIdTest`: Tests `compareTo()` ordering and `toString()` format
  - `MachineIdTest`: Tests `compareTo()` ordering and `toString()` format
  - `ProductIdTest`: Tests `compareTo()` ordering and `toString()` format

## Notable Details
All new ID type tests follow a consistent pattern, verifying that:
- Comparison operations correctly order by value
- String representation includes the type name and value (e.g., "Machine(7)")

https://claude.ai/code/session_012PqzHmHNVXgWn66JintGnR