### PR TITLE
Implement C2 catalogue and draft economics calculation (partial)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,17 @@ Claude Cloud provisioning is deliberately lightweight: `infra/dev/claude-cloud.s
 
 Before considering a change complete, run `./arcogine check`. For anything touching the API-web contract or E2E flows, also run `cd product/interfaces/web && npx playwright test` (or `./arcogine check --full`) — Playwright's own config builds/starts the API jar and web dev server via `webServer`, but the jar must already be built once (`cd product && ./gradlew :cli:bootJar`) for a clean checkout.
 
+## Checking a PR after pushing
+
+After opening or pushing to a PR, checking CI status alone is not enough — a
+submitted review with a verdict like `CHANGES REQUIRED` does **not** appear
+in a plain comment listing (e.g. the GitHub MCP server's
+`pull_request_read` with `method: get_comments` or `get_review_comments`
+only surfaces issue comments and inline review threads, not the review
+body itself). Always also fetch reviews explicitly (`method: get_reviews`)
+before declaring a PR green or waiting-on-CI. Do this on every check-in,
+not just the first one after pushing.
+
 ## Do not edit
 
 - `product/**/build/`, `product/interfaces/web/node_modules/`, `product/interfaces/web/coverage/`, `product/interfaces/web/dist/` — generated output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,17 +52,6 @@ Claude Cloud provisioning is deliberately lightweight: `infra/dev/claude-cloud.s
 
 Before considering a change complete, run `./arcogine check`. For anything touching the API-web contract or E2E flows, also run `cd product/interfaces/web && npx playwright test` (or `./arcogine check --full`) — Playwright's own config builds/starts the API jar and web dev server via `webServer`, but the jar must already be built once (`cd product && ./gradlew :cli:bootJar`) for a clean checkout.
 
-## Checking a PR after pushing
-
-After opening or pushing to a PR, checking CI status alone is not enough — a
-submitted review with a verdict like `CHANGES REQUIRED` does **not** appear
-in a plain comment listing (e.g. the GitHub MCP server's
-`pull_request_read` with `method: get_comments` or `get_review_comments`
-only surfaces issue comments and inline review threads, not the review
-body itself). Always also fetch reviews explicitly (`method: get_reviews`)
-before declaring a PR green or waiting-on-CI. Do this on every check-in,
-not just the first one after pushing.
-
 ## Do not edit
 
 - `product/**/build/`, `product/interfaces/web/node_modules/`, `product/interfaces/web/coverage/`, `product/interfaces/web/dist/` — generated output.

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -293,6 +293,43 @@ C2 is ready when:
 8. An executable canonical factory may still be rejected for violating challenge rules, and an admitted candidate must still pass Arcogine executability validation before publication/run.
 9. The fixed challenge workload/input cannot be silently replaced by the candidate attempt.
 
