### PR TITLE
G1: implement durable factory model fingerprint v1

### DIFF
--- a/docs/planning/factory-design-capability.md
+++ b/docs/planning/factory-design-capability.md
@@ -105,7 +105,7 @@ D2 Executability validation         PARTIAL
 D3 Publication / semantic identity  PARTIAL
     immutable publication           implemented
     content hash                    implemented, provisional policy
-    durable fingerprint contract    not yet — see ADR-0004
+    durable fingerprint contract    implemented for factory-model:v1 — see ADR-0006
     controlled revision identity    deferred
 D4 Runtime instantiation            PARTIAL
     runtime from published model    implemented
@@ -118,7 +118,8 @@ D1's acceptance criteria call for resource definitions and installed instances t
 
 Two callouts worth being explicit about:
 
-- `FactoryModelVersion.contentHash()` exists and is deterministic, but its own Javadoc describes it as an internal, in-memory identity policy, not a persisted/public/cross-process compatibility guarantee. See [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md) for what remains to be specified (canonicalization, ordering semantics, algorithm/format versioning, compatibility guarantee) before it can be promoted to a durable fingerprint contract.
+- `FactoryModelVersion.fingerprint()` now implements the durable `factory-model:v1` contract from [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md). The legacy `contentHash()` remains a separate compatibility surface and must not be reinterpreted as the v1 fingerprint.
+- Controlled revision identity and lineage remain deferred; this durable semantic fingerprint does not make Governance G1 complete and does not introduce revision persistence or workflow state.
 - Model provenance now reaches both `IntegratedHandler` and `SimResult` (the latter via the simulation-module `ModelProvenanceSource` capability, so `SimRunner` stays free of any dependency on `IntegratedHandler` or the API layer). "Runtime observations/results identify the source model version" (the D3/D4 acceptance criteria below, and the equivalent criterion in the [engine-readiness plan](factory-simulation-engine-readiness.md)) is true at both the handler and result layers today; broader run-level provenance (run ID, scenario/input fingerprint, engine build) remains outstanding.
 
 ## 4. Current-model migration strategy

--- a/docs/planning/governance-conformance-capability.md
+++ b/docs/planning/governance-conformance-capability.md
@@ -142,6 +142,13 @@ G1-G5 are architectural substrate. G6-G7 establish governance workflow integrati
 
 ## 5. G1 — Durable fingerprint and controlled revision lineage
 
