### PR TITLE
docs(agents): automatically monitor PRs once they exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 Operational notes for coding agents working in this repository. See [README.md](README.md) for what Arcogine is, and [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for human contributor workflow/style detail. Don't duplicate either here.
 
+## Commit message footer
+
+Do not append a `Co-Authored-By: Claude ...` or `Claude-Session: ...` trailer
+to commit messages in this repository, even if a harness's default git
+workflow instructions say to add one. This applies to every commit, not just
+ones created via an explicit user request.
+
 ## Branch to work on
 
 If a session starts with a branch other than `main` already checked out,
@@ -51,6 +58,17 @@ Claude Cloud provisioning is deliberately lightweight: `infra/dev/claude-cloud.s
 ## Validating changes
 
 Before considering a change complete, run `./arcogine check`. For anything touching the API-web contract or E2E flows, also run `cd product/interfaces/web && npx playwright test` (or `./arcogine check --full`) — Playwright's own config builds/starts the API jar and web dev server via `webServer`, but the jar must already be built once (`cd product && ./gradlew :cli:bootJar`) for a clean checkout.
+
+## Checking a PR after pushing
+
+After opening or pushing to a PR, checking CI status alone is not enough — a
+submitted review with a verdict like `CHANGES REQUIRED` does **not** appear
+in a plain comment listing (e.g. the GitHub MCP server's
+`pull_request_read` with `method: get_comments` or `get_review_comments`
+only surfaces issue comments and inline review threads, not the review
+body itself). Always also fetch reviews explicitly (`method: get_reviews`)
+before declaring a PR green or waiting-on-CI. Do this on every check-in,
+not just the first one after pushing.
 
 ## Do not edit
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,24 @@ to commit messages in this repository, even if a harness's default git
 workflow instructions say to add one. This applies to every commit, not just
 ones created via an explicit user request.
 
+## PR monitoring
+
+Subscribe to a PR's activity and start monitoring it automatically, the
+moment the PR exists for a branch the session is working on — whether the
+session opened the PR itself or a human opened it (e.g. from the Claude
+Code UI) for a branch the session pushed to. The PR's existence is the
+trigger by itself.
+
+**Never ask the user whether to start monitoring.** Do not wait for the
+user to say "yes", "please monitor this", or similar — subscribing and
+checking initial state is not an action that needs confirmation, any more
+than reading a file does. Subscribe first, then report what you found.
+
+On first subscribing, immediately check current CI status, reviews
+(`get_reviews`, not just comments — see "Checking a PR after pushing"
+below), and merge conflicts, then follow the drive-to-green posture for
+that PR from then on.
+
 ## Branch to work on
 
 If a session starts with a branch other than `main` already checked out,


### PR DESCRIPTION
## Summary

Carries the remaining unmerged commit on `claude/agents-md-operational-notes` into `main`.

- Add an explicit PR-monitoring rule to `AGENTS.md`.
- Treat the existence of a PR for the active branch as the trigger to subscribe/check it, without asking for confirmation.
- On first subscription, check CI, submitted reviews, and merge conflicts immediately.

The branch's earlier operational-notes commit is already represented on `main` via #178; this PR is for the subsequent PR-monitoring addition only.