+### Implementation status (C2 — partial)
+
+C2 is **partially** implemented. The catalogue seam and deterministic draft-economics
+calculation described in 6.1 are implemented in the existing `:challenge` module
+(package `com.arcogine.challenge.catalogue`, `com.arcogine.challenge.economics`), with no new
+`project(...)` dependency on `:types`, `:simulation`, `:factory`, `:economy`, `:finance`, `:api`,
+or `:cli`. Candidate admissibility (6.2) is **not** implemented and remains for the next slice.
+
+Implemented:
+
+- `EquipmentOffer`, an immutable game-owned catalogue entry (item id, non-negative purchase cost,
+  optional positive quantity limit), and `EquipmentCatalogue`, an immutable collection of offers
+  with value equality and lookup by item id. Neither assumes Arcogine's canonical
+  `ResourceDefinition` is a reusable equipment type.
+- `EquipmentCatalogueValidator`, a deterministic, side-effect-free static validator producing an
+  `EquipmentCatalogueValidationResult` of `EquipmentCatalogueIssue` (stable code, field path,
+  message): catalogue-internal validity (blank/duplicate item ids, negative cost, invalid quantity
+  limit), plus a separate `validateChallengeResolution` check that every
+  `ChallengeDefinition.availableEquipment` identity resolves to exactly one catalogue offer. It
+  does not call, extend, or share a result type with `ChallengeDefinitionValidator` or
+  `FactoryModelValidator`.
+- `DraftEquipmentOccurrence` (a catalogue item id only -- no position, footprint, or canonical
+  resource id) and `DraftEconomicsCalculator`, a pure static calculator that resolves each
+  occurrence through the catalogue and derives an immutable `DraftEconomics` (starting budget,
+  committed construction cost, remaining budget) from the challenge's starting budget. Unknown
+  catalogue references and 64-bit cost/budget overflow are reported as a structured
+  `DraftEconomicsFailure` via `DraftEconomicsResult`, never as an uncaught exception or a silently
+  wrapped total. The calculator mutates none of its inputs and is order-independent over
+  occurrences.
+
+Not implemented, and deliberately deferred to the next C2 slice (candidate admissibility, 6.2):
+rejecting draft occurrences for using catalogue items outside a challenge's `availableEquipment`,
+enforcing per-item quantity limits against candidate occurrence counts, budget-affordability
+rejection, floor/placement constraints, and any projection from a catalogue item occurrence to
+canonical factory/resource semantics. No Engine Readiness gate is satisfied by this partial C2
+work; C3-C5 remain deferred.
+
 ## 7. C3 — Deterministic challenge evaluation
 
 ### Goal

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
@@ -1,0 +1,71 @@
+package com.arcogine.challenge.catalogue;
+
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An immutable, game-owned collection of {@link EquipmentOffer}s available to a content context.
+ *
+ * <p>A challenge's {@code availableEquipment} is a subset of the identities this catalogue may
+ * offer -- this type does not decide which offers a particular challenge allows; that
+ * relationship is validated separately (see {@link
+ * com.arcogine.challenge.catalogue.EquipmentCatalogueValidator#validateChallengeResolution}).
+ *
+ * <p>Construction only establishes an immutable value; it does not decide whether the catalogue's
+ * content (e.g. duplicate item ids) is valid. Use {@link EquipmentCatalogueValidator} for
+ * deterministic structured diagnostics.
+ */
+public final class EquipmentCatalogue {
+
+    private final List<EquipmentOffer> offers;
+
+    public EquipmentCatalogue(List<EquipmentOffer> offers) {
+        List<EquipmentOffer> copy = offers == null ? List.of() : List.copyOf(offers);
+        for (EquipmentOffer offer : copy) {
+            if (offer == null) {
+                throw new NullPointerException("offers must not contain null entries");
+            }
+        }
+        this.offers = copy;
+    }
+
+    /** All offers, in declaration order. */
+    public List<EquipmentOffer> offers() {
+        return offers;
+    }
+
+    /**
+     * Resolves an offer by item identity.
+     *
+     * <p>When {@code offers} contains duplicate item ids, this returns the first matching offer in
+     * declaration order; {@link EquipmentCatalogueValidator} is the source of truth for rejecting
+     * duplicates.
+     */
+    public Optional<EquipmentOffer> findByItemId(EquipmentCatalogueItemId itemId) {
+        if (itemId == null) {
+            throw new NullPointerException("itemId");
+        }
+        for (EquipmentOffer offer : offers) {
+            if (offer.itemId().equals(itemId)) {
+                return Optional.of(offer);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof EquipmentCatalogue other && offers.equals(other.offers);
+    }
+
+    @Override
+    public int hashCode() {
+        return offers.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "EquipmentCatalogue" + offers;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
@@ -21,13 +21,8 @@ public final class EquipmentCatalogue {
     private final List<EquipmentOffer> offers;
 
     public EquipmentCatalogue(List<EquipmentOffer> offers) {
-        List<EquipmentOffer> copy = offers == null ? List.of() : List.copyOf(offers);
-        for (EquipmentOffer offer : copy) {
-            if (offer == null) {
-                throw new NullPointerException("offers must not contain null entries");
-            }
-        }
-        this.offers = copy;
+        // List.copyOf rejects null elements with its own NullPointerException.
+        this.offers = offers == null ? List.of() : List.copyOf(offers);
     }
 
     /** All offers, in declaration order. */

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueIssue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueIssue.java
@@ -1,0 +1,28 @@
+package com.arcogine.challenge.catalogue;
+
+/**
+ * A single deterministic diagnostic produced by {@link EquipmentCatalogueValidator}.
+ *
+ * @param code stable, machine-readable issue code (e.g. {@code "offers.purchaseCost.negative"})
+ * @param path field path the issue applies to (e.g. {@code "offers[0].purchaseCostCredits"})
+ * @param message human-readable description of the issue
+ */
+public record EquipmentCatalogueIssue(String code, String path, String message) {
+
+    public EquipmentCatalogueIssue {
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
+        if (path == null) {
+            throw new NullPointerException("path");
+        }
+        if (message == null) {
+            throw new NullPointerException("message");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return path + " [" + code + "]: " + message;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidationResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidationResult.java
@@ -1,0 +1,19 @@
+package com.arcogine.challenge.catalogue;
+
+import java.util.List;
+
+/** Deterministic, structured result of validating an {@link EquipmentCatalogue}. */
+public record EquipmentCatalogueValidationResult(List<EquipmentCatalogueIssue> issues) {
+
+    public EquipmentCatalogueValidationResult {
+        issues = issues == null ? List.of() : List.copyOf(issues);
+    }
+
+    public static EquipmentCatalogueValidationResult valid() {
+        return new EquipmentCatalogueValidationResult(List.of());
+    }
+
+    public boolean isValid() {
+        return issues.isEmpty();
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidator.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidator.java
@@ -1,0 +1,103 @@
+package com.arcogine.challenge.catalogue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Deterministic validation of whether an {@link EquipmentCatalogue}'s content is internally valid,
+ * and whether a {@link ChallengeDefinition}'s catalogue references resolve.
+ *
+ * <p>This is a distinct validation domain from {@code
+ * com.arcogine.challenge.validation.ChallengeDefinitionValidator} (which validates a challenge's
+ * own content in isolation) and from Arcogine's {@code FactoryModelValidator} (which validates
+ * canonical production executability). It does not call, extend, or reuse either.
+ *
+ * <p>Validation never mutates its inputs, never consults wall-clock time, random state, or any
+ * runtime/session lookup, and iterates declared collections in their existing order, so repeated
+ * validation of identical inputs always produces an equal result with equal issue ordering.
+ */
+public final class EquipmentCatalogueValidator {
+
+    private EquipmentCatalogueValidator() {}
+
+    public static EquipmentCatalogueValidationResult validate(EquipmentCatalogue catalogue) {
+        if (catalogue == null) {
+            throw new NullPointerException("catalogue");
+        }
+        List<EquipmentCatalogueIssue> issues = new ArrayList<>();
+
+        Set<EquipmentCatalogueItemId> seenItemIds = new HashSet<>();
+        List<EquipmentOffer> offers = catalogue.offers();
+        for (int i = 0; i < offers.size(); i++) {
+            EquipmentOffer offer = offers.get(i);
+            String path = "offers[" + i + "]";
+
+            if (isBlank(offer.itemId().value())) {
+                issues.add(new EquipmentCatalogueIssue(
+                        "offers.itemId.blank", path + ".itemId", "must be present and non-blank"));
+            } else if (!seenItemIds.add(offer.itemId())) {
+                issues.add(new EquipmentCatalogueIssue(
+                        "offers.itemId.duplicate",
+                        path + ".itemId",
+                        "duplicate catalogue item id: " + offer.itemId().value()));
+            }
+
+            if (offer.purchaseCostCredits() < 0) {
+                issues.add(new EquipmentCatalogueIssue(
+                        "offers.purchaseCostCredits.negative",
+                        path + ".purchaseCostCredits",
+                        "must be >= 0"));
+            }
+
+            if (offer.quantityLimit().isPresent() && offer.quantityLimit().getAsInt() <= 0) {
+                issues.add(new EquipmentCatalogueIssue(
+                        "offers.quantityLimit.not-positive",
+                        path + ".quantityLimit",
+                        "must be > 0 when present"));
+            }
+        }
+
+        return new EquipmentCatalogueValidationResult(issues);
+    }
+
+    /**
+     * Validates that every {@link ChallengeDefinition#availableEquipment()} identity resolves to
+     * exactly one offer in {@code catalogue}.
+     *
+     * <p>This does not decide catalogue-internal validity (duplicates, negative costs, etc.) --
+     * use {@link #validate(EquipmentCatalogue)} for that -- nor does it reject draft occurrences
+     * for using equipment outside the challenge's allowed set; that is candidate admissibility, a
+     * later Challenge Readiness slice.
+     */
+    public static EquipmentCatalogueValidationResult validateChallengeResolution(
+            ChallengeDefinition challenge, EquipmentCatalogue catalogue) {
+        if (challenge == null) {
+            throw new NullPointerException("challenge");
+        }
+        if (catalogue == null) {
+            throw new NullPointerException("catalogue");
+        }
+
+        List<EquipmentCatalogueIssue> issues = new ArrayList<>();
+        List<EquipmentCatalogueItemId> availableEquipment = challenge.availableEquipment();
+        for (int i = 0; i < availableEquipment.size(); i++) {
+            EquipmentCatalogueItemId itemId = availableEquipment.get(i);
+            if (catalogue.findByItemId(itemId).isEmpty()) {
+                issues.add(new EquipmentCatalogueIssue(
+                        "challenge.availableEquipment.unresolved",
+                        "availableEquipment[" + i + "]",
+                        "no catalogue offer for item id: " + itemId.value()));
+            }
+        }
+
+        return new EquipmentCatalogueValidationResult(issues);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidator.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidator.java
@@ -68,10 +68,14 @@ public final class EquipmentCatalogueValidator {
      * Validates that every {@link ChallengeDefinition#availableEquipment()} identity resolves to
      * exactly one offer in {@code catalogue}.
      *
-     * <p>This does not decide catalogue-internal validity (duplicates, negative costs, etc.) --
-     * use {@link #validate(EquipmentCatalogue)} for that -- nor does it reject draft occurrences
-     * for using equipment outside the challenge's allowed set; that is candidate admissibility, a
-     * later Challenge Readiness slice.
+     * <p>This counts matching offers itself rather than delegating to {@link
+     * EquipmentCatalogue#findByItemId}, which deliberately returns only the first match -- an
+     * identity with zero or more than one matching offer is reported here even when the
+     * catalogue itself has not been separately validated for internal duplicates via {@link
+     * #validate(EquipmentCatalogue)}. It does not decide other catalogue-internal validity
+     * (blank ids, negative costs, etc.) -- use {@link #validate(EquipmentCatalogue)} for that --
+     * nor does it reject draft occurrences for using equipment outside the challenge's allowed
+     * set; that is candidate admissibility, a later Challenge Readiness slice.
      */
     public static EquipmentCatalogueValidationResult validateChallengeResolution(
             ChallengeDefinition challenge, EquipmentCatalogue catalogue) {
@@ -83,14 +87,23 @@ public final class EquipmentCatalogueValidator {
         }
 
         List<EquipmentCatalogueIssue> issues = new ArrayList<>();
+        List<EquipmentOffer> offers = catalogue.offers();
         List<EquipmentCatalogueItemId> availableEquipment = challenge.availableEquipment();
         for (int i = 0; i < availableEquipment.size(); i++) {
             EquipmentCatalogueItemId itemId = availableEquipment.get(i);
-            if (catalogue.findByItemId(itemId).isEmpty()) {
+            String path = "availableEquipment[" + i + "]";
+
+            long matches = offers.stream().filter(offer -> offer.itemId().equals(itemId)).count();
+            if (matches == 0) {
                 issues.add(new EquipmentCatalogueIssue(
                         "challenge.availableEquipment.unresolved",
-                        "availableEquipment[" + i + "]",
+                        path,
                         "no catalogue offer for item id: " + itemId.value()));
+            } else if (matches > 1) {
+                issues.add(new EquipmentCatalogueIssue(
+                        "challenge.availableEquipment.ambiguous",
+                        path,
+                        "multiple catalogue offers for item id: " + itemId.value()));
             }
         }
 

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentOffer.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentOffer.java
@@ -1,0 +1,40 @@
+package com.arcogine.challenge.catalogue;
+
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.util.OptionalInt;
+
+/**
+ * An immutable, game-owned equipment offer: a purchasable catalogue entry, not a canonical
+ * Arcogine production resource.
+ *
+ * <p>{@code EquipmentOffer} carries only what the game needs to price and (optionally) cap a
+ * catalogue item -- it does not carry capability, executability, or runtime meaning. Construction
+ * only establishes an immutable value; it does not decide whether the offer is part of a valid
+ * catalogue. Use {@link EquipmentCatalogueValidator} for deterministic structured diagnostics.
+ *
+ * @param itemId game-owned identity of the catalogue item this offer represents
+ * @param purchaseCostCredits non-negative game-owned purchase cost, in credits
+ * @param quantityLimit optional positive limit on how many occurrences of this item a challenge
+ *     may allow; empty means unlimited
+ */
+public record EquipmentOffer(
+        EquipmentCatalogueItemId itemId, long purchaseCostCredits, OptionalInt quantityLimit) {
+
+    public EquipmentOffer {
+        if (itemId == null) {
+            throw new NullPointerException("itemId");
+        }
+        if (quantityLimit == null) {
+            throw new NullPointerException("quantityLimit");
+        }
+    }
+
+    public static EquipmentOffer of(EquipmentCatalogueItemId itemId, long purchaseCostCredits) {
+        return new EquipmentOffer(itemId, purchaseCostCredits, OptionalInt.empty());
+    }
+
+    public static EquipmentOffer of(
+            EquipmentCatalogueItemId itemId, long purchaseCostCredits, int quantityLimit) {
+        return new EquipmentOffer(itemId, purchaseCostCredits, OptionalInt.of(quantityLimit));
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomics.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomics.java
@@ -1,0 +1,18 @@
+package com.arcogine.challenge.economics;
+
+/**
+ * An immutable, derived snapshot of draft construction economics for one exact challenge budget,
+ * catalogue, and set of draft equipment occurrences.
+ *
+ * <p>This is not mutable ledger state and does not model transactions, a wallet, or purchase/sale
+ * history -- {@link DraftEconomicsCalculator} derives it fresh from its inputs each time it is
+ * called.
+ *
+ * @param startingBudgetCredits the challenge's starting budget this snapshot was derived from
+ * @param committedConstructionCostCredits sum of purchase costs of the priced draft occurrences
+ * @param remainingBudgetCredits {@code startingBudgetCredits - committedConstructionCostCredits}
+ */
+public record DraftEconomics(
+        long startingBudgetCredits,
+        long committedConstructionCostCredits,
+        long remainingBudgetCredits) {}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsCalculator.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsCalculator.java
@@ -4,6 +4,8 @@ import com.arcogine.challenge.ChallengeDefinition;
 import com.arcogine.challenge.EquipmentCatalogueItemId;
 import com.arcogine.challenge.catalogue.EquipmentCatalogue;
 import com.arcogine.challenge.catalogue.EquipmentOffer;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,11 +13,14 @@ import java.util.Optional;
  * A pure, deterministic calculator that derives {@link DraftEconomics} from an exact challenge
  * budget, catalogue, and set of draft equipment occurrences.
  *
- * <p>{@code calculate} resolves each occurrence through the game catalogue, sums committed
- * construction cost, and derives remaining budget from the challenge's starting budget. It
- * mutates none of its inputs, consults no wall-clock time, environment, random value, or global
- * registry, and never calls Finance or factory validation. For identical inputs it always
- * produces an equal result, regardless of occurrence order.
+ * <p>{@code calculate} resolves every occurrence through the game catalogue before aggregating
+ * cost, sums committed construction cost, and derives remaining budget from the challenge's
+ * starting budget. It mutates none of its inputs, consults no wall-clock time, environment,
+ * random value, or global registry, and never calls Finance or factory validation. For identical
+ * inputs -- including a failure outcome -- it always produces an equal result, regardless of
+ * occurrence order: unresolved item ids are reported via the lexicographically smallest offending
+ * identity rather than the first one encountered, and cost overflow is checked only once all
+ * occurrences have resolved, so which failure is reported never depends on occurrence order.
  *
  * <p>This calculator does not enforce that occurrences use only the challenge's {@code
  * availableEquipment}, nor does it enforce catalogue quantity limits against occurrence counts --
@@ -39,21 +44,34 @@ public final class DraftEconomicsCalculator {
             throw new NullPointerException("occurrences");
         }
 
-        long committedConstructionCostCredits = 0L;
+        List<EquipmentCatalogueItemId> unresolved = new ArrayList<>();
+        List<EquipmentOffer> resolvedOffers = new ArrayList<>();
         for (DraftEquipmentOccurrence occurrence : occurrences) {
             EquipmentCatalogueItemId itemId = occurrence.itemId();
             Optional<EquipmentOffer> offer = catalogue.findByItemId(itemId);
             if (offer.isEmpty()) {
-                return DraftEconomicsResult.failure(
-                        DraftEconomicsFailure.unknownCatalogueItem(itemId));
+                unresolved.add(itemId);
+            } else {
+                resolvedOffers.add(offer.get());
             }
+        }
 
-            try {
-                committedConstructionCostCredits = Math.addExact(
-                        committedConstructionCostCredits, offer.get().purchaseCostCredits());
-            } catch (ArithmeticException overflow) {
-                return DraftEconomicsResult.failure(DraftEconomicsFailure.costOverflow());
+        if (!unresolved.isEmpty()) {
+            EquipmentCatalogueItemId failingItemId = unresolved.stream()
+                    .min(Comparator.comparing(EquipmentCatalogueItemId::value))
+                    .orElseThrow();
+            return DraftEconomicsResult.failure(
+                    DraftEconomicsFailure.unknownCatalogueItem(failingItemId));
+        }
+
+        long committedConstructionCostCredits = 0L;
+        try {
+            for (EquipmentOffer offer : resolvedOffers) {
+                committedConstructionCostCredits =
+                        Math.addExact(committedConstructionCostCredits, offer.purchaseCostCredits());
             }
+        } catch (ArithmeticException overflow) {
+            return DraftEconomicsResult.failure(DraftEconomicsFailure.costOverflow());
         }
 
         long startingBudgetCredits = challenge.startingBudget();

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsCalculator.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsCalculator.java
@@ -1,0 +1,71 @@
+package com.arcogine.challenge.economics;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.catalogue.EquipmentCatalogue;
+import com.arcogine.challenge.catalogue.EquipmentOffer;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A pure, deterministic calculator that derives {@link DraftEconomics} from an exact challenge
+ * budget, catalogue, and set of draft equipment occurrences.
+ *
+ * <p>{@code calculate} resolves each occurrence through the game catalogue, sums committed
+ * construction cost, and derives remaining budget from the challenge's starting budget. It
+ * mutates none of its inputs, consults no wall-clock time, environment, random value, or global
+ * registry, and never calls Finance or factory validation. For identical inputs it always
+ * produces an equal result, regardless of occurrence order.
+ *
+ * <p>This calculator does not enforce that occurrences use only the challenge's {@code
+ * availableEquipment}, nor does it enforce catalogue quantity limits against occurrence counts --
+ * those checks belong to candidate admissibility, a later Challenge Readiness slice.
+ */
+public final class DraftEconomicsCalculator {
+
+    private DraftEconomicsCalculator() {}
+
+    public static DraftEconomicsResult calculate(
+            ChallengeDefinition challenge,
+            EquipmentCatalogue catalogue,
+            List<DraftEquipmentOccurrence> occurrences) {
+        if (challenge == null) {
+            throw new NullPointerException("challenge");
+        }
+        if (catalogue == null) {
+            throw new NullPointerException("catalogue");
+        }
+        if (occurrences == null) {
+            throw new NullPointerException("occurrences");
+        }
+
+        long committedConstructionCostCredits = 0L;
+        for (DraftEquipmentOccurrence occurrence : occurrences) {
+            EquipmentCatalogueItemId itemId = occurrence.itemId();
+            Optional<EquipmentOffer> offer = catalogue.findByItemId(itemId);
+            if (offer.isEmpty()) {
+                return DraftEconomicsResult.failure(
+                        DraftEconomicsFailure.unknownCatalogueItem(itemId));
+            }
+
+            try {
+                committedConstructionCostCredits = Math.addExact(
+                        committedConstructionCostCredits, offer.get().purchaseCostCredits());
+            } catch (ArithmeticException overflow) {
+                return DraftEconomicsResult.failure(DraftEconomicsFailure.costOverflow());
+            }
+        }
+
+        long startingBudgetCredits = challenge.startingBudget();
+        long remainingBudgetCredits;
+        try {
+            remainingBudgetCredits =
+                    Math.subtractExact(startingBudgetCredits, committedConstructionCostCredits);
+        } catch (ArithmeticException overflow) {
+            return DraftEconomicsResult.failure(DraftEconomicsFailure.costOverflow());
+        }
+
+        return DraftEconomicsResult.success(new DraftEconomics(
+                startingBudgetCredits, committedConstructionCostCredits, remainingBudgetCredits));
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsCalculator.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsCalculator.java
@@ -3,6 +3,8 @@ package com.arcogine.challenge.economics;
 import com.arcogine.challenge.ChallengeDefinition;
 import com.arcogine.challenge.EquipmentCatalogueItemId;
 import com.arcogine.challenge.catalogue.EquipmentCatalogue;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueValidationResult;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueValidator;
 import com.arcogine.challenge.catalogue.EquipmentOffer;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -13,14 +15,18 @@ import java.util.Optional;
  * A pure, deterministic calculator that derives {@link DraftEconomics} from an exact challenge
  * budget, catalogue, and set of draft equipment occurrences.
  *
- * <p>{@code calculate} resolves every occurrence through the game catalogue before aggregating
- * cost, sums committed construction cost, and derives remaining budget from the challenge's
- * starting budget. It mutates none of its inputs, consults no wall-clock time, environment,
- * random value, or global registry, and never calls Finance or factory validation. For identical
- * inputs -- including a failure outcome -- it always produces an equal result, regardless of
- * occurrence order: unresolved item ids are reported via the lexicographically smallest offending
- * identity rather than the first one encountered, and cost overflow is checked only once all
- * occurrences have resolved, so which failure is reported never depends on occurrence order.
+ * <p>{@code calculate} first validates the catalogue via {@link EquipmentCatalogueValidator#validate}
+ * -- an internally invalid catalogue (negative purchase costs, duplicate item ids, etc.) fails
+ * deterministically rather than silently producing an order-dependent or otherwise incorrect
+ * result. Once the catalogue is known valid, it resolves every occurrence through it before
+ * aggregating cost, sums committed construction cost, and derives remaining budget from the
+ * challenge's starting budget. It mutates none of its inputs, consults no wall-clock time,
+ * environment, random value, or global registry, and never calls Finance or factory validation.
+ * For identical inputs -- including a failure outcome -- it always produces an equal result,
+ * regardless of occurrence order: unresolved item ids are reported via the lexicographically
+ * smallest offending identity rather than the first one encountered, and cost overflow is checked
+ * only once all occurrences have resolved, so which failure is reported never depends on
+ * occurrence order.
  *
  * <p>This calculator does not enforce that occurrences use only the challenge's {@code
  * availableEquipment}, nor does it enforce catalogue quantity limits against occurrence counts --
@@ -42,6 +48,11 @@ public final class DraftEconomicsCalculator {
         }
         if (occurrences == null) {
             throw new NullPointerException("occurrences");
+        }
+
+        EquipmentCatalogueValidationResult catalogueValidation = EquipmentCatalogueValidator.validate(catalogue);
+        if (!catalogueValidation.isValid()) {
+            return DraftEconomicsResult.failure(DraftEconomicsFailure.invalidCatalogue(catalogueValidation));
         }
 
         List<EquipmentCatalogueItemId> unresolved = new ArrayList<>();

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsFailure.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsFailure.java
@@ -1,6 +1,7 @@
 package com.arcogine.challenge.economics;
 
 import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueValidationResult;
 
 /**
  * A structured, deterministic reason {@link DraftEconomicsCalculator} could not derive {@link
@@ -18,6 +19,16 @@ public record DraftEconomicsFailure(String code, String message) {
         if (message == null) {
             throw new NullPointerException("message");
         }
+    }
+
+    public static DraftEconomicsFailure invalidCatalogue(EquipmentCatalogueValidationResult validation) {
+        if (validation == null) {
+            throw new NullPointerException("validation");
+        }
+        return new DraftEconomicsFailure(
+                "catalogue.invalid",
+                "catalogue failed internal validation (" + validation.issues().size() + " issue(s)): "
+                        + validation.issues().get(0));
     }
 
     public static DraftEconomicsFailure unknownCatalogueItem(EquipmentCatalogueItemId itemId) {

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsFailure.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsFailure.java
@@ -1,0 +1,38 @@
+package com.arcogine.challenge.economics;
+
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+
+/**
+ * A structured, deterministic reason {@link DraftEconomicsCalculator} could not derive {@link
+ * DraftEconomics} for a given input.
+ *
+ * @param code stable, machine-readable failure code
+ * @param message human-readable description of the failure
+ */
+public record DraftEconomicsFailure(String code, String message) {
+
+    public DraftEconomicsFailure {
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
+        if (message == null) {
+            throw new NullPointerException("message");
+        }
+    }
+
+    public static DraftEconomicsFailure unknownCatalogueItem(EquipmentCatalogueItemId itemId) {
+        return new DraftEconomicsFailure(
+                "draft.occurrence.unknown-catalogue-item",
+                "no catalogue offer for item id: " + itemId.value());
+    }
+
+    public static DraftEconomicsFailure costOverflow() {
+        return new DraftEconomicsFailure(
+                "draft.cost.overflow", "committed construction cost overflowed a 64-bit total");
+    }
+
+    @Override
+    public String toString() {
+        return "[" + code + "]: " + message;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEconomicsResult.java
@@ -1,0 +1,31 @@
+package com.arcogine.challenge.economics;
+
+/**
+ * The outcome of {@link DraftEconomicsCalculator#calculate}: either a derived {@link
+ * DraftEconomics} snapshot, or a structured {@link DraftEconomicsFailure} explaining why one could
+ * not be derived.
+ *
+ * <p>Exactly one of {@link #economics()} or {@link #failure()} is present. This is a narrow,
+ * domain-specific result shape -- not a generic {@code Result<T, E>} framework.
+ */
+public record DraftEconomicsResult(DraftEconomics economics, DraftEconomicsFailure failure) {
+
+    public DraftEconomicsResult {
+        if ((economics == null) == (failure == null)) {
+            throw new IllegalArgumentException(
+                    "exactly one of economics or failure must be present");
+        }
+    }
+
+    public static DraftEconomicsResult success(DraftEconomics economics) {
+        return new DraftEconomicsResult(economics, null);
+    }
+
+    public static DraftEconomicsResult failure(DraftEconomicsFailure failure) {
+        return new DraftEconomicsResult(null, failure);
+    }
+
+    public boolean isSuccess() {
+        return economics != null;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEquipmentOccurrence.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/economics/DraftEquipmentOccurrence.java
@@ -1,0 +1,20 @@
+package com.arcogine.challenge.economics;
+
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+
+/**
+ * A single occurrence of a catalogue item in a draft, carrying only what draft economics needs to
+ * price it.
+ *
+ * <p>This deliberately carries no position, orientation, footprint, routing, operation
+ * assignment, machine capability, canonical resource id, or runtime state -- those belong to a
+ * later projection/placement slice, not to construction-cost calculation.
+ */
+public record DraftEquipmentOccurrence(EquipmentCatalogueItemId itemId) {
+
+    public DraftEquipmentOccurrence {
+        if (itemId == null) {
+            throw new NullPointerException("itemId");
+        }
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueFixtures.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueFixtures.java
@@ -1,0 +1,29 @@
+package com.arcogine.challenge.catalogue;
+
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.util.List;
+
+/**
+ * A reference catalogue matching {@code ChallengeFixtures.referenceChallenge()}'s
+ * available-equipment identities, with simple fixed test prices.
+ */
+public final class EquipmentCatalogueFixtures {
+
+    public static final long CUTTER_COST_CREDITS = 5_000L;
+    public static final long ASSEMBLY_STATION_COST_CREDITS = 8_000L;
+    public static final long INSPECTOR_COST_CREDITS = 3_000L;
+
+    private EquipmentCatalogueFixtures() {}
+
+    public static EquipmentCatalogue referenceCatalogue() {
+        return new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(
+                        new EquipmentCatalogueItemId("equipment.cutter"), CUTTER_COST_CREDITS),
+                EquipmentOffer.of(
+                        new EquipmentCatalogueItemId("equipment.assembly-station"),
+                        ASSEMBLY_STATION_COST_CREDITS),
+                EquipmentOffer.of(
+                        new EquipmentCatalogueItemId("equipment.inspector"),
+                        INSPECTOR_COST_CREDITS)));
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueIssueTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueIssueTest.java
@@ -1,0 +1,37 @@
+package com.arcogine.challenge.catalogue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class EquipmentCatalogueIssueTest {
+
+    @Test
+    void nullCodeIsRejected() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new EquipmentCatalogueIssue(null, "path", "message"));
+    }
+
+    @Test
+    void nullPathIsRejected() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new EquipmentCatalogueIssue("code", null, "message"));
+    }
+
+    @Test
+    void nullMessageIsRejected() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new EquipmentCatalogueIssue("code", "path", null));
+    }
+
+    @Test
+    void toStringIncludesPathCodeAndMessage() {
+        EquipmentCatalogueIssue issue = new EquipmentCatalogueIssue("code", "path", "message");
+
+        assertEquals("path [code]: message", issue.toString());
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueTest.java
@@ -1,0 +1,77 @@
+package com.arcogine.challenge.catalogue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class EquipmentCatalogueTest {
+
+    @Test
+    void findsOfferByItemId() {
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        Optional<EquipmentOffer> found =
+                catalogue.findByItemId(new EquipmentCatalogueItemId("equipment.cutter"));
+
+        assertTrue(found.isPresent());
+        assertEquals(EquipmentCatalogueFixtures.CUTTER_COST_CREDITS, found.get().purchaseCostCredits());
+    }
+
+    @Test
+    void unknownItemIdResolvesToEmpty() {
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        assertTrue(catalogue
+                .findByItemId(new EquipmentCatalogueItemId("equipment.unknown"))
+                .isEmpty());
+    }
+
+    @Test
+    void callerMutationOfSourceListCannotAlterCatalogue() {
+        List<EquipmentOffer> source = new ArrayList<>(EquipmentCatalogueFixtures.referenceCatalogue().offers());
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(source);
+
+        source.clear();
+
+        assertEquals(3, catalogue.offers().size());
+    }
+
+    @Test
+    void offersListIsImmutable() {
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        assertThrows(UnsupportedOperationException.class, () -> catalogue
+                .offers()
+                .add(EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.extra"), 1L)));
+    }
+
+    @Test
+    void nullOfferEntryIsRejected() {
+        List<EquipmentOffer> withNull = new ArrayList<>();
+        withNull.add(null);
+
+        assertThrows(NullPointerException.class, () -> new EquipmentCatalogue(withNull));
+    }
+
+    @Test
+    void nullOffersDefaultsToEmpty() {
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(null);
+
+        assertEquals(List.of(), catalogue.offers());
+    }
+
+    @Test
+    void equalityIsValueBased() {
+        EquipmentCatalogue first = EquipmentCatalogueFixtures.referenceCatalogue();
+        EquipmentCatalogue second = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueTest.java
@@ -74,4 +74,18 @@ class EquipmentCatalogueTest {
         assertEquals(first, second);
         assertEquals(first.hashCode(), second.hashCode());
     }
+
+    @Test
+    void findByItemIdRejectsNullItemId() {
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        assertThrows(NullPointerException.class, () -> catalogue.findByItemId(null));
+    }
+
+    @Test
+    void toStringIncludesOffers() {
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        assertTrue(catalogue.toString().contains("EquipmentCatalogue"));
+    }
 }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidationResultTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidationResultTest.java
@@ -1,0 +1,25 @@
+package com.arcogine.challenge.catalogue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EquipmentCatalogueValidationResultTest {
+
+    @Test
+    void validFactoryProducesAnEmptyValidResult() {
+        EquipmentCatalogueValidationResult result = EquipmentCatalogueValidationResult.valid();
+
+        assertTrue(result.isValid());
+        assertEquals(List.of(), result.issues());
+    }
+
+    @Test
+    void nullIssuesDefaultsToEmpty() {
+        EquipmentCatalogueValidationResult result = new EquipmentCatalogueValidationResult(null);
+
+        assertEquals(List.of(), result.issues());
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidatorDependencyBoundaryTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidatorDependencyBoundaryTest.java
@@ -1,0 +1,20 @@
+package com.arcogine.challenge.catalogue;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves the {@code :challenge} module's no-factory-runtime dependency boundary at the classpath
+ * level: {@code FactoryModelValidator} is not reachable from this test module, so {@link
+ * EquipmentCatalogueValidator} cannot call, extend, or otherwise depend on it.
+ */
+class EquipmentCatalogueValidatorDependencyBoundaryTest {
+
+    @Test
+    void factoryModelValidatorIsNotOnTheClasspath() {
+        assertThrows(
+                ClassNotFoundException.class,
+                () -> Class.forName("com.arcogine.factory.model.validation.FactoryModelValidator"));
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidatorTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidatorTest.java
@@ -1,0 +1,130 @@
+package com.arcogine.challenge.catalogue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.ChallengeFixtures;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class EquipmentCatalogueValidatorTest {
+
+    @Test
+    void referenceCatalogueOffersPassValidation() {
+        EquipmentCatalogueValidationResult result =
+                EquipmentCatalogueValidator.validate(EquipmentCatalogueFixtures.referenceCatalogue());
+
+        assertTrue(result.isValid());
+        assertEquals(List.of(), result.issues());
+    }
+
+    @Test
+    void duplicateItemIdsAreRejectedDeterministically() {
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 1L),
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 2L)));
+
+        EquipmentCatalogueValidationResult result = EquipmentCatalogueValidator.validate(catalogue);
+
+        assertTrue(containsIssue(result, "offers.itemId.duplicate", "offers[1].itemId"));
+    }
+
+    @Test
+    void blankItemIdIsRejected() {
+        EquipmentCatalogue catalogue =
+                new EquipmentCatalogue(List.of(EquipmentOffer.of(new EquipmentCatalogueItemId(" "), 1L)));
+
+        EquipmentCatalogueValidationResult result = EquipmentCatalogueValidator.validate(catalogue);
+
+        assertTrue(containsIssue(result, "offers.itemId.blank", "offers[0].itemId"));
+    }
+
+    @Test
+    void negativePurchaseCostIsRejected() {
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(
+                List.of(EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), -1L)));
+
+        EquipmentCatalogueValidationResult result = EquipmentCatalogueValidator.validate(catalogue);
+
+        assertTrue(containsIssue(
+                result, "offers.purchaseCostCredits.negative", "offers[0].purchaseCostCredits"));
+    }
+
+    @Test
+    void nonPositiveQuantityLimitIsRejectedWhenPresent() {
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 1L, 0)));
+
+        EquipmentCatalogueValidationResult result = EquipmentCatalogueValidator.validate(catalogue);
+
+        assertTrue(containsIssue(
+                result, "offers.quantityLimit.not-positive", "offers[0].quantityLimit"));
+    }
+
+    @Test
+    void multipleIssuesHaveStableDeterministicOrdering() {
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(new EquipmentCatalogueItemId(" "), -1L, 0),
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 1L)));
+
+        EquipmentCatalogueValidationResult result = EquipmentCatalogueValidator.validate(catalogue);
+
+        List<String> codes =
+                result.issues().stream().map(EquipmentCatalogueIssue::code).collect(Collectors.toList());
+
+        assertEquals(
+                List.of(
+                        "offers.itemId.blank",
+                        "offers.purchaseCostCredits.negative",
+                        "offers.quantityLimit.not-positive"),
+                codes);
+    }
+
+    @Test
+    void repeatedValidationOfIdenticalCatalogueProducesEqualResults() {
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        assertEquals(
+                EquipmentCatalogueValidator.validate(catalogue),
+                EquipmentCatalogueValidator.validate(catalogue));
+    }
+
+    @Test
+    void allReferenceChallengeAvailableEquipmentResolves() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        EquipmentCatalogueValidationResult result =
+                EquipmentCatalogueValidator.validateChallengeResolution(challenge, catalogue);
+
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void missingCatalogueItemProducesDeterministicStructuredIssue() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(
+                List.of(EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 1L)));
+
+        EquipmentCatalogueValidationResult result =
+                EquipmentCatalogueValidator.validateChallengeResolution(challenge, catalogue);
+
+        assertTrue(containsIssue(
+                result,
+                "challenge.availableEquipment.unresolved",
+                "availableEquipment[1]"));
+        assertTrue(containsIssue(
+                result,
+                "challenge.availableEquipment.unresolved",
+                "availableEquipment[2]"));
+    }
+
+    private static boolean containsIssue(
+            EquipmentCatalogueValidationResult result, String code, String path) {
+        return result.issues().stream()
+                .anyMatch(issue -> issue.code().equals(code) && issue.path().equals(path));
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidatorTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidatorTest.java
@@ -1,6 +1,7 @@
 package com.arcogine.challenge.catalogue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.arcogine.challenge.ChallengeDefinition;
@@ -120,6 +121,27 @@ class EquipmentCatalogueValidatorTest {
                 result,
                 "challenge.availableEquipment.unresolved",
                 "availableEquipment[2]"));
+    }
+
+    @Test
+    void validateRejectsNullCatalogue() {
+        assertThrows(NullPointerException.class, () -> EquipmentCatalogueValidator.validate(null));
+    }
+
+    @Test
+    void validateChallengeResolutionRejectsNullChallenge() {
+        assertThrows(
+                NullPointerException.class,
+                () -> EquipmentCatalogueValidator.validateChallengeResolution(
+                        null, EquipmentCatalogueFixtures.referenceCatalogue()));
+    }
+
+    @Test
+    void validateChallengeResolutionRejectsNullCatalogue() {
+        assertThrows(
+                NullPointerException.class,
+                () -> EquipmentCatalogueValidator.validateChallengeResolution(
+                        ChallengeFixtures.referenceChallenge(), null));
     }
 
     private static boolean containsIssue(

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidatorTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueValidatorTest.java
@@ -124,6 +124,22 @@ class EquipmentCatalogueValidatorTest {
     }
 
     @Test
+    void duplicateMatchingOffersMakeResolutionAmbiguousRatherThanValid() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 1L),
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 2L),
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.assembly-station"), 3L),
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.inspector"), 4L)));
+
+        EquipmentCatalogueValidationResult result =
+                EquipmentCatalogueValidator.validateChallengeResolution(challenge, catalogue);
+
+        assertTrue(containsIssue(
+                result, "challenge.availableEquipment.ambiguous", "availableEquipment[0]"));
+    }
+
+    @Test
     void validateRejectsNullCatalogue() {
         assertThrows(NullPointerException.class, () -> EquipmentCatalogueValidator.validate(null));
     }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentOfferTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentOfferTest.java
@@ -1,0 +1,51 @@
+package com.arcogine.challenge.catalogue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.util.OptionalInt;
+import org.junit.jupiter.api.Test;
+
+class EquipmentOfferTest {
+
+    @Test
+    void nullItemIdIsRejected() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new EquipmentOffer(null, 1L, OptionalInt.empty()));
+    }
+
+    @Test
+    void nullQuantityLimitIsRejected() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new EquipmentOffer(new EquipmentCatalogueItemId("equipment.cutter"), 1L, null));
+    }
+
+    @Test
+    void factoryWithoutLimitLeavesQuantityLimitEmpty() {
+        EquipmentOffer offer =
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 5_000L);
+
+        assertTrue(offer.quantityLimit().isEmpty());
+    }
+
+    @Test
+    void factoryWithLimitCarriesIt() {
+        EquipmentOffer offer =
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 5_000L, 3);
+
+        assertEquals(OptionalInt.of(3), offer.quantityLimit());
+    }
+
+    @Test
+    void equalityIsValueBased() {
+        EquipmentOffer first = EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 5_000L, 3);
+        EquipmentOffer second = EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 5_000L, 3);
+
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsCalculatorTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsCalculatorTest.java
@@ -2,11 +2,16 @@ package com.arcogine.challenge.economics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.arcogine.challenge.ChallengeDefinition;
 import com.arcogine.challenge.ChallengeFixtures;
+import com.arcogine.challenge.ChallengeIdentity;
+import com.arcogine.challenge.ChallengeWorkload;
 import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import com.arcogine.challenge.FactoryFloorConstraint;
 import com.arcogine.challenge.catalogue.EquipmentCatalogue;
 import com.arcogine.challenge.catalogue.EquipmentCatalogueFixtures;
 import com.arcogine.challenge.catalogue.EquipmentOffer;
@@ -146,6 +151,53 @@ class DraftEconomicsCalculatorTest {
         assertEquals(budgetBefore, challenge.startingBudget());
         assertEquals(offersBefore, catalogue.offers());
         assertEquals(occurrencesBefore, occurrences);
+    }
+
+    @Test
+    void remainingBudgetOverflowFailsExplicitlyRatherThanWrapping() {
+        ChallengeDefinition challenge = new ChallengeDefinition(
+                new ChallengeIdentity("challenge.overflow", "1"),
+                new FactoryFloorConstraint(1, 1),
+                Long.MIN_VALUE,
+                new ChallengeWorkload("product.any", 1),
+                List.of(),
+                1L,
+                new EvaluationPolicyIdentity("policy.any", "1"));
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(EquipmentOffer.of(CUTTER, 1L)));
+        List<DraftEquipmentOccurrence> occurrences = List.of(new DraftEquipmentOccurrence(CUTTER));
+
+        DraftEconomicsResult result = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertFalse(result.isSuccess());
+        assertEquals("draft.cost.overflow", result.failure().code());
+    }
+
+    @Test
+    void calculateRejectsNullChallenge() {
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        assertThrows(
+                NullPointerException.class,
+                () -> DraftEconomicsCalculator.calculate(null, catalogue, List.of()));
+    }
+
+    @Test
+    void calculateRejectsNullCatalogue() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+
+        assertThrows(
+                NullPointerException.class,
+                () -> DraftEconomicsCalculator.calculate(challenge, null, List.of()));
+    }
+
+    @Test
+    void calculateRejectsNullOccurrences() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        assertThrows(
+                NullPointerException.class,
+                () -> DraftEconomicsCalculator.calculate(challenge, catalogue, null));
     }
 
     @Test

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsCalculatorTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsCalculatorTest.java
@@ -1,0 +1,162 @@
+package com.arcogine.challenge.economics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.ChallengeFixtures;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.catalogue.EquipmentCatalogue;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueFixtures;
+import com.arcogine.challenge.catalogue.EquipmentOffer;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DraftEconomicsCalculatorTest {
+
+    private static final EquipmentCatalogueItemId CUTTER =
+            new EquipmentCatalogueItemId("equipment.cutter");
+    private static final EquipmentCatalogueItemId ASSEMBLY_STATION =
+            new EquipmentCatalogueItemId("equipment.assembly-station");
+    private static final EquipmentCatalogueItemId INSPECTOR =
+            new EquipmentCatalogueItemId("equipment.inspector");
+
+    @Test
+    void computesExactCommittedConstructionCost() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        List<DraftEquipmentOccurrence> occurrences = List.of(
+                new DraftEquipmentOccurrence(CUTTER),
+                new DraftEquipmentOccurrence(CUTTER),
+                new DraftEquipmentOccurrence(ASSEMBLY_STATION));
+
+        DraftEconomicsResult result = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertTrue(result.isSuccess());
+        long expectedCost = 2 * EquipmentCatalogueFixtures.CUTTER_COST_CREDITS
+                + EquipmentCatalogueFixtures.ASSEMBLY_STATION_COST_CREDITS;
+        assertEquals(expectedCost, result.economics().committedConstructionCostCredits());
+    }
+
+    @Test
+    void remainingBudgetEqualsStartingBudgetMinusCommittedCost() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        List<DraftEquipmentOccurrence> occurrences =
+                List.of(new DraftEquipmentOccurrence(CUTTER), new DraftEquipmentOccurrence(INSPECTOR));
+
+        DraftEconomics economics =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences).economics();
+
+        assertEquals(challenge.startingBudget(), economics.startingBudgetCredits());
+        assertEquals(
+                challenge.startingBudget() - economics.committedConstructionCostCredits(),
+                economics.remainingBudgetCredits());
+    }
+
+    @Test
+    void reorderingEquivalentOccurrencesDoesNotChangeTheResult() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        List<DraftEquipmentOccurrence> ordered = List.of(
+                new DraftEquipmentOccurrence(CUTTER),
+                new DraftEquipmentOccurrence(ASSEMBLY_STATION),
+                new DraftEquipmentOccurrence(INSPECTOR));
+        List<DraftEquipmentOccurrence> reordered = List.of(
+                new DraftEquipmentOccurrence(INSPECTOR),
+                new DraftEquipmentOccurrence(CUTTER),
+                new DraftEquipmentOccurrence(ASSEMBLY_STATION));
+
+        DraftEconomicsResult first = DraftEconomicsCalculator.calculate(challenge, catalogue, ordered);
+        DraftEconomicsResult second = DraftEconomicsCalculator.calculate(challenge, catalogue, reordered);
+
+        assertEquals(first.economics(), second.economics());
+    }
+
+    @Test
+    void removingAnOccurrenceChangesCostDeterministically() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        List<DraftEquipmentOccurrence> withCutter =
+                List.of(new DraftEquipmentOccurrence(CUTTER), new DraftEquipmentOccurrence(INSPECTOR));
+        List<DraftEquipmentOccurrence> withoutCutter = List.of(new DraftEquipmentOccurrence(INSPECTOR));
+
+        DraftEconomics withCutterEconomics =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, withCutter).economics();
+        DraftEconomics withoutCutterEconomics =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, withoutCutter).economics();
+
+        assertEquals(
+                EquipmentCatalogueFixtures.CUTTER_COST_CREDITS,
+                withCutterEconomics.committedConstructionCostCredits()
+                        - withoutCutterEconomics.committedConstructionCostCredits());
+    }
+
+    @Test
+    void unknownDraftCatalogueIdentityFailsExplicitly() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        List<DraftEquipmentOccurrence> occurrences =
+                List.of(new DraftEquipmentOccurrence(new EquipmentCatalogueItemId("equipment.unknown")));
+
+        DraftEconomicsResult result = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertFalse(result.isSuccess());
+        assertEquals("draft.occurrence.unknown-catalogue-item", result.failure().code());
+    }
+
+    @Test
+    void arithmeticOverflowFailsExplicitlyRatherThanWrapping() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(
+                List.of(EquipmentOffer.of(CUTTER, Long.MAX_VALUE)));
+        List<DraftEquipmentOccurrence> occurrences =
+                List.of(new DraftEquipmentOccurrence(CUTTER), new DraftEquipmentOccurrence(CUTTER));
+
+        DraftEconomicsResult result = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertFalse(result.isSuccess());
+        assertEquals("draft.cost.overflow", result.failure().code());
+    }
+
+    @Test
+    void repeatedCalculationFromIdenticalInputsReturnsEqualResults() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        List<DraftEquipmentOccurrence> occurrences = List.of(new DraftEquipmentOccurrence(CUTTER));
+
+        DraftEconomicsResult first = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+        DraftEconomicsResult second = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertEquals(first, second);
+    }
+
+    @Test
+    void calculationDoesNotMutateChallengeCatalogueOrDraft() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        List<DraftEquipmentOccurrence> occurrences = List.of(new DraftEquipmentOccurrence(CUTTER));
+        long budgetBefore = challenge.startingBudget();
+        List<EquipmentOffer> offersBefore = List.copyOf(catalogue.offers());
+        List<DraftEquipmentOccurrence> occurrencesBefore = List.copyOf(occurrences);
+
+        DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertEquals(budgetBefore, challenge.startingBudget());
+        assertEquals(offersBefore, catalogue.offers());
+        assertEquals(occurrencesBefore, occurrences);
+    }
+
+    @Test
+    void runsWithoutAnArcogineRuntimeOrActiveSimulationSession() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+
+        DraftEconomicsResult result =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, List.of());
+
+        assertTrue(result.isSuccess());
+        assertEquals(0L, result.economics().committedConstructionCostCredits());
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsCalculatorTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsCalculatorTest.java
@@ -126,6 +126,70 @@ class DraftEconomicsCalculatorTest {
     }
 
     @Test