+### Current status
+
+**Partial.** ADR-0006 is implemented for the factory-model:v1 durable semantic fingerprint. The
+typed fingerprint and canonical binary encoding now coexist with the legacy `contentHash()`;
+controlled revision identity and lineage remain deferred to a subsequent ADR and implementation
+slice. G1 is therefore not complete until that revision and later persistence work exists.
+
 ### Goal
 
 Promote the current provisional content-derived identity into an explicit durable semantic fingerprint contract, and introduce a separate controlled revision lifecycle for historical lineage.

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelFingerprintV1.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelFingerprintV1.java
@@ -1,0 +1,109 @@
+package com.arcogine.factory.model;
+
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ModelFingerprint;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+
+/** The durable, language-independent {@code factory-model:v1} canonicalization policy. */
+final class FactoryModelFingerprintV1 {
+
+    private static final byte[] PREFIX = "arcogine.factory-model.v1\0".getBytes(StandardCharsets.US_ASCII);
+
+    private FactoryModelFingerprintV1() {}
+
+    static ModelFingerprint fingerprint(FactoryModel model) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return new ModelFingerprint("factory-model", "v1", "sha256", HexFormat.of().formatHex(digest.digest(canonicalBytes(model))));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    static byte[] canonicalBytes(FactoryModel model) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        bytes.writeBytes(PREFIX);
+
+        List<ResourceDefinition> resources = model.resources();
+        writeU64(bytes, resources.size());
+        for (ResourceDefinition resource : resources) {
+            writeI64(bytes, resource.id().value());
+            writeText(bytes, resource.name());
+            writeI64(bytes, resource.concurrency());
+            writeOptionalF64(bytes, resource.capacityLiters());
+            writeI64(bytes, resource.setupTime());
+        }
+
+        List<OperationDefinition> operations = model.operations();
+        writeU64(bytes, operations.size());
+        for (OperationDefinition operation : operations) {
+            writeI64(bytes, operation.id());
+            writeText(bytes, operation.name());
+            writeU64(bytes, operation.steps().size());
+            for (OperationStepDefinition step : operation.steps()) {
+                writeI64(bytes, step.stepId());
+                writeText(bytes, step.name());
+                writeI64(bytes, step.duration());
+                List<MachineId> eligibleResources = step.eligibleResources().stream()
+                        .sorted()
+                        .toList();
+                writeU64(bytes, eligibleResources.size());
+                for (MachineId resourceId : eligibleResources) {
+                    writeI64(bytes, resourceId.value());
+                }
+            }
+        }
+
+        List<ProductDefinition> products = model.products();
+        writeU64(bytes, products.size());
+        for (ProductDefinition product : products) {
+            writeI64(bytes, product.id().value());
+            writeText(bytes, product.name());
+            writeI64(bytes, product.operationId());
+        }
+        return bytes.toByteArray();
+    }
+
+    private static void writeU64(ByteArrayOutputStream bytes, long value) {
+        writeI64(bytes, value);
+    }
+
+    private static void writeI64(ByteArrayOutputStream bytes, long value) {
+        bytes.writeBytes(ByteBuffer.allocate(Long.BYTES).putLong(value).array());
+    }
+
+    private static void writeText(ByteArrayOutputStream bytes, String value) {
+        ByteBuffer encoded;
+        try {
+            encoded = StandardCharsets.UTF_8.newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .encode(CharBuffer.wrap(value));
+        } catch (CharacterCodingException e) {
+            throw new IllegalArgumentException("text contains an invalid Unicode scalar value", e);
+        }
+        byte[] text = new byte[encoded.remaining()];
+        encoded.get(text);
+        writeU64(bytes, text.length);
+        bytes.writeBytes(text);
+    }
+
+    private static void writeOptionalF64(ByteArrayOutputStream bytes, Double value) {
+        if (value == null) {
+            bytes.write(0);
+            return;
+        }
+        bytes.write(1);
+        long bits = Double.isNaN(value) ? 0x7ff8000000000000L : Double.doubleToRawLongBits(value);
+        writeI64(bytes, bits);
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelVersion.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/FactoryModelVersion.java
@@ -2,6 +2,7 @@ package com.arcogine.factory.model;
 
 import com.arcogine.factory.model.validation.FactoryModelValidator;
 import com.arcogine.types.MachineId;
+import com.arcogine.types.ModelFingerprint;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -45,6 +46,10 @@ public record FactoryModelVersion(FactoryModel model) {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 not available", e);
         }
+    }
+
+    public ModelFingerprint fingerprint() {
+        return FactoryModelFingerprintV1.fingerprint(model);
     }
 
     /**

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidator.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/validation/FactoryModelValidator.java
@@ -28,6 +28,7 @@ public final class FactoryModelValidator {
 
         Set<MachineId> resourceIds = new HashSet<>();
         for (ResourceDefinition resource : model.resources()) {
+            rejectMalformedUnicode(errors, "resources[" + resource.id() + "].name", resource.name());
             if (!resourceIds.add(resource.id())) {
                 errors.add(new ModelValidationError(
                         "resources", "duplicate resource id: " + resource.id()));
@@ -40,6 +41,7 @@ public final class FactoryModelValidator {
 
         Set<Long> operationIds = new HashSet<>();
         for (OperationDefinition operation : model.operations()) {
+            rejectMalformedUnicode(errors, "operations[" + operation.id() + "].name", operation.name());
             if (!operationIds.add(operation.id())) {
                 errors.add(new ModelValidationError(
                         "operations", "duplicate operation id: " + operation.id()));
@@ -49,6 +51,10 @@ public final class FactoryModelValidator {
                         "operations[" + operation.id() + "].steps", "must not be empty"));
             }
             for (OperationStepDefinition step : operation.steps()) {
+                rejectMalformedUnicode(
+                        errors,
+                        "operations[" + operation.id() + "].steps[" + step.stepId() + "].name",
+                        step.name());
                 if (step.duration() <= 0) {
                     errors.add(new ModelValidationError(
                             "operations[" + operation.id() + "].steps[" + step.stepId() + "].duration",
@@ -74,6 +80,7 @@ public final class FactoryModelValidator {
 
         Set<com.arcogine.types.ProductId> productIds = new HashSet<>();
         for (ProductDefinition product : model.products()) {
+            rejectMalformedUnicode(errors, "products[" + product.id() + "].name", product.name());
             if (!productIds.add(product.id())) {
                 errors.add(new ModelValidationError(
                         "products", "duplicate product id: " + product.id()));
@@ -86,6 +93,23 @@ public final class FactoryModelValidator {
         }
 
         return new ModelValidationResult(errors);
+    }
+
+    private static void rejectMalformedUnicode(
+            List<ModelValidationError> errors, String field, String value) {
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            if (Character.isHighSurrogate(character)) {
+                if (index + 1 >= value.length() || !Character.isLowSurrogate(value.charAt(index + 1))) {
+                    errors.add(new ModelValidationError(field, "must contain only valid Unicode scalar values"));
+                    return;
+                }
+                index++;
+            } else if (Character.isLowSurrogate(character)) {
+                errors.add(new ModelValidationError(field, "must contain only valid Unicode scalar values"));
+                return;
+            }
+        }
     }
 
     /**

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelFingerprintV1Test.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelFingerprintV1Test.java
@@ -1,0 +1,198 @@
+package com.arcogine.factory.model;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.arcogine.factory.model.validation.FactoryModelValidationException;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ModelFingerprint;
+import com.arcogine.types.ProductId;
+import java.util.HexFormat;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class FactoryModelFingerprintV1Test {
+
+    private static FactoryModel representativeModel() {
+        return new FactoryModel(
+                List.of(
+                        new ResourceDefinition(new MachineId(-2), "M|ill", 3, -0.0, -7),
+                        new ResourceDefinition(new MachineId(5), "Second", 1, null, 0)),
+                List.of(new OperationDefinition(
+                        42,
+                        "Op:🚀",
+                        List.of(new OperationStepDefinition(
+                                9,
+                                "Step;é",
+                                new LinkedHashSet<>(List.of(new MachineId(5), new MachineId(-2))),
+                                11)))),
+                List.of(new ProductDefinition(new ProductId(8), "P\u0000|𐀀", 42)));
+    }
+
+    @Test
+    void representativeVectorPinsCanonicalBytesAndFingerprint() {
+        FactoryModelVersion version = FactoryModelPublisher.publish(representativeModel());
+
+        assertArrayEquals(
+                HexFormat.of().parseHex(
+                        "6172636f67696e652e666163746f72792d6d6f64656c2e7631000000000000000002fffffffffffffffe00000000000000054d7c696c6c0000000000000003018000000000000000fffffffffffffff9000000000000000500000000000000065365636f6e6400000000000000010000000000000000000000000000000001000000000000002a00000000000000074f703af09f9a80000000000000000100000000000000090000000000000007537465703bc3a9000000000000000b0000000000000002fffffffffffffffe000000000000000500000000000000010000000000000008000000000000000750007cf0908080000000000000002a"),
+                FactoryModelFingerprintV1.canonicalBytes(representativeModel()));
+        assertEquals(
+                "factory-model:v1:sha256:5b08fbe9a8db08f229ed6161444a05834b306cb4d54425ae06b5f99cef9acd01",
+                version.fingerprint().toString());
+    }
+
+    @Test
+    void setIterationOrderDoesNotChangeFingerprint() {
+        FactoryModel first = representativeModel();
+        FactoryModel second = new FactoryModel(
+                first.resources(),
+                List.of(new OperationDefinition(
+                        42,
+                        "Op:🚀",
+                        List.of(new OperationStepDefinition(
+                                9, "Step;é", Set.of(new MachineId(-2), new MachineId(5)), 11)))),
+                first.products());
+
+        assertEquals(
+                FactoryModelPublisher.publish(first).fingerprint(),
+                FactoryModelPublisher.publish(second).fingerprint());
+    }
+
+    @Test
+    void meaningfulFieldAndListChangesChangeFingerprint() {
+        FactoryModelVersion original = FactoryModelPublisher.publish(representativeModel());
+        FactoryModel reordered = new FactoryModel(
+                List.of(
+                        new ResourceDefinition(new MachineId(5), "Second", 1, null, 0),
+                        new ResourceDefinition(new MachineId(-2), "M|ill", 3, -0.0, -7)),
+                List.of(new OperationDefinition(
+                        42, "Op:🚀", List.of(new OperationStepDefinition(
+                                9, "Step;é", Set.of(new MachineId(-2), new MachineId(5)), 11)))),
+                List.of(new ProductDefinition(new ProductId(8), "P\u0000|𐀀", 42)));
+
+        assertNotEquals(original.fingerprint(), FactoryModelPublisher.publish(reordered).fingerprint());
+    }
+
+    @Test
+    void namesIdsStepsAndCapacityParticipateInFingerprint() {
+        FactoryModelVersion original = FactoryModelPublisher.publish(representativeModel());
+
+        assertDifferent(original, modelWithResourceName("Other"));
+        assertDifferent(original, modelWithOperationName("Other"));
+        assertDifferent(original, modelWithStepName("Other"));
+        assertDifferent(original, modelWithProductName("Other"));
+        assertDifferent(original, modelWithResourceId(7));
+        assertDifferent(original, modelWithCapacity(1.0));
+    }
+
+    @Test
+    void listOrderAndFloatingPointPayloadArePartOfTheContract() {
+        FactoryModel model = new FactoryModel(
+                List.of(new ResourceDefinition(new MachineId(1), "A", 1, 0.0, 0),
+                        new ResourceDefinition(new MachineId(2), "B", 1, null, 0)),
+                List.of(new OperationDefinition(1, "One", List.of(
+                                new OperationStepDefinition(1, "First", Set.of(new MachineId(1)), 1),
+                                new OperationStepDefinition(2, "Second", Set.of(new MachineId(1)), 2))),
+                        new OperationDefinition(2, "Two", List.of(
+                                new OperationStepDefinition(1, "Only", Set.of(new MachineId(2)), 1)))),
+                List.of(new ProductDefinition(new ProductId(1), "One", 1),
+                        new ProductDefinition(new ProductId(2), "Two", 2)));
+
+        FactoryModelVersion original = FactoryModelPublisher.publish(model);
+        FactoryModelVersion resourceReordered = FactoryModelPublisher.publish(new FactoryModel(
+                List.of(model.resources().get(1), model.resources().get(0)), model.operations(), model.products()));
+        FactoryModelVersion operationReordered = FactoryModelPublisher.publish(new FactoryModel(
+                model.resources(), List.of(model.operations().get(1), model.operations().get(0)), model.products()));
+        FactoryModelVersion stepReordered = FactoryModelPublisher.publish(new FactoryModel(
+                model.resources(), List.of(new OperationDefinition(1, "One", List.of(
+                        model.operations().get(0).steps().get(1), model.operations().get(0).steps().get(0))),
+                        model.operations().get(1)), model.products()));
+        FactoryModelVersion productReordered = FactoryModelPublisher.publish(new FactoryModel(
+                model.resources(), model.operations(), List.of(model.products().get(1), model.products().get(0))));
+        FactoryModelVersion negativeZero = FactoryModelPublisher.publish(new FactoryModel(
+                List.of(new ResourceDefinition(new MachineId(1), "A", 1, -0.0, 0), model.resources().get(1)),
+                model.operations(), model.products()));
+
+        assertNotEquals(original.fingerprint(), resourceReordered.fingerprint());
+        assertNotEquals(original.fingerprint(), operationReordered.fingerprint());
+        assertNotEquals(original.fingerprint(), stepReordered.fingerprint());
+        assertNotEquals(original.fingerprint(), productReordered.fingerprint());
+        assertNotEquals(original.fingerprint(), negativeZero.fingerprint());
+    }
+
+    private static void assertDifferent(FactoryModelVersion original, FactoryModel changed) {
+        assertNotEquals(original.fingerprint(), FactoryModelPublisher.publish(changed).fingerprint());
+    }
+
+    private static FactoryModel modelWithResourceName(String name) {
+        return new FactoryModel(
+                List.of(new ResourceDefinition(new MachineId(-2), name, 3, -0.0, -7),
+                        new ResourceDefinition(new MachineId(5), "Second", 1, null, 0)),
+                representativeModel().operations(), representativeModel().products());
+    }
+
+    private static FactoryModel modelWithOperationName(String name) {
+        OperationDefinition operation = representativeModel().operations().get(0);
+        return new FactoryModel(representativeModel().resources(),
+                List.of(new OperationDefinition(operation.id(), name, operation.steps())), representativeModel().products());
+    }
+
+    private static FactoryModel modelWithStepName(String name) {
+        OperationDefinition operation = representativeModel().operations().get(0);
+        OperationStepDefinition step = operation.steps().get(0);
+        return new FactoryModel(representativeModel().resources(),
+                List.of(new OperationDefinition(operation.id(), operation.name(),
+                        List.of(new OperationStepDefinition(step.stepId(), name, step.eligibleResources(), step.duration())))),
+                representativeModel().products());
+    }
+
+    private static FactoryModel modelWithProductName(String name) {
+        return new FactoryModel(representativeModel().resources(), representativeModel().operations(),
+                List.of(new ProductDefinition(new ProductId(8), name, 42)));
+    }
+
+    private static FactoryModel modelWithResourceId(long id) {
+        OperationDefinition operation = representativeModel().operations().get(0);
+        return new FactoryModel(
+                List.of(new ResourceDefinition(new MachineId(id), "M|ill", 3, -0.0, -7),
+                        new ResourceDefinition(new MachineId(5), "Second", 1, null, 0)),
+                List.of(new OperationDefinition(operation.id(), operation.name(),
+                        List.of(new OperationStepDefinition(operation.steps().get(0).stepId(),
+                                operation.steps().get(0).name(), Set.of(new MachineId(id), new MachineId(5)),
+                                operation.steps().get(0).duration())))),
+                representativeModel().products());
+    }
+
+    private static FactoryModel modelWithCapacity(double capacity) {
+        return new FactoryModel(
+                List.of(new ResourceDefinition(new MachineId(-2), "M|ill", 3, capacity, -7),
+                        new ResourceDefinition(new MachineId(5), "Second", 1, null, 0)),
+                representativeModel().operations(), representativeModel().products());
+    }
+
+    @Test
+    void malformedUnicodeIsRejectedAtPublication() {
+        FactoryModel malformed = new FactoryModel(
+                List.of(new ResourceDefinition(new MachineId(1), "bad\uD800", 1, null, 0)),
+                List.of(),
+                List.of());
+
+        FactoryModelValidationException exception = assertThrows(
+                FactoryModelValidationException.class, () -> FactoryModelPublisher.publish(malformed));
+
+        assertEquals("resources[Machine(1)].name", exception.result().errors().get(0).field());
+    }
+
+    @Test
+    void durableFingerprintRemainsSeparateFromLegacyHash() {
+        FactoryModelVersion version = FactoryModelPublisher.publish(representativeModel());
+
+        assertNotEquals(version.contentHash(), version.fingerprint().digest());
+        assertEquals(new ModelFingerprint("factory-model", "v1", "sha256", version.fingerprint().digest()), version.fingerprint());
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelFingerprintV1Test.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/FactoryModelFingerprintV1Test.java
@@ -125,6 +125,75 @@ class FactoryModelFingerprintV1Test {
         assertNotEquals(original.fingerprint(), negativeZero.fingerprint());
     }
 
+        @Test
+        void negativeFiniteCapacityUsesItsExactBinary64Payload() {
+                FactoryModelVersion version = FactoryModelPublisher.publish(modelWithCapacity(-123.5));
+
+                assertNotEquals(
+                                FactoryModelPublisher.publish(modelWithCapacity(123.5)).fingerprint(),
+                                version.fingerprint());
+        }
+
+        @Test
+        void allTextFieldsRejectMalformedUnicodeAtPublication() {
+                assertMalformedResourceNameIsRejected();
+                assertMalformedOperationNameIsRejected();
+                assertMalformedStepNameIsRejected();
+                assertMalformedProductNameIsRejected();
+        }
+
+        @Test
+        void differentNaNPayloadsHaveTheSameFingerprint() {
+                assertEquals(
+                                FactoryModelPublisher.publish(modelWithCapacity(Double.longBitsToDouble(0x7ff0000000000001L))).fingerprint(),
+                                FactoryModelPublisher.publish(modelWithCapacity(Double.longBitsToDouble(0x7fffffffffffffffL))).fingerprint());
+        }
+
+        @Test
+        void legacyContentHashCompatibilityValueRemainsPinned() {
+                assertEquals(
+                        "3fbe9d181b8d982150d85a1ef422ad06142fc79a573ae43687fdedbe15cc569c",
+                        FactoryModelPublisher.publish(validLegacyFixture()).contentHash());
+        }
+
+        private static FactoryModel validLegacyFixture() {
+                return new FactoryModel(
+                                List.of(new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0)),
+                                List.of(new OperationDefinition(100, "Widget routing",
+                                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)))),
+                                List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
+        }
+
+        private static void assertMalformedResourceNameIsRejected() {
+                FactoryModel malformed = new FactoryModel(
+                                List.of(new ResourceDefinition(new MachineId(1), "bad\uD800", 1, null, 0)),
+                                representativeModel().operations(), representativeModel().products());
+                assertThrows(FactoryModelValidationException.class, () -> FactoryModelPublisher.publish(malformed));
+        }
+
+        private static void assertMalformedOperationNameIsRejected() {
+                OperationDefinition operation = representativeModel().operations().get(0);
+                FactoryModel malformed = new FactoryModel(representativeModel().resources(),
+                                List.of(new OperationDefinition(operation.id(), "bad\uD800", operation.steps())), representativeModel().products());
+                assertThrows(FactoryModelValidationException.class, () -> FactoryModelPublisher.publish(malformed));
+        }
+
+        private static void assertMalformedStepNameIsRejected() {
+                OperationDefinition operation = representativeModel().operations().get(0);
+                OperationStepDefinition step = operation.steps().get(0);
+                FactoryModel malformed = new FactoryModel(representativeModel().resources(),
+                                List.of(new OperationDefinition(operation.id(), operation.name(),
+                                                List.of(new OperationStepDefinition(step.stepId(), "bad\uDC00", step.eligibleResources(), step.duration())))),
+                                representativeModel().products());
+                assertThrows(FactoryModelValidationException.class, () -> FactoryModelPublisher.publish(malformed));
+        }
+
+        private static void assertMalformedProductNameIsRejected() {
+                FactoryModel malformed = new FactoryModel(representativeModel().resources(), representativeModel().operations(),
+                                List.of(new ProductDefinition(new ProductId(8), "bad\uDC00", 42)));
+                assertThrows(FactoryModelValidationException.class, () -> FactoryModelPublisher.publish(malformed));
+        }
+
     private static void assertDifferent(FactoryModelVersion original, FactoryModel changed) {
         assertNotEquals(original.fingerprint(), FactoryModelPublisher.publish(changed).fingerprint());
     }

--- a/product/types/src/main/java/com/arcogine/types/ModelFingerprint.java
+++ b/product/types/src/main/java/com/arcogine/types/ModelFingerprint.java
@@ -1,0 +1,31 @@
+package com.arcogine.types;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/** A durable semantic identity under a named and versioned fingerprint policy. */
+public record ModelFingerprint(String namespace, String policyVersion, String algorithm, String digest) {
+
+    private static final Pattern SHA256_DIGEST = Pattern.compile("[0-9a-f]{64}");
+
+    public ModelFingerprint {
+        requireText(namespace, "namespace");
+        requireText(policyVersion, "policyVersion");
+        requireText(algorithm, "algorithm");
+        requireText(digest, "digest");
+        if ("sha256".equals(algorithm) && !SHA256_DIGEST.matcher(digest).matches()) {
+            throw new IllegalArgumentException("sha256 digest must be 64 lowercase hexadecimal characters");
+        }
+    }
+
+    private static void requireText(String value, String field) {
+        if (Objects.requireNonNull(value, field).isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return namespace + ":" + policyVersion + ":" + algorithm + ":" + digest;
+    }
+}

--- a/product/types/src/test/java/com/arcogine/types/ModelFingerprintTest.java
+++ b/product/types/src/test/java/com/arcogine/types/ModelFingerprintTest.java
@@ -1,0 +1,28 @@
+package com.arcogine.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ModelFingerprintTest {
+
+    @Test
+    void rendersCanonicalExternalForm() {
+        ModelFingerprint fingerprint = new ModelFingerprint("factory-model", "v1", "sha256", "a".repeat(64));
+
+        assertEquals("factory-model:v1:sha256:" + "a".repeat(64), fingerprint.toString());
+    }
+
+    @Test
+    void rejectsBlankComponents() {
+        assertThrows(NullPointerException.class, () -> new ModelFingerprint(null, "v1", "sha256", "a".repeat(64)));
+        assertThrows(IllegalArgumentException.class, () -> new ModelFingerprint("factory-model", " ", "sha256", "a".repeat(64)));
+    }
+
+    @Test
+    void rejectsMalformedSha256Digest() {
+        assertThrows(IllegalArgumentException.class, () -> new ModelFingerprint("factory-model", "v1", "sha256", "A".repeat(64)));
+        assertThrows(IllegalArgumentException.class, () -> new ModelFingerprint("factory-model", "v1", "sha256", "a".repeat(63)));
+    }
+}


### PR DESCRIPTION
## In scope

- Typed `ModelFingerprint`
- `factory-model:v1` canonical binary encoding and SHA-256 fingerprint generation
- `FactoryModelVersion.fingerprint()`
- Unicode publication validation
- Literal golden compatibility vectors
- Legacy `contentHash()` coexistence

## Out of scope

- Controlled revision identity or lineage
- Revision persistence
- Semantic ChangeSets
- Conformance, findings, or evidence/provenance frameworks
- External workflow or Jira integration
- Approvals or deployments
- Challenge Readiness type sharing

## Validation

- Full Java test suite passed
- Full Gradle `check` passed
- Focused fingerprint and shared-type tests passed
- `git diff --check` passed

The durable semantic identity remains separate from historical revision identity.