+    void unknownItemFailureIsOrderIndependentAcrossPermutationsOfTheSameMultiset() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        EquipmentCatalogueItemId unknownA = new EquipmentCatalogueItemId("equipment.unknown-a");
+        EquipmentCatalogueItemId unknownB = new EquipmentCatalogueItemId("equipment.unknown-b");
+        List<DraftEquipmentOccurrence> forward = List.of(
+                new DraftEquipmentOccurrence(unknownA), new DraftEquipmentOccurrence(unknownB));
+        List<DraftEquipmentOccurrence> reversed = List.of(
+                new DraftEquipmentOccurrence(unknownB), new DraftEquipmentOccurrence(unknownA));
+
+        DraftEconomicsResult forwardResult = DraftEconomicsCalculator.calculate(challenge, catalogue, forward);
+        DraftEconomicsResult reversedResult =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, reversed);
+
+        assertEquals(forwardResult, reversedResult);
+        assertEquals("no catalogue offer for item id: equipment.unknown-a", forwardResult.failure().message());
+    }
+
+    @Test
+    void unknownItemFailureTakesPrecedenceOverOverflowRegardlessOfOrder() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(
+                List.of(EquipmentOffer.of(CUTTER, Long.MAX_VALUE)));
+        EquipmentCatalogueItemId unknown = new EquipmentCatalogueItemId("equipment.unknown");
+        List<DraftEquipmentOccurrence> knownFirst = List.of(
+                new DraftEquipmentOccurrence(CUTTER),
+                new DraftEquipmentOccurrence(CUTTER),
+                new DraftEquipmentOccurrence(unknown));
+        List<DraftEquipmentOccurrence> unknownFirst = List.of(
+                new DraftEquipmentOccurrence(unknown),
+                new DraftEquipmentOccurrence(CUTTER),
+                new DraftEquipmentOccurrence(CUTTER));
+
+        DraftEconomicsResult knownFirstResult =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, knownFirst);
+        DraftEconomicsResult unknownFirstResult =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, unknownFirst);
+
+        assertEquals(knownFirstResult, unknownFirstResult);
+        assertEquals("draft.occurrence.unknown-catalogue-item", knownFirstResult.failure().code());
+    }
+
+    @Test
+    void overflowFailureIsOrderIndependentAcrossPermutationsOfTheSameMultiset() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogueItemId large = new EquipmentCatalogueItemId("equipment.large");
+        EquipmentCatalogueItemId small = new EquipmentCatalogueItemId("equipment.small");
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(large, Long.MAX_VALUE), EquipmentOffer.of(small, 1L)));
+        List<DraftEquipmentOccurrence> largeFirst =
+                List.of(new DraftEquipmentOccurrence(large), new DraftEquipmentOccurrence(small));
+        List<DraftEquipmentOccurrence> smallFirst =
+                List.of(new DraftEquipmentOccurrence(small), new DraftEquipmentOccurrence(large));
+
+        DraftEconomicsResult largeFirstResult =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, largeFirst);
+        DraftEconomicsResult smallFirstResult =
+                DraftEconomicsCalculator.calculate(challenge, catalogue, smallFirst);
+
+        assertEquals(largeFirstResult, smallFirstResult);
+        assertEquals("draft.cost.overflow", largeFirstResult.failure().code());
+    }
+
+    @Test
     void repeatedCalculationFromIdenticalInputsReturnsEqualResults() {
         ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
         EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsCalculatorTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsCalculatorTest.java
@@ -126,6 +126,49 @@ class DraftEconomicsCalculatorTest {
     }
 
     @Test
+    void negativeCostOfferInCatalogueFailsExplicitlyInsteadOfProducingALargerBudget() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(EquipmentOffer.of(CUTTER, -1L)));
+        List<DraftEquipmentOccurrence> occurrences = List.of(new DraftEquipmentOccurrence(CUTTER));
+
+        DraftEconomicsResult result = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertFalse(result.isSuccess());
+        assertEquals("catalogue.invalid", result.failure().code());
+    }
+
+    @Test
+    void duplicateItemIdInCatalogueFailsExplicitlyRatherThanPricingAmbiguously() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(
+                List.of(EquipmentOffer.of(CUTTER, 1L), EquipmentOffer.of(CUTTER, 2L)));
+        List<DraftEquipmentOccurrence> occurrences = List.of(new DraftEquipmentOccurrence(CUTTER));
+
+        DraftEconomicsResult result = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertFalse(result.isSuccess());
+        assertEquals("catalogue.invalid", result.failure().code());
+    }
+
+    @Test
+    void duplicatePricedCatalogueDoesNotOverflowDifferentlyByOrder() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogueItemId large = new EquipmentCatalogueItemId("equipment.large");
+        EquipmentCatalogueItemId small = new EquipmentCatalogueItemId("equipment.small");
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(large, Long.MAX_VALUE),
+                EquipmentOffer.of(small, 1L),
+                EquipmentOffer.of(small, -1L)));
+        List<DraftEquipmentOccurrence> occurrences =
+                List.of(new DraftEquipmentOccurrence(large), new DraftEquipmentOccurrence(small));
+
+        DraftEconomicsResult result = DraftEconomicsCalculator.calculate(challenge, catalogue, occurrences);
+
+        assertFalse(result.isSuccess());
+        assertEquals("catalogue.invalid", result.failure().code());
+    }
+
+    @Test
     void unknownItemFailureIsOrderIndependentAcrossPermutationsOfTheSameMultiset() {
         ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
         EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsFailureTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsFailureTest.java
@@ -1,0 +1,26 @@
+package com.arcogine.challenge.economics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class DraftEconomicsFailureTest {
+
+    @Test
+    void nullCodeIsRejected() {
+        assertThrows(NullPointerException.class, () -> new DraftEconomicsFailure(null, "message"));
+    }
+
+    @Test
+    void nullMessageIsRejected() {
+        assertThrows(NullPointerException.class, () -> new DraftEconomicsFailure("code", null));
+    }
+
+    @Test
+    void toStringIncludesCodeAndMessage() {
+        DraftEconomicsFailure failure = new DraftEconomicsFailure("code", "message");
+
+        assertEquals("[code]: message", failure.toString());
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsFailureTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsFailureTest.java
@@ -2,10 +2,31 @@ package com.arcogine.challenge.economics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.arcogine.challenge.catalogue.EquipmentCatalogueIssue;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueValidationResult;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class DraftEconomicsFailureTest {
+
+    @Test
+    void invalidCatalogueRejectsNullValidation() {
+        assertThrows(NullPointerException.class, () -> DraftEconomicsFailure.invalidCatalogue(null));
+    }
+
+    @Test
+    void invalidCatalogueSummarizesTheFirstIssue() {
+        EquipmentCatalogueValidationResult validation = new EquipmentCatalogueValidationResult(
+                List.of(new EquipmentCatalogueIssue("code", "path", "message")));
+
+        DraftEconomicsFailure failure = DraftEconomicsFailure.invalidCatalogue(validation);
+
+        assertEquals("catalogue.invalid", failure.code());
+        assertTrue(failure.message().contains("1 issue"));
+        assertTrue(failure.message().contains("path [code]: message"));
+    }
 
     @Test
     void nullCodeIsRejected() {

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsResultTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEconomicsResultTest.java
@@ -1,0 +1,21 @@
+package com.arcogine.challenge.economics;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class DraftEconomicsResultTest {
+
+    @Test
+    void bothEconomicsAndFailurePresentIsRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new DraftEconomicsResult(
+                        new DraftEconomics(0L, 0L, 0L), new DraftEconomicsFailure("code", "message")));
+    }
+
+    @Test
+    void neitherEconomicsNorFailurePresentIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new DraftEconomicsResult(null, null));
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEquipmentOccurrenceTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/economics/DraftEquipmentOccurrenceTest.java
@@ -1,0 +1,13 @@
+package com.arcogine.challenge.economics;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class DraftEquipmentOccurrenceTest {
+
+    @Test
+    void nullItemIdIsRejected() {
+        assertThrows(NullPointerException.class, () -> new DraftEquipmentOccurrence(null));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the catalogue seam and deterministic draft-economics calculation for Challenge Readiness C2, as specified in the design document. This is a partial C2 implementation covering equipment catalogues and construction-cost calculation; candidate admissibility validation is deferred to a later slice.

## Key Changes

- **Equipment Catalogue Types**
  - `EquipmentOffer`: immutable game-owned catalogue entry (item id, non-negative purchase cost, optional positive quantity limit)
  - `EquipmentCatalogue`: immutable collection of offers with value equality and lookup by item id
  - Neither type assumes Arcogine's canonical `ResourceDefinition` is reusable as an equipment type

- **Catalogue Validation**
  - `EquipmentCatalogueValidator`: deterministic, side-effect-free static validator producing structured `EquipmentCatalogueIssue` diagnostics
  - Validates catalogue-internal validity (blank/duplicate item ids, negative cost, invalid quantity limit)
  - Separate `validateChallengeResolution` check that every `ChallengeDefinition.availableEquipment` identity resolves to exactly one catalogue offer
  - Does not call, extend, or share result types with `ChallengeDefinitionValidator` or `FactoryModelValidator`

- **Draft Economics Calculation**
  - `DraftEquipmentOccurrence`: catalogue item id only (no position, footprint, or canonical resource id)
  - `DraftEconomicsCalculator`: pure, deterministic calculator deriving `DraftEconomics` from challenge budget, catalogue, and draft occurrences
  - `DraftEconomics`: immutable snapshot of starting budget, committed construction cost, and remaining budget
  - `DraftEconomicsResult` and `DraftEconomicsFailure`: structured success/failure outcomes with stable error codes
  - Handles arithmetic overflow explicitly rather than wrapping; produces equal results for identical inputs regardless of occurrence order

- **Test Coverage**
  - Comprehensive test suites for all new types and validators
  - Fixture support (`EquipmentCatalogueFixtures`) matching reference challenge equipment
  - Dependency boundary test proving `FactoryModelValidator` is not reachable from the `:challenge` module

## Implementation Details

- No new `project(...)` dependencies on `:types`, `:simulation`, `:factory`, `:economy`, `:finance`, `:api`, or `:cli`
- All types are immutable with value-based equality
- Validation and calculation never mutate inputs, consult wall-clock time, or access global state
- Deterministic ordering of validation issues for stable diagnostics
- Calculator does not enforce challenge `availableEquipment` restrictions or catalogue quantity limits against occurrence counts (deferred to candidate admissibility slice)

https://claude.ai/code/session_012R3Db8kHY1nmPxgxbMSJsM