### PR TITLE
docs: close Gate 2, require work decomposition, protect ADR history

### DIFF
--- a/.github/scripts/check-adr-immutability.py
+++ b/.github/scripts/check-adr-immutability.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Fail when an Accepted/Superseded ADR body is rewritten.
+
+Accepted ADRs are historical records. After acceptance, only the metadata
+needed to mark an ADR Superseded may change in place. Decision/body changes
+must be recorded in a new ADR that declares `Supersedes: ADR-NNNN`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+ADR_DIR = "docs/architecture/decisions"
+ADR_NAME = re.compile(r"^(\d{4})-[^/]+\.md$")
+STATUS = re.compile(r"^Status:\s*(\S+)\s*$", re.MULTILINE)
+SUPERSEDED_BY = re.compile(r"^Superseded by:\s*(ADR-\d{4})\s*$", re.MULTILINE)
+SUPERSEDES = re.compile(r"^Supersedes:\s*(ADR-\d{4})\s*$", re.MULTILINE)
+ALLOWED_MUTABLE_METADATA = re.compile(r"^(?:Status|Superseded by):.*(?:\n|$)", re.MULTILINE)
+
+
+def run_git(*args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout
+
+
+def status(text: str) -> str | None:
+    match = STATUS.search(text)
+    return match.group(1) if match else None
+
+
+def superseded_by(text: str) -> str | None:
+    match = SUPERSEDED_BY.search(text)
+    return match.group(1) if match else None
+
+
+def immutable_body(text: str) -> str:
+    return ALLOWED_MUTABLE_METADATA.sub("", text)
+
+
+def adr_id(path: str) -> str:
+    name = Path(path).name
+    match = ADR_NAME.match(name)
+    if not match:
+        raise ValueError(path)
+    return f"ADR-{match.group(1)}"
+
+
+def list_base_adrs(base_ref: str) -> list[str]:
+    output = run_git("ls-tree", "-r", "--name-only", base_ref, ADR_DIR)
+    paths: list[str] = []
+    for path in output.splitlines():
+        name = Path(path).name
+        match = ADR_NAME.match(name)
+        if match and match.group(1) != "0000":
+            paths.append(path)
+    return sorted(paths)
+
+
+def read_base(base_ref: str, path: str) -> str:
+    return run_git("show", f"{base_ref}:{path}")
+
+
+def read_current(path: str) -> str | None:
+    file_path = Path(path)
+    if not file_path.exists():
+        return None
+    return file_path.read_text(encoding="utf-8")
+
+
+def current_new_adrs(base_paths: set[str]) -> dict[str, str]:
+    found: dict[str, str] = {}
+    root = Path(ADR_DIR)
+    if not root.exists():
+        return found
+    for path in sorted(root.glob("[0-9][0-9][0-9][0-9]-*.md")):
+        relative = path.as_posix()
+        if relative in base_paths or path.name.startswith("0000-"):
+            continue
+        found[adr_id(relative)] = path.read_text(encoding="utf-8")
+    return found
+
+
+def validate(base_ref: str) -> list[str]:
+    errors: list[str] = []
+    base_paths = list_base_adrs(base_ref)
+    base_path_set = set(base_paths)
+    new_adrs = current_new_adrs(base_path_set)
+
+    for path in base_paths:
+        before = read_base(base_ref, path)
+        before_status = status(before)
+        if before_status not in {"Accepted", "Superseded"}:
+            continue
+
+        after = read_current(path)
+        if after is None:
+            errors.append(f"{path}: accepted ADRs may not be deleted or renamed")
+            continue
+
+        if immutable_body(before) != immutable_body(after):
+            errors.append(
+                f"{path}: {before_status} ADR body changed; create a superseding ADR instead"
+            )
+            continue
+
+        after_status = status(after)
+        if before_status == "Superseded":
+            if after_status != "Superseded":
+                errors.append(f"{path}: Superseded status is immutable")
+            if superseded_by(before) != superseded_by(after):
+                errors.append(f"{path}: existing Superseded-by metadata is immutable")
+            continue
+
+        # Accepted ADR: unchanged Accepted metadata is fine. The only allowed
+        # transition is Accepted -> Superseded with a matching new ADR.
+        if after_status == "Accepted":
+            if superseded_by(after) is not None:
+                errors.append(
+                    f"{path}: Accepted ADR cannot declare Superseded by without Status: Superseded"
+                )
+            continue
+
+        if after_status != "Superseded":
+            errors.append(
+                f"{path}: Accepted ADR status may only remain Accepted or become Superseded"
+            )
+            continue
+
+        target = superseded_by(after)
+        if target is None:
+            errors.append(f"{path}: Superseded ADR must declare `Superseded by: ADR-NNNN`")
+            continue
+
+        new_text = new_adrs.get(target)
+        if new_text is None:
+            errors.append(
+                f"{path}: {target} must be a new ADR in the same change when superseding {adr_id(path)}"
+            )
+            continue
+
+        match = SUPERSEDES.search(new_text)
+        expected = adr_id(path)
+        if not match or match.group(1) != expected:
+            errors.append(
+                f"{target}: must declare `Supersedes: {expected}` when replacing {path}"
+            )
+
+    return errors
+
+
+def base_from_ci_event() -> str | None:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    event_name = os.environ.get("GITHUB_EVENT_NAME")
+    if not event_path or not event_name:
+        return None
+
+    event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    if event_name == "pull_request":
+        return event.get("pull_request", {}).get("base", {}).get("sha")
+    if event_name == "push":
+        before = event.get("before")
+        if before and set(before) != {"0"}:
+            return before
+    return None
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-ref", help="Git ref/commit containing the historical ADRs")
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="derive the base commit from GITHUB_EVENT_PATH; skip non-diff CI events",
+    )
+    args = parser.parse_args(argv)
+
+    base_ref = args.base_ref
+    if args.ci:
+        base_ref = base_from_ci_event()
+        if base_ref is None:
+            print("ADR immutability: no comparable CI base for this event; skipped")
+            return 0
+
+    if not base_ref:
+        parser.error("provide --base-ref or --ci")
+
+    errors = validate(base_ref)
+    if errors:
+        print("ADR immutability check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"ADR immutability check passed against {base_ref}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check-adr-immutability.py
+++ b/.github/scripts/check-adr-immutability.py
@@ -3,7 +3,7 @@
 
 Accepted ADRs are historical records. After acceptance, only the metadata
 needed to mark an ADR Superseded may change in place. Decision/body changes
-must be recorded in a new ADR that declares `Supersedes: ADR-NNNN`.
+must be recorded in a new Accepted ADR that declares `Supersedes: ADR-NNNN`.
 """
 
 from __future__ import annotations
@@ -125,7 +125,7 @@ def validate(base_ref: str) -> list[str]:
             continue
 
         # Accepted ADR: unchanged Accepted metadata is fine. The only allowed
-        # transition is Accepted -> Superseded with a matching new ADR.
+        # transition is Accepted -> Superseded with a matching new Accepted ADR.
         if after_status == "Accepted":
             if superseded_by(after) is not None:
                 errors.append(
@@ -148,6 +148,12 @@ def validate(base_ref: str) -> list[str]:
         if new_text is None:
             errors.append(
                 f"{path}: {target} must be a new ADR in the same change when superseding {adr_id(path)}"
+            )
+            continue
+
+        if status(new_text) != "Accepted":
+            errors.append(
+                f"{target}: superseding ADR must be `Status: Accepted` before {adr_id(path)} can become Superseded"
             )
             continue
 

--- a/.github/scripts/check-adr-immutability.test.py
+++ b/.github/scripts/check-adr-immutability.test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+SCRIPT = Path(__file__).with_name("check-adr-immutability.py").resolve()
+
+
+def run(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=cwd,
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def write(cwd: Path, name: str, text: str) -> None:
+    path = cwd / "docs/architecture/decisions" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def git_init(cwd: Path) -> None:
+    run(cwd, "git", "init", "-q")
+    run(cwd, "git", "config", "user.email", "ci@example.invalid")
+    run(cwd, "git", "config", "user.name", "CI")
+
+
+def commit(cwd: Path, message: str) -> str:
+    run(cwd, "git", "add", ".")
+    run(cwd, "git", "commit", "-qm", message)
+    return run(cwd, "git", "rev-parse", "HEAD").stdout.strip()
+
+
+def check_case(name: str, mutate, expected_ok: bool) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        git_init(repo)
+        write(
+            repo,
+            "0001-example.md",
+            "# ADR-0001: Example\n\nStatus: Accepted\nDate: 2026-01-01\n\n## Decision\n\nKeep history.\n",
+        )
+        write(
+            repo,
+            "0002-proposed.md",
+            "# ADR-0002: Proposed\n\nStatus: Proposed\n\n## Decision\n\nStill open.\n",
+        )
+        base = commit(repo, "base")
+        mutate(repo)
+
+        result = run(
+            repo,
+            "python3",
+            str(SCRIPT),
+            "--base-ref",
+            base,
+            check=False,
+        )
+        ok = result.returncode == 0
+        if ok != expected_ok:
+            raise AssertionError(
+                f"{name}: expected ok={expected_ok}, got {ok}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+        print(f"PASS: {name}")
+
+
+def main() -> None:
+    check_case("unchanged accepted ADR", lambda repo: None, True)
+
+    def edit_body(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        path.write_text(path.read_text().replace("Keep history.", "Rewrite history."))
+
+    check_case("accepted ADR body edit is rejected", edit_body, False)
+
+    def delete_accepted(repo: Path) -> None:
+        (repo / "docs/architecture/decisions/0001-example.md").unlink()
+
+    check_case("accepted ADR deletion is rejected", delete_accepted, False)
+
+    def edit_proposed(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0002-proposed.md"
+        path.write_text(path.read_text().replace("Still open.", "Still changing."))
+
+    check_case("proposed ADR may change", edit_proposed, True)
+
+    def supersede_without_new(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        text = path.read_text().replace(
+            "Status: Accepted\n", "Status: Superseded\nSuperseded by: ADR-0003\n"
+        )
+        path.write_text(text)
+
+    check_case("supersession requires matching new ADR", supersede_without_new, False)
+
+    def valid_supersession(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        text = path.read_text().replace(
+            "Status: Accepted\n", "Status: Superseded\nSuperseded by: ADR-0003\n"
+        )
+        path.write_text(text)
+        write(
+            repo,
+            "0003-replacement.md",
+            "# ADR-0003: Replacement\n\nStatus: Accepted\nSupersedes: ADR-0001\n\n## Decision\n\nNew decision.\n",
+        )
+
+    check_case("metadata-only supersession with matching new ADR is allowed", valid_supersession, True)
+
+    print("All ADR immutability tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/check-adr-immutability.test.py
+++ b/.github/scripts/check-adr-immutability.test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-import shutil
 import subprocess
 import tempfile
 
@@ -101,6 +100,20 @@ def main() -> None:
 
     check_case("supersession requires matching new ADR", supersede_without_new, False)
 
+    def supersede_with_proposed(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        text = path.read_text().replace(
+            "Status: Accepted\n", "Status: Superseded\nSuperseded by: ADR-0003\n"
+        )
+        path.write_text(text)
+        write(
+            repo,
+            "0003-replacement.md",
+            "# ADR-0003: Replacement\n\nStatus: Proposed\nSupersedes: ADR-0001\n\n## Decision\n\nCandidate decision.\n",
+        )
+
+    check_case("proposed ADR cannot supersede accepted ADR", supersede_with_proposed, False)
+
     def valid_supersession(repo: Path) -> None:
         path = repo / "docs/architecture/decisions/0001-example.md"
         text = path.read_text().replace(
@@ -113,7 +126,7 @@ def main() -> None:
             "# ADR-0003: Replacement\n\nStatus: Accepted\nSupersedes: ADR-0001\n\n## Decision\n\nNew decision.\n",
         )
 
-    check_case("metadata-only supersession with matching new ADR is allowed", valid_supersession, True)
+    check_case("metadata-only supersession with matching accepted ADR is allowed", valid_supersession, True)
 
     print("All ADR immutability tests passed.")
 

--- a/.github/scripts/classify-changes.test.sh
+++ b/.github/scripts/classify-changes.test.sh
@@ -5,9 +5,9 @@
 # loudly here instead of silently letting a real change skip its checks.
 #
 # The classify job is also the always-running dependency of the repository's
-# single required `gate` status, so repository-wide documentation-link checks
-# are invoked here as part of the same fail-closed path rather than through a
-# separate, non-required workflow.
+# single required `gate` status, so repository-wide documentation-link and ADR
+# history checks are invoked here as part of the same fail-closed path rather
+# than through separate, non-required workflows.
 set -euo pipefail
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -85,3 +85,5 @@ echo "All classification tests passed."
 
 python3 "$dir/check-markdown-links.test.py"
 python3 "$dir/check-markdown-links.py" "$repo"
+python3 "$dir/check-adr-immutability.test.py"
+python3 "$dir/check-adr-immutability.py" --ci

--- a/docs/architecture/decisions/0005-gate-2-explicit-eligibility-dispatch-policy.md
+++ b/docs/architecture/decisions/0005-gate-2-explicit-eligibility-dispatch-policy.md
@@ -1,6 +1,7 @@
 # ADR-0005: Gate 2 explicit-eligibility dispatch policy
 
-Status: Accepted
+Status: Superseded
+Superseded by: ADR-0009
 Date: 2026-08-26
 
 ## Context
@@ -13,7 +14,7 @@ A repository-grounded audit (see the Gate 2 session preceding this ADR) confirme
 
 ## Decision
 
-Gate 2 is classified **A: preserve existing model eligibility into runtime, plus a deterministic selector** — not a new capability abstraction (classification C) and not a canonical-model extension (classification B), since the model already carries what is needed.
+Gate 2's first slice is classified **A: preserve existing model eligibility into runtime, plus a deterministic selector** — not a new capability abstraction (classification C) and not a canonical-model extension (classification B), since the model already carries what is needed.
 
 Concretely:
 
@@ -36,11 +37,9 @@ Concretely:
 
 Model-side eligibility (`OperationStepDefinition.eligibleResources`), runtime operational status (`MachineState`), and runtime queue state (`Machine`'s per-machine `ArrayDeque`) remain three distinct types, matching Gate 2's acceptance criterion 7; this decision does not merge them.
 
-Gate 2's parallel-capacity requirement applies when the runtime has multiple **independently dispatchable** pieces of work. `Gate2MultiResourceDispatchAcceptanceTest` proves that two independent orders/jobs can occupy two equivalent eligible machines concurrently, and that adding the second eligible resource changes queueing behavior under that workload. The dispatcher is responsible for selecting among eligible resources for work that already exists; it does not define how one accepted production order is decomposed into multiple concurrent execution units.
+Explicitly out of scope for this slice: capability taxonomies/tags, resource pools or work centers as first-class types, projected-completion-time or other load-aware ranking beyond queue depth, multiple `Job`s per `Order`, and any failure/maintenance modeling for offline machines beyond simple exclusion from new dispatch and reconsideration of already-waiting work.
 
-A single quantity-scaled order still maps to one `Job`, whose repeated routing advances one step at a time. Allowing that one order to exploit several equivalent machines concurrently would require a separate work-decomposition decision: for example, independently dispatchable lots, batches, or execution units plus aggregate progress/completion semantics. That capability is explicitly **not part of Gate 2** and is deferred until a supported consumer requires one accepted order to expose multiple independently dispatchable execution units.
-
-Explicitly out of scope for Gate 2: capability taxonomies/tags, resource pools or work centers as first-class types, projected-completion-time or other load-aware ranking beyond queue depth, multiple `Job`s per `Order`, intra-order execution decomposition, and any failure/maintenance modeling for offline machines beyond simple exclusion from new dispatch and reconsideration of already-waiting work.
+This slice proves parallel-capacity benefit for independent orders/jobs, not for a single quantity-scaled order: `submitOrder` still creates exactly one `Job` per order, and that job's repeated routing still advances one step at a time. A fixed-contract workload expressed as one large-quantity order therefore cannot yet exploit a second eligible machine's capacity from within that one job -- doing so would require intra-job execution parallelism or multiple execution objects per order, both excluded above. See the planning document's §6.4 criteria 3 and 5 for the acceptance-criteria implication.
 
 ## Alternatives considered
 
@@ -60,20 +59,14 @@ Rejected for this slice: it requires estimating in-flight completion, which is s
 
 Rejected: eligibility is unordered and must not admit duplicate entries; a `Set` matches `OperationStepDefinition.eligibleResources`'s own shape and avoids inventing meaning for machine order that dispatch does not use (the deterministic order emerges from the selection policy itself, not from insertion order).
 
-### Treat intra-order parallelism as Gate 2 closure work
-
-Rejected: dispatch and work decomposition answer different questions. Gate 2 selects which eligible resource executes an independently dispatchable unit of work. Splitting one accepted order into several concurrently executable units introduces new production semantics around divisibility, lot/batch identity, precedence, partial progress, completion aggregation, and event correlation. Those semantics should be introduced only when a concrete workload requires them, not as an accidental extension of the resource selector.
-
 ## Consequences
 
 - A single operation step can now be published with, and dispatched against, more than one eligible machine, without any change to `FactoryModel`, `OperationStepDefinition`, `ResourceDefinition`, or `MachineId`.
 - Removing or disabling one eligible instance no longer requires changing the product/operation definition — dispatch simply stops selecting an offline machine for new work among a real multi-candidate eligible set, and work already waiting is not stranded on it: the whole eligible set is reconsidered as machines free up or come online.
 - `RoutingStep.machineId()` no longer exists; callers read `eligibleMachines()` and, where they need one concrete choice, call `FactoryHandler`'s private `selectMachine`. External consumers (`interfaces/api`, `interfaces/cli`) that construct single-machine `RoutingStep`s are unaffected by the added convenience constructor.
 - `TaskStart`/`TaskEnd` event payloads continue to carry the one machine actually assigned; no externally visible event semantics change.
-- Gate 2 is complete for deterministic dispatch across equivalent eligible capacity when sufficient independently dispatchable work exists.
-- Intra-order parallelism remains a deferred execution-decomposition capability. If activated, it should define lot/batch/execution-unit identity and aggregate progress/completion explicitly rather than silently changing Gate 2 dispatch semantics.
 - This tie-break policy is now a recorded architectural decision rather than planning-document prose; a future slice that adds load-aware ranking (e.g. projected completion time) should update or supersede this ADR rather than silently reinterpreting the policy.
 
 ## Charter alignment
 
-This decision keeps the **published model owns eligibility / runtime owns dispatch** boundary established by ADR-0003 intact: `FactoryModel` still owns capability/eligibility facts, and `FactoryHandler` still owns the run-time decision of which eligible instance actually executes a given independently dispatchable unit of work.
+This decision keeps the **published model owns eligibility / runtime owns dispatch** boundary established by ADR-0003 intact: `FactoryModel` still owns capability/eligibility facts, and `FactoryHandler` still owns the run-time decision of which eligible instance actually executes a given unit of work.

--- a/docs/architecture/decisions/0005-gate-2-explicit-eligibility-dispatch-policy.md
+++ b/docs/architecture/decisions/0005-gate-2-explicit-eligibility-dispatch-policy.md
@@ -13,7 +13,7 @@ A repository-grounded audit (see the Gate 2 session preceding this ADR) confirme
 
 ## Decision
 
-Gate 2's first slice is classified **A: preserve existing model eligibility into runtime, plus a deterministic selector** — not a new capability abstraction (classification C) and not a canonical-model extension (classification B), since the model already carries what is needed.
+Gate 2 is classified **A: preserve existing model eligibility into runtime, plus a deterministic selector** — not a new capability abstraction (classification C) and not a canonical-model extension (classification B), since the model already carries what is needed.
 
 Concretely:
 
@@ -36,9 +36,11 @@ Concretely:
 
 Model-side eligibility (`OperationStepDefinition.eligibleResources`), runtime operational status (`MachineState`), and runtime queue state (`Machine`'s per-machine `ArrayDeque`) remain three distinct types, matching Gate 2's acceptance criterion 7; this decision does not merge them.
 
-Explicitly out of scope for this slice: capability taxonomies/tags, resource pools or work centers as first-class types, projected-completion-time or other load-aware ranking beyond queue depth, multiple `Job`s per `Order`, and any failure/maintenance modeling for offline machines beyond simple exclusion from new dispatch and reconsideration of already-waiting work.
+Gate 2's parallel-capacity requirement applies when the runtime has multiple **independently dispatchable** pieces of work. `Gate2MultiResourceDispatchAcceptanceTest` proves that two independent orders/jobs can occupy two equivalent eligible machines concurrently, and that adding the second eligible resource changes queueing behavior under that workload. The dispatcher is responsible for selecting among eligible resources for work that already exists; it does not define how one accepted production order is decomposed into multiple concurrent execution units.
 
-This slice proves parallel-capacity benefit for independent orders/jobs, not for a single quantity-scaled order: `submitOrder` still creates exactly one `Job` per order, and that job's repeated routing still advances one step at a time. A fixed-contract workload expressed as one large-quantity order therefore cannot yet exploit a second eligible machine's capacity from within that one job -- doing so would require intra-job execution parallelism or multiple execution objects per order, both excluded above. See the planning document's §6.4 criteria 3 and 5 for the acceptance-criteria implication.
+A single quantity-scaled order still maps to one `Job`, whose repeated routing advances one step at a time. Allowing that one order to exploit several equivalent machines concurrently would require a separate work-decomposition decision: for example, independently dispatchable lots, batches, or execution units plus aggregate progress/completion semantics. That capability is explicitly **not part of Gate 2** and is deferred until a supported consumer requires one accepted order to expose multiple independently dispatchable execution units.
+
+Explicitly out of scope for Gate 2: capability taxonomies/tags, resource pools or work centers as first-class types, projected-completion-time or other load-aware ranking beyond queue depth, multiple `Job`s per `Order`, intra-order execution decomposition, and any failure/maintenance modeling for offline machines beyond simple exclusion from new dispatch and reconsideration of already-waiting work.
 
 ## Alternatives considered
 
@@ -58,14 +60,20 @@ Rejected for this slice: it requires estimating in-flight completion, which is s
 
 Rejected: eligibility is unordered and must not admit duplicate entries; a `Set` matches `OperationStepDefinition.eligibleResources`'s own shape and avoids inventing meaning for machine order that dispatch does not use (the deterministic order emerges from the selection policy itself, not from insertion order).
 
+### Treat intra-order parallelism as Gate 2 closure work
+
+Rejected: dispatch and work decomposition answer different questions. Gate 2 selects which eligible resource executes an independently dispatchable unit of work. Splitting one accepted order into several concurrently executable units introduces new production semantics around divisibility, lot/batch identity, precedence, partial progress, completion aggregation, and event correlation. Those semantics should be introduced only when a concrete workload requires them, not as an accidental extension of the resource selector.
+
 ## Consequences
 
 - A single operation step can now be published with, and dispatched against, more than one eligible machine, without any change to `FactoryModel`, `OperationStepDefinition`, `ResourceDefinition`, or `MachineId`.
 - Removing or disabling one eligible instance no longer requires changing the product/operation definition — dispatch simply stops selecting an offline machine for new work among a real multi-candidate eligible set, and work already waiting is not stranded on it: the whole eligible set is reconsidered as machines free up or come online.
 - `RoutingStep.machineId()` no longer exists; callers read `eligibleMachines()` and, where they need one concrete choice, call `FactoryHandler`'s private `selectMachine`. External consumers (`interfaces/api`, `interfaces/cli`) that construct single-machine `RoutingStep`s are unaffected by the added convenience constructor.
 - `TaskStart`/`TaskEnd` event payloads continue to carry the one machine actually assigned; no externally visible event semantics change.
+- Gate 2 is complete for deterministic dispatch across equivalent eligible capacity when sufficient independently dispatchable work exists.
+- Intra-order parallelism remains a deferred execution-decomposition capability. If activated, it should define lot/batch/execution-unit identity and aggregate progress/completion explicitly rather than silently changing Gate 2 dispatch semantics.
 - This tie-break policy is now a recorded architectural decision rather than planning-document prose; a future slice that adds load-aware ranking (e.g. projected completion time) should update or supersede this ADR rather than silently reinterpreting the policy.
 
 ## Charter alignment
 
-This decision keeps the **published model owns eligibility / runtime owns dispatch** boundary established by ADR-0003 intact: `FactoryModel` still owns capability/eligibility facts, and `FactoryHandler` still owns the run-time decision of which eligible instance actually executes a given unit of work.
+This decision keeps the **published model owns eligibility / runtime owns dispatch** boundary established by ADR-0003 intact: `FactoryModel` still owns capability/eligibility facts, and `FactoryHandler` still owns the run-time decision of which eligible instance actually executes a given independently dispatchable unit of work.

--- a/docs/architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md
+++ b/docs/architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md
@@ -1,0 +1,136 @@
+# ADR-0009: Gate 2 closure and work-decomposition boundary
+
+Status: Accepted
+Date: 2026-08-28
+Supersedes: ADR-0005
+
+## Context
+
+ADR-0005 established Arcogine's deterministic explicit-eligibility dispatch policy and correctly implemented the model/runtime boundary needed for equivalent eligible resources. Its first-slice scope also left Gate 2 acceptance criteria 3 and 5 open for a different question: whether one quantity-scaled production order must itself expose several concurrently dispatchable execution units.
+
+That wording conflated two distinct production concerns:
+
+```text
+work decomposition
+    what independently dispatchable execution units exist?
+
+resource dispatch
+    which eligible resource executes one such unit?
+```
+
+The implemented Gate 2 selector can only choose among resources for work that already exists. It cannot decide that one accepted order should become several lots, batches, jobs, or execution units without introducing additional production semantics around divisibility, identity, precedence, progress, and aggregate completion.
+
+The repository now also has a concrete consumer that makes the decomposition question non-hypothetical. The factory-design game reference challenge defines a fixed contract to produce 20 units of Product A and expects a second cutter to be capable of reducing CUT queueing/completion time. Challenge workload identity is game-owned, but the game is explicitly prohibited from recreating Arcogine workload decomposition, queueing, or dispatch semantics. With today's runtime shape, one `submitWorkload(..., 20, ...)` creates one accepted `Order` and one sequential `Job`, so the reference challenge cannot yet obtain the intended parallel-capacity trade-off from a single fixed production contract.
+
+ADR-0005 is therefore preserved as historical record and superseded by this decision. Its actual deterministic selector and pending-work behavior remain valid; this ADR changes the scope/closure interpretation and records the newly activated follow-up capability.
+
+## Decision
+
+### 1. Gate 2 is complete at the dispatch boundary
+
+Gate 2 answers:
+
+> Given an independently dispatchable unit of work and a published set of eligible resource instances, which resource executes it deterministically?
+
+The existing implementation satisfies that contract:
+
+- published multi-resource eligibility survives model validation and runtime assembly;
+- multiple equivalent eligible resources can execute the same operation;
+- independently dispatchable jobs can use equivalent resources concurrently;
+- equal candidates resolve through the accepted deterministic ranking;
+- offline/recovered resources are handled without rewriting product/operation definitions;
+- eligibility, operational status, and queue state remain distinct.
+
+Accordingly, Gate 2 criteria 3 and 5 are satisfied by appropriate workloads containing sufficient independently dispatchable work. A requirement to split one accepted production order into several concurrent units is not part of resource selection itself.
+
+The dispatch policy from ADR-0005 remains unchanged:
+
+```text
+eligible
+    -> online
+    -> able to accept work immediately
+    -> shallowest queue
+    -> lowest MachineId
+```
+
+The `pendingMultiEligible` cross-machine waiting-work semantics from ADR-0005 also remain unchanged.
+
+### 2. Intra-order parallelism is a separate Engine work-decomposition capability
+
+One accepted order may only use several equivalent resources concurrently if Arcogine first defines independently dispatchable execution units within that order.
+
+That capability must explicitly decide at least:
+
+- whether and where order quantity is divisible;
+- execution-unit / lot / batch identity and lifecycle;
+- whether one Order still maps to one Job or to a higher-level execution aggregate;
+- operation precedence when units of one order progress independently;
+- partial progress and aggregate completion semantics;
+- event/observation correlation across Order, Job, and any new execution-unit identity;
+- deterministic interaction with setup, material, transfer, or other constraints when those capabilities exist.
+
+The implementation must not assume that one quantity unit automatically equals one execution object.
+
+### 3. The current reference challenge activates this capability
+
+The factory-design game is already a concrete supported-consumer requirement: its fixed 20-unit contract and second-cutter strategy require the engine to demonstrate that additional compatible bottleneck capacity can improve execution of that same fixed contract.
+
+Therefore work decomposition is no longer merely a dormant future option. It is a **required pre-playable Engine capability for the current reference challenge**.
+
+The game/challenge layer remains responsible only for saying what workload must be produced. It must not translate one challenge workload into several Arcogine Orders merely to manufacture parallelism unless a future, separately accepted contract explicitly assigns that mapping to the game. Arcogine owns the production execution decomposition needed to run one accepted production requirement correctly.
+
+### 4. Work decomposition precedes Gate 4 closure for the current vertical slice
+
+For the currently activated reference challenge, the preferred critical path is:
+
+```text
+Gate 1  explicit workload/execution baseline       COMPLETE
+Gate 2  deterministic resource dispatch           COMPLETE
+Gate 3  consumer-neutral session control           COMPLETE
+        ↓
+W1      intra-order work decomposition
+        ↓
+Gate 4  stable observations and event envelopes
+        ↓
+Gate 5  spatial runtime consequences
+        ↓
+Playable/runtime-integrated game
+```
+
+W1 is placed before Gate 4 because it is expected to introduce or refine runtime execution identities and correlation semantics. Gate 4 should stabilize externally visible identifiers, observations, and event envelopes after those production entities are known rather than freeze a public contract that immediately needs structural revision.
+
+This ordering is specific to the current reference consumer. Gate 2 itself remains complete independently of W1.
+
+## Alternatives considered
+
+### Keep single-order parallelism inside Gate 2
+
+Rejected. It makes a resource-selector gate responsible for inventing work units and obscures the fact that decomposition is a larger production-semantic decision.
+
+### Represent the fixed game workload as multiple independent Arcogine Orders
+
+Rejected for the current reference challenge. The challenge defines one fixed production requirement, and the game is not allowed to recreate Arcogine production execution semantics. Splitting that requirement into several Orders solely to make capacity scale would move an authoritative production decision into the consumer layer and change the meaning of `Order` without a separate accepted contract.
+
+A future consumer may legitimately submit multiple independent Orders when its source workload genuinely contains multiple independent orders; that remains fully supported and is the correct Gate 2 proving workload.
+
+### Delay work decomposition until after Gate 4
+
+Rejected for the current vertical slice. Because decomposition is now a known pre-playable requirement and is likely to introduce new externally observable execution identities, stabilizing Gate 4 first would create avoidable contract churn.
+
+### Introduce a generalized lot/batch/scheduling framework now
+
+Rejected. W1 should implement only the minimum decomposition semantics proven necessary by the reference challenge. Material lots, transfer batches, setup optimization, inventory allocation, and generalized scheduling remain separate unless the implementation audit proves they are inseparable.
+
+## Consequences
+
+- ADR-0005 remains historical evidence of the original first-slice decision and implementation scope.
+- Gate 2 can be marked complete without pretending that intra-order parallelism already exists.
+- The current factory-design reference challenge now has an explicit upstream Engine dependency instead of silently assuming one quantity-scaled Job can use parallel capacity.
+- Work decomposition becomes the next semantic Engine prerequisite before Gate 4 closure for the playable vertical slice.
+- Gate 4 must account for whatever stable execution-unit identities/correlation W1 establishes.
+- No runtime behavior changes merely by accepting this ADR; W1 still requires a separate repository-grounded design/implementation slice.
+- The accepted Gate 2 selection ranking and queue-recovery behavior do not change.
+
+## Charter alignment
+
+This decision preserves Arcogine's ownership of executable production semantics. The game states the fixed production requirement and evaluates outcomes; Arcogine defines how accepted production intent becomes executable work and how that work is dispatched. The consumer does not invent a parallel workload representation merely to obtain a desired game result.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -45,8 +45,8 @@ Each ADR has one of the following statuses:
 - **Accepted** — the decision has been made and represents the intended
   design.
 - **Rejected** — the proposal was explicitly considered and not adopted.
-- **Superseded** — a later ADR replaced this decision. The original record is
-  preserved as-is and links to the ADR that replaced it.
+- **Superseded** — a later Accepted ADR replaced this decision. The original
+  record is preserved as-is and links to the ADR that replaced it.
 
 A Proposed ADR is a useful way to structure an open design discussion, but
 its existence never implies acceptance — readers should be able to tell at a
@@ -72,9 +72,14 @@ decision/body text is not edited in place, even to make the old decision read
 more like the architecture that exists later. If the decision changes:
 
 1. write a new ADR describing the new decision;
-2. reference the old ADR from the new one (`Supersedes: ADR-NNNN`);
-3. change only the old ADR's supersession metadata: set `Status: Superseded`
+2. the replacement ADR must itself be `Status: Accepted` before it can
+   supersede an existing Accepted ADR;
+3. reference the old ADR from the new one (`Supersedes: ADR-NNNN`);
+4. change only the old ADR's supersession metadata: set `Status: Superseded`
    and add `Superseded by: ADR-NNNN`.
+
+A Proposed replacement does not supersede established architecture. Keep the
+old ADR Accepted until the replacement decision is actually Accepted.
 
 Typos or explanatory improvements discovered after acceptance should normally
 be corrected in current-state documentation, not by rewriting the accepted
@@ -93,11 +98,13 @@ For every ADR that was `Accepted` or `Superseded` on the PR base commit, CI:
 - rejects any change to the ADR body/decision text;
 - permits an `Accepted` ADR only to remain `Accepted` or transition to
   `Superseded`;
-- permits that transition only when the same change adds a new ADR whose
-  `Supersedes: ADR-NNNN` metadata points back to the old record;
+- permits that transition only when the same change adds a new **Accepted**
+  ADR whose `Supersedes: ADR-NNNN` metadata points back to the old record;
+- rejects a Proposed replacement as insufficient to supersede established
+  architecture;
 - keeps an already `Superseded` ADR fully immutable, including its
   supersession target.
 
 `Proposed` ADRs remain editable until accepted. The guard is intentionally
-stricter than human review: changing an accepted decision requires a new ADR,
-not an exception flag or reviewer override.
+stricter than human review: changing an accepted decision requires a new
+Accepted ADR, not an exception flag or reviewer override.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -56,7 +56,7 @@ glance which parts are established fact versus open question or proposal.
 
 1. Copy [`0000-template.md`](0000-template.md) to `NNNN-short-title.md`,
    where `NNNN` is the next unused four-digit number (check the existing
-   files in this directory).
+   files in this directory and concurrent ADR work before allocating it).
 2. Fill in the sections that apply; don't pad a section with content just to
    fill it in.
 3. Set `Status: Proposed` (or `Accepted` if the decision is already made and
@@ -67,12 +67,37 @@ Numbers are never reused, even if an ADR is later rejected or superseded.
 
 ## Changing a decision
 
-Accepted ADRs are not rewritten to make a past decision look different from
-what was actually decided. Minor corrections or clarifications that don't
-change the decision itself may be edited in place. If the decision itself
-changes:
+Accepted ADRs are immutable historical records. Once an ADR is Accepted, its
+decision/body text is not edited in place, even to make the old decision read
+more like the architecture that exists later. If the decision changes:
 
 1. write a new ADR describing the new decision;
 2. reference the old ADR from the new one (`Supersedes: ADR-NNNN`);
-3. mark the old ADR's status `Superseded` and link forward to the new one
-   (`Superseded by: ADR-NNNN`).
+3. change only the old ADR's supersession metadata: set `Status: Superseded`
+   and add `Superseded by: ADR-NNNN`.
+
+Typos or explanatory improvements discovered after acceptance should normally
+be corrected in current-state documentation, not by rewriting the accepted
+ADR. If an error in the ADR itself is materially misleading, supersede it so
+the historical record and the correction are both explicit.
+
+### CI enforcement
+
+The repository enforces this rule through
+`.github/scripts/check-adr-immutability.py`, which runs in the always-required
+`Classify changes` / `CI / gate` path.
+
+For every ADR that was `Accepted` or `Superseded` on the PR base commit, CI:
+
+- rejects deletion or rename of the ADR file;
+- rejects any change to the ADR body/decision text;
+- permits an `Accepted` ADR only to remain `Accepted` or transition to
+  `Superseded`;
+- permits that transition only when the same change adds a new ADR whose
+  `Supersedes: ADR-NNNN` metadata points back to the old record;
+- keeps an already `Superseded` ADR fully immutable, including its
+  supersession target.
+
+`Proposed` ADRs remain editable until accepted. The guard is intentionally
+stricter than human review: changing an accepted decision requires a new ADR,
+not an exception flag or reviewer override.

--- a/docs/planning/factory-design-game-consumer.md
+++ b/docs/planning/factory-design-game-consumer.md
@@ -3,8 +3,8 @@
 > **Status:** Proposed  
 > **Scope:** A separate, single-player factory-design game consuming Arcogine as its production engine  
 > **Authority:** Planning only; this document does not describe current capability or accepted architecture  
-> **Dependency:** Headless [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md) may progress independently; playable/runtime-integrated game implementation begins only after the model-seam entry gate (§1.1 of [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)) and Gates 1-5 in that same document are satisfied  
-> **Related:** [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md), [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md), [Factory Design Architecture](../architecture/factory-design.md), [Factory Design Capability](factory-design-capability.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md)
+> **Dependency:** Headless [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md) may progress independently; playable/runtime-integrated game implementation begins only after the model-seam entry gate (§1.1 of [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)), Engine Gates 1-5, and the reference-challenge work-decomposition prerequisite recorded by [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md) are satisfied  
+> **Related:** [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md), [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md), [Factory Design Architecture](../architecture/factory-design.md), [Factory Design Capability](factory-design-capability.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md)
 
 ## 1. Initiative summary
 
@@ -49,6 +49,7 @@ The game may own an editor-specific draft, but that draft is not the authoritati
 [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) owns runtime concerns:
 
 - production orders, quantity semantics, and work execution;
+- work decomposition when one accepted production requirement must expose multiple independently dispatchable execution units;
 - capability/eligibility-based deterministic dispatch;
 - consumer-neutral session and bounded advancement;
 - supported observations and externally visible runtime events;
@@ -79,12 +80,13 @@ Before playable or runtime-integrated game implementation starts, Arcogine must 
 
 1. The model-seam entry gate (§1.1 of Factory Simulation Engine Readiness): the behavior-preserving canonical-model seam, narrower than the full D1-D4 acceptance criteria.
 2. Gate 1: explicit production workload and separate execution semantics.
-3. Gate 2: capability/eligibility-based deterministic resource dispatch.
+3. Gate 2: capability/eligibility-based deterministic resource dispatch for independently dispatchable work.
 4. Gate 3: consumer-neutral simulation session with bounded advancement.
-5. Gate 4: stable observations and ordered external runtime events.
-6. Gate 5: deterministic spatial runtime consequences.
+5. The reference-challenge work-decomposition prerequisite from ADR-0009: one fixed accepted production requirement can expose multiple independently dispatchable execution units so equivalent bottleneck capacity can affect that same contract.
+6. Gate 4: stable observations and ordered external runtime events, including the execution identities/correlation introduced by work decomposition.
+7. Gate 5: deterministic spatial runtime consequences.
 
-The headless capacity and layout benchmarks must pass before a game UI is used as evidence for those capabilities.
+The headless dispatch-capacity, fixed-contract work-decomposition, and layout benchmarks must pass before a game UI is used as evidence for those capabilities. Gate 2 remains complete independently of work decomposition; the extra prerequisite exists because the current reference challenge specifically requires both semantics together.
 
 ## 3. Charter and semantic alignment
 
@@ -117,7 +119,7 @@ The demonstrator is a factory-layout challenge in which the player receives a fi
 | G-01 | Bounded challenge | One level defines a floor, starting budget, fixed contract, deadline, and unambiguous success/failure condition. |
 | G-02 | Factory editor | The player can place, move, rotate, and remove resource instances in a game-owned draft. Out-of-bounds/overlap problems are shown clearly. |
 | G-03 | Small equipment catalogue | At least three resource types support three sequential operations. Multiple instances of a type can be installed. |
-| G-04 | Capacity matters | Adding compatible capacity at a bottleneck can reduce queueing or completion time. |
+| G-04 | Capacity matters | Adding compatible capacity at a bottleneck can reduce queueing or completion time for the fixed production contract. |
 | G-05 | Distance matters | Transfer time depends deterministically on semantic layout. |
 | G-06 | Design-run loop | The player can validate/publish a draft, start a run, pause, step, reset, and return to design mode. Structural edits are between runs initially. |
 | G-07 | Legible operation | The player can see resource state, queues, active work, transfers, contract progress, and core KPIs. |
@@ -188,13 +190,13 @@ Live placement/movement/removal during active work is not required for the verti
 | Shared executability validation | Arcogine design/model boundary |
 | Published model identity/version/provenance | Arcogine design/model boundary |
 | Products, operations, resource definitions/instances, semantic layout | Arcogine canonical model |
-| Orders, work items, queues, dispatch, processing, transfers in progress | Arcogine runtime |
+| Orders, work decomposition/execution units, queues, dispatch, processing, transfers in progress | Arcogine runtime |
 | Simulation clock, event ordering, deterministic random behavior | Arcogine runtime |
 | Runtime observations and KPIs | Arcogine runtime |
 | Model/command/event/observation compatibility contracts | Arcogine |
 | Combined save file | Game wrapper around Arcogine checkpoint plus game-owned state |
 
-Arcogine should not acquire `Level`, `StarRating`, `Unlock`, `PlayerCurrency`, challenge-evaluation policy, game-attempt history, decorative furniture, campaign progress, or tutorial steps. The game should not reproduce validation, scheduling, queueing, dispatch, transfer, or KPI semantics that Arcogine owns.
+Arcogine should not acquire `Level`, `StarRating`, `Unlock`, `PlayerCurrency`, challenge-evaluation policy, game-attempt history, decorative furniture, campaign progress, or tutorial steps. The game should not reproduce validation, workload decomposition, scheduling, queueing, dispatch, transfer, or KPI semantics that Arcogine owns.
 
 ## 6. Client-specific requirements after upstream readiness
 
@@ -227,6 +229,8 @@ The initial game economy may include starting cash, purchase/resale prices, cont
 These are game rules. They do not extend Arcogine Finance unless a separate product-level use case creates a genuine engine requirement.
 
 Challenge identity/version, admissibility, evaluation-policy identity/version, score/success semantics, and attempt provenance/history are specified in [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md). Challenge evaluation may interpret authoritative Arcogine outcome facts but must not recreate production semantics to derive facts Arcogine did not report.
+
+The fixed challenge workload remains one game-owned production requirement. The game does not split it into multiple Arcogine Orders merely to obtain parallel capacity. Arcogine's work-decomposition capability is responsible for exposing independently dispatchable execution units while preserving the authoritative parent production requirement.
 
 ### 6.6 Persistence and local runtime
 
@@ -264,20 +268,22 @@ The vertical slice does not require:
 | Scoring formula | Playtests showing meaningful factory trade-offs |
 | Tutorial sequence | First-time-user observation |
 
-Canonical model, order/work semantics, dispatch, session behavior, event envelopes, and transfer rules are upstream decisions and do not belong here.
+Canonical model, order/work semantics, work decomposition, dispatch, session behavior, event envelopes, and transfer rules are upstream decisions and do not belong here.
 
 ## 9. Playable/runtime-integrated game implementation entry criteria
 
 Headless Challenge Readiness C1-C5 is explicitly outside this entry gate and may proceed earlier under the constraints in §2.3. Playable or runtime-integrated game implementation may begin when all of the following are true:
 
 1. The model-seam entry gate (§1.1 of [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)) is satisfied.
-2. Gates 1-5 in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) are satisfied.
-3. A game-like draft can project into the canonical model and publish a `FactoryModelVersion` without using mutable runtime classes.
-4. The headless capacity benchmark proves equivalent-resource dispatch and exposes the resulting bottleneck.
-5. The headless layout benchmark proves deterministic transfer consequences across distinct published model versions.
-6. A reference consumer can instantiate, submit workload, advance, observe, and reset without Arcogine internals.
-7. Model and runtime observation contracts are stable enough for a prototype consumer.
-8. No unresolved game requirement requires the client to reproduce authoritative Arcogine logic.
+2. Gates 1-3 in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) are satisfied, including Gate 2 at its deterministic-dispatch boundary.
+3. The ADR-0009 work-decomposition prerequisite is implemented and a single fixed accepted production requirement can exercise parallel equivalent bottleneck capacity without the game manufacturing independent Orders.
+4. Gates 4-5 in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) are satisfied after accounting for the execution identities/correlation introduced by work decomposition.
+5. A game-like draft can project into the canonical model and publish a `FactoryModelVersion` without using mutable runtime classes.
+6. The headless capacity benchmark proves equivalent-resource dispatch, and a fixed-contract decomposition benchmark proves the current reference workload can actually use that capacity.
+7. The headless layout benchmark proves deterministic transfer consequences across distinct published model versions.
+8. A reference consumer can instantiate, submit workload, advance, observe, and reset without Arcogine internals.
+9. Model and runtime observation contracts are stable enough for a prototype consumer.
+10. No unresolved game requirement requires the client to reproduce authoritative Arcogine logic.
 
 ## 10. Vertical-slice acceptance criteria
 
@@ -288,7 +294,7 @@ The game vertical slice is successful when:
 3. A fixed production contract runs independently of pricing, stochastic demand, and autonomous sales behavior.
 4. Quantity represents real production workload rather than primarily commercial value.
 5. The same resources arranged differently produce different deterministic completion times where transfer distance differs.
-6. Adding compatible capacity at the actual bottleneck changes throughput, queueing, utilization, or completion time.
+6. Adding compatible capacity at the actual bottleneck changes throughput, queueing, utilization, or completion time for the same fixed production contract; the game does not achieve this by rewriting the contract as artificial independent Orders.
 7. The player can identify the bottleneck and major delay sources from supported observations presented by the game.
 8. Invalid drafts display structured diagnostics and do not publish or partially mutate runtime state.
 9. Retrying the same published model with the same seed/workload/commands reproduces behavior and result.

--- a/docs/planning/factory-design-game-vertical-slice.md
+++ b/docs/planning/factory-design-game-vertical-slice.md
@@ -3,7 +3,7 @@
 > **Status:** Proposed  
 > **Scope:** Product hypothesis for the first playable factory-design game slice  
 > **Authority:** Planning only; this document does not describe current Arcogine capability or accepted architecture  
-> **Related:** [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [Factory Design Capability](factory-design-capability.md), [Product Charter](../product/charter.md)
+> **Related:** [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [Factory Design Capability](factory-design-capability.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [Product Charter](../product/charter.md)
 
 ## 1. Product thesis
 
@@ -61,6 +61,8 @@ The player should form hypotheses about the production system, test them through
 The player decides where additional compatible resources are worth their capital cost.
 
 Adding capacity at a true bottleneck should be capable of reducing queueing or completion time. Adding capacity away from the bottleneck may produce little or no benefit. Solving one bottleneck may expose another.
+
+For the fixed-contract reference challenge below, this requirement applies to one accepted production requirement, not to a game-authored collection of artificial independent orders. Arcogine therefore needs the pre-playable work-decomposition capability recorded by ADR-0009 before the second-cutter strategy can be used as runtime evidence.
 
 ### 3.2 Resource eligibility and dispatch
 
@@ -122,6 +124,8 @@ Strategy B
 ```
 
 Neither approach should dominate under every constraint. The useful product question is whether the player can understand why one design performs better in a particular run.
+
+The 20-unit contract remains one fixed game-owned production requirement. The game must not obtain Strategy A's parallelism by silently translating that requirement into several independent Arcogine `Order`s. Arcogine owns how accepted production intent is decomposed into independently dispatchable execution units; that capability is an explicit pre-playable dependency under ADR-0009 and the consumer plan.
 
 ## 5. Player evidence and attempt comparison
 

--- a/docs/planning/factory-simulation-engine-readiness.md
+++ b/docs/planning/factory-simulation-engine-readiness.md
@@ -4,7 +4,7 @@
 > **Scope:** Prepare Arcogine's factory runtime for external consumers after the canonical factory-model boundary is established  
 > **Authority:** Planning only; this document defines runtime-readiness gates, not current capability or accepted architecture  
 > **Prerequisite:** the model-seam entry gate (§1.1) — narrower than full D1-D4 in [Factory Design Capability](factory-design-capability.md)  
-> **Related:** [Factory Design Architecture](../architecture/factory-design.md), [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md), [Architecture Overview](../architecture/overview.md)
+> **Related:** [Factory Design Architecture](../architecture/factory-design.md), [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md), [Architecture Overview](../architecture/overview.md)
 
 ## 1. Purpose
 
@@ -120,7 +120,7 @@ It follows these constraints:
 
 ## 4. Readiness policy
 
-Game implementation begins only after the design prerequisite and Gates 1-5 below are satisfied by headless evidence.
+Game implementation begins only after the design prerequisite, Gates 1-5, and the currently activated W1 capability below are satisfied by headless evidence.
 
 ```text
 Prerequisite  Model-seam entry gate satisfied (§1.1) — not full Design D1-D4
@@ -131,6 +131,8 @@ Gate 2        Capability-based deterministic dispatch
         ↓
 Gate 3        Consumer-neutral simulation session
         ↓
+W1            Intra-order work decomposition / lot-and-batch execution
+        ↓
 Gate 4        Stable observations and event envelopes
         ↓
 Gate 5        Spatial runtime consequences
@@ -138,7 +140,7 @@ Gate 5        Spatial runtime consequences
 Game consumer may begin
 ```
 
-A deferred execution capability may be promoted into this critical path only when a supported consumer requires it; see §14.1 for intra-order work decomposition / lot-and-batch execution. It is not a hidden completion condition for Gate 2.
+The current fixed-quantity factory-design reference challenge already activates **W1 — intra-order work decomposition / lot-and-batch execution**. W1 is therefore a required Engine capability in the critical path between Gate 3 and Gate 4. It is not a hidden completion condition for Gate 2; Gate 2 remains complete for dispatch of independently dispatchable work. See [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md) and §14.1.
 
 Distribution hardening follows the core gates. A first UI experiment may begin after these gates; a distributable client additionally requires the contract, recovery, persistence, and packaging work in Section 11.
 
@@ -195,7 +197,7 @@ The second Gate 1 slice added an explicit, consumer-neutral workload-submission 
 
 The third Gate 1 slice made order quantity consume proportional production work. `FactoryHandler.submitOrder` now sizes a job's routing to `routing.stepCount() * quantity` instead of `routing.stepCount()`: the job repeats its routing once per unit of quantity, and dispatch/completion resolve each job-global step back to its underlying `RoutingStep` by `stepIndex % routing.stepCount()`. This was chosen over multiplying each step's fixed `duration` by quantity, and over creating one `Job`/`JobId` per unit, because it gives countable progress (`Job.currentStep()` is a job-global counter that advances once per routing step executed, i.e. `routing.stepCount()` times per unit) without multiplying `Order`/`Job` object volume per unit of quantity -- a 100,000-unit order still creates exactly one `Order` and one `Job`, just with a larger `totalSteps` counter. This deliberately does not bound *event* volume the same way: `TaskStart`/`TaskEnd` events are still scheduled once per routing step per unit (quantity-proportional), because that is the mechanism that makes quantity actually consume proportional machine-occupied time; only object allocation (`Order`/`Job`/`JobId`) stays flat. The externally visible `TaskStart`/`TaskEnd.stepIndex` continues to carry the routing-local index (`stepIndex % routing.stepCount()`), not the job-global counter, so that event field's existing meaning is unchanged. `Job` remains strictly one-to-one with `Order` under this model, so `OrderCompleted`'s existing `jobId` correlation field stays unambiguous and did not need to change; `OrderCompleted` still fires exactly once per order, only after the job's full (quantity-scaled) routing completes. `completedSales`/`backlog`/`avgLeadTime` keep their existing per-order (per-job) counting semantics -- quantity now changes *how long* a job occupies a machine and stays in backlog, not what those counts measure. Both the economy-driven `OrderCreation` path and `FactoryRuntime.submitWorkload` resolve to this same `submitOrder` operation, so they share identical proportional-quantity semantics. See `ProportionalQuantityWorkTest` for the headless proof, including a multi-step, multi-quantity execution that exercises the `stepIndex` modulo wrap-around directly (quantity 10 taking ten times the machine-occupied ticks of quantity 1, determinism, single completion, and economy/explicit-path equivalence).
 
-One accepted order corresponds to exactly one execution job (the routing repeats within that job rather than spawning multiple jobs). This is the deliberate current model, not an unfinished corner: it gives countable per-unit progress without multiplying `Order`/`Job` object volume per unit of quantity. Multiple execution objects per order become necessary only if a future work-decomposition model requires independently dispatchable lots/batches/execution units within one accepted order; that capability is deferred under §14.1 and is not part of Gate 2.
+One accepted order currently corresponds to exactly one execution job (the routing repeats within that job rather than spawning multiple jobs). This remains the implemented model today, but the current fixed-quantity reference challenge now requires a subsequent W1 work-decomposition capability that can expose independently dispatchable execution units within one accepted order. W1 is active planning under §14.1 and [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md); it is separate from Gate 2.
 
 The existing `OrderCompleted` event retains `jobId`, not an explicit `orderId`, as its correlation field. Under the 1 Order <-> 1 Job invariant this model keeps, that correlation is unambiguous and fully supported: a consumer resolves `OrderCompleted.jobId` through `FactoryRuntime.job(jobId)` to a `JobView`, whose `orderId()` identifies the accepted `Order` the completion belongs to. `Gate1EngineReadinessAcceptanceTest` proves this path end to end through `FactoryRuntime` alone. Adding an explicit `orderId` field to the event payload is a stable-event-contract concern -- it belongs to the later Gate 4 (`§8`) work on event envelopes, not Gate 1: Gate 1 only requires that completion be derivable and observable through a supported observation, which it is.
 
@@ -266,11 +268,11 @@ dispatch decision
 
 A routing step used to point to one concrete `MachineId`, so a second equivalent machine could not naturally participate in the route -- even though `OperationStepDefinition.eligibleResources` was already `Set<MachineId>`, `FactoryModelValidator` rejected any step naming more than one, and `FactoryRuntimeAssembler`/`RoutingStep` collapsed to a single machine.
 
-Gate 2 removed that restriction: `RoutingStep` now carries `Set<MachineId> eligibleMachines`, and `FactoryHandler` selects among them deterministically at dispatch time. See ADR-0005 for the full decision and its alternatives.
+Gate 2 removed that restriction: `RoutingStep` now carries `Set<MachineId> eligibleMachines`, and `FactoryHandler` selects among them deterministically at dispatch time. See ADR-0005 for the original dispatch decision; [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md) supersedes its slice-scoping conclusion and records the dispatch-vs-decomposition boundary.
 
 ### 6.3 Deterministic dispatch
 
-The accepted policy (ADR-0005), applied in `FactoryHandler.selectMachine`:
+The dispatch policy established by ADR-0005, applied in `FactoryHandler.selectMachine`:
 
 1. eligible;
 2. online (an eligible machine that is `Offline` is excluded from selection while any eligible machine is online);
@@ -278,9 +280,9 @@ The accepted policy (ADR-0005), applied in `FactoryHandler.selectMachine`:
 4. lowest queue depth;
 5. lowest `MachineId` as final tie-breaker.
 
-Projected-completion-time ranking, resource pools, and capability taxonomies were considered and deliberately deferred (see ADR-0005's alternatives) -- none are required by the acceptance criteria below. A future slice that adds load-aware ranking should update or supersede ADR-0005 rather than reinterpreting this policy silently.
+Projected-completion-time ranking, resource pools, and capability taxonomies were considered and deliberately deferred -- none are required by the acceptance criteria below. A future slice that changes ranking must record that decision rather than silently reinterpreting the current policy.
 
-Gate 2 is about **dispatch**, not work decomposition: the runtime selects an eligible resource for an independently dispatchable unit of work that already exists. Whether one accepted production order should be split into several concurrently executable lots/batches/execution units is a separate production-semantic capability (§14.1).
+Gate 2 is about **dispatch**, not work decomposition: the runtime selects an eligible resource for an independently dispatchable unit of work that already exists. Splitting one accepted production order into several concurrently executable lots/batches/execution units is the separate W1 production-semantic capability now activated by the current reference challenge (§14.1; [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md)).
 
 ### 6.4 Acceptance criteria
 
@@ -288,13 +290,13 @@ Gate 2 is satisfied when:
 
 1. Runtime consumes model-side resource definitions and installed instances rather than redefining them. **Satisfied** (unchanged by this slice -- `FactoryRuntimeAssembler` builds `Machine`s directly from `ResourceDefinition`).
 2. Two equivalent eligible resource instances can both execute the same operation. **Satisfied** -- proved at both the `FactoryHandler` seam (`MultiResourceDispatchTest`) and end to end through the published-model boundary (`Gate2MultiResourceDispatchAcceptanceTest`, driven entirely through `FactoryRuntime`).
-3. Both resources are used when workload justifies parallel capacity. **Satisfied** for sufficient independently dispatchable work: `Gate2MultiResourceDispatchAcceptanceTest.publishedMultiEligibleModelSurvivesAssemblyAndDispatchesBothOrdersConcurrently` proves two independent orders occupy both eligible machines at once, through `FactoryRuntime` alone. Gate 2 does not require one quantity-scaled order to be decomposed into several concurrent execution units; that is deferred under §14.1.
+3. Both resources are used when workload justifies parallel capacity. **Satisfied** for sufficient independently dispatchable work: `Gate2MultiResourceDispatchAcceptanceTest.publishedMultiEligibleModelSurvivesAssemblyAndDispatchesBothOrdersConcurrently` proves two independent orders occupy both eligible machines at once, through `FactoryRuntime` alone. Gate 2 does not require one quantity-scaled order to be decomposed into several concurrent execution units; that is W1.
 4. Equal candidates resolve reproducibly through a stable tie-break rule. **Satisfied** -- `MultiResourceDispatchTest.equalCandidatesResolveDeterministicallyToTheLowestMachineId` and `Gate2MultiResourceDispatchAcceptanceTest.identicalWorkloadFromTwoFreshRuntimesResolvesToTheSameMachineAssignments`.
 5. Adding a second compatible resource changes queueing, utilization, throughput, or completion time in an appropriate workload. **Satisfied**: under concurrent independent orders, both machines' queues stay empty where a single-machine model would queue the second order. The criterion requires an appropriate workload with sufficient independently dispatchable work; it does not require intra-order work decomposition.
 6. Removing/disabling one instance does not require changing the product definition. **Satisfied**, including the machine-recovery lifecycle: `MultiResourceDispatchTest.machineComingBackOnlineDispatchesWorkThatWasStrandedWaitingOnAnotherMachine` and `Gate2MultiResourceDispatchAcceptanceTest.bringingAnEligibleMachineOnlineDispatchesWorkStrandedWaitingForTheOtherMachine` prove that work waiting because one eligible machine was offline is not pinned to whichever other machine happened to be checked when it started waiting -- `FactoryHandler` reconsiders it against its whole eligible set whenever any eligible machine frees up or comes online (see `pendingMultiEligible`/`tryDispatchPendingMultiEligible`), so a machine that was offline when a job first waited can still pick it up once it recovers. `Gate2MultiResourceDispatchAcceptanceTest.offlineEligibleMachineIsExcludedAndRemovingItDoesNotRequireChangingTheProductDefinition` proves the product/operation definition is untouched, only runtime machine availability changes. `Gate2MultiResourceDispatchAcceptanceTest.disjointPendingPoolDispatchesEvenWhileAnEarlierUnrelatedPoolIsStillFull` proves the pending backlog does not head-of-line block: an undispatchable entry waiting on one still-fully-busy eligible pool does not stop a later entry with a disjoint eligible pool from dispatching the moment its own pool frees up.
 7. Resource capability, operational status, and queue state remain distinct concepts. **Satisfied** -- `OperationStepDefinition.eligibleResources` (model eligibility), `MachineState` (operational status), and `Machine`'s per-machine queue plus `FactoryHandler`'s cross-machine pending backlog (runtime queue state) remain separate types; this slice does not merge them.
 
-**Gate 2 is complete.** All seven criteria have executable evidence for deterministic resource selection and parallel-capacity use across independently dispatchable work. Intra-order parallelism is not an unfinished Gate 2 condition; it is a deferred work-decomposition / lot-and-batch execution capability with its own activation trigger (§14.1). Also deferred unless a concrete need arises: load-aware ranking beyond queue depth and resource pools/capability taxonomies.
+**Gate 2 is complete.** All seven criteria have executable evidence for deterministic resource selection and parallel-capacity use across independently dispatchable work. Intra-order parallelism is not an unfinished Gate 2 condition; it is the separately activated W1 work-decomposition / lot-and-batch execution capability (§14.1, ADR-0009). Also deferred unless a concrete need arises: load-aware ranking beyond queue depth and resource pools/capability taxonomies.
 
 ## 7. Gate 3 — Consumer-neutral simulation session
 
@@ -368,7 +370,7 @@ Gate 3 is satisfied when a non-graphical reference consumer can:
 
 This slice deliberately does not migrate `interfaces/api`'s `SimThread` or `interfaces/cli`'s `SimRunner`/`HeadlessHandler` onto `FactoryRuntime`/`advanceUntil` -- both still duplicate their own bespoke max-time loop, which ADR-0007 records as accepted, separately tracked follow-up rather than silently left unrecorded. Neither called `submitWorkload`/`setMachineAvailability` either, so this slice's `CommandResult<T>` signature change touches no production code outside the `factory` module's own tests. It also does not add event envelopes/cursors (Gate 4), a new session-identity type, or a general command-result framework beyond the two commands that need one today -- no acceptance criterion above requires more.
 
-With Gate 3 closed, **Gate 4 (stable observations and event envelopes, §8) is the next active gate.**
+With Gate 3 closed, **W1 — intra-order work decomposition / lot-and-batch execution (§14.1) is the next active Engine semantic slice.** Gate 4 follows W1 so its stable observation/event contract can include the execution identities and correlation semantics W1 establishes.
 
 ## 8. Gate 4 — Stable observations and event envelopes
 
@@ -525,9 +527,9 @@ Gate 5 is satisfied when:
 
 ## 10. Headless engine acceptance scenarios
 
-The gates are proven before a game client exists. Model variants are published through the design capability and instantiated as separate runtimes.
+The gates and active W1 capability are proven before a game client exists. Model variants are published through the design capability and instantiated as separate runtimes.
 
-### 10.1 Capacity benchmark
+### 10.1 Gate 2 capacity benchmark — independently dispatchable work
 
 ```text
 Product
@@ -555,9 +557,41 @@ Expected evidence:
 - if assembly becomes the new bottleneck, supported observations expose it;
 - no product definition is rewritten to name the second cutter.
 
-This benchmark intentionally does not require one quantity-scaled order to split across both cutters. If a supported consumer later requires that behavior, activate the deferred work-decomposition capability in §14.1.
+This benchmark intentionally proves Gate 2 only: it does not require one quantity-scaled order to split across both cutters. The current reference consumer does require that separate behavior, so W1 has its own fixed-contract benchmark below.
 
-### 10.2 Layout benchmark
+### 10.2 W1 fixed-contract work-decomposition benchmark
+
+```text
+Product
+    CUT -> ASSEMBLE -> INSPECT
+
+Production requirement
+    one accepted order for 20 units
+
+Published model A
+    one cutter
+    one assembler
+    one inspector
+
+Published model B
+    two equivalent cutters
+    one assembler
+    one inspector
+```
+
+Expected evidence:
+
+- the workload remains one accepted production requirement / one parent Order rather than being rewritten by the consumer into several independent Orders;
+- the runtime exposes more than one independently dispatchable execution unit under that Order;
+- model B can execute different portions of the same Order concurrently on both eligible cutters;
+- parent-order quantity, progress, completion, and correlation remain deterministic and unambiguous;
+- adding the second cutter changes queueing, throughput, utilization, or completion time for this fixed-contract workload;
+- repeated fresh runs with the same model, workload, and commands reproduce the same decomposition, assignments, ordered events, and terminal result;
+- the proof uses Arcogine-owned execution semantics rather than game-owned splitting logic.
+
+This benchmark is the minimum headless evidence for W1. The concrete representation of execution units/lots/batches is not prescribed by the benchmark and must follow the accepted W1 design.
+
+### 10.3 Layout benchmark
 
 ```text
 Same product definition
@@ -638,13 +672,12 @@ Scenario factory semantics
 1. Separate accepted immutable order intent from mutable job execution. **Implemented as the first behavior-preserving Gate 1 slice.**
 2. Add explicit workload submission independent of the economy/pricing loop. **Implemented as the second Gate 1 slice** (`FactoryRuntime.submitWorkload`, backed by package-private `FactoryHandler.submitOrder`).
 3. Make quantity consume proportional production work and allow multiple work items/jobs per order where required. **Implemented as the third Gate 1 slice**: a job's routing repeats once per unit of quantity (`totalSteps = routing.stepCount() * quantity`) rather than spawning multiple `Job`/`JobId` aggregates, giving a job-global executed-step counter (`Job.currentStep()`) from which per-unit progress can be derived, while keeping `Job` one-to-one with `Order`.
-4. Capability/eligibility-driven deterministic dispatch. **Implemented as Gate 2**: published multi-resource eligibility survives into runtime routing, independently dispatchable work is selected deterministically across equivalent resources, and queue/recovery semantics are covered by `MultiResourceDispatchTest` and `Gate2MultiResourceDispatchAcceptanceTest` (see ADR-0005).
+4. Capability/eligibility-driven deterministic dispatch. **Implemented as Gate 2**: published multi-resource eligibility survives into runtime routing, independently dispatchable work is selected deterministically across equivalent resources, and queue/recovery semantics are covered by `MultiResourceDispatchTest` and `Gate2MultiResourceDispatchAcceptanceTest` (see ADR-0005 and ADR-0009).
 5. Consumer-neutral session and bounded advancement. **Implemented as the Gate 3 slice** (`FactoryRuntime.modelVersion()`, `advanceUntil(SimTime, long)`, `reset()`, `submitWorkload`/`setMachineAvailability` returning `CommandResult<T>`, `pendingWorkView()`; see [ADR-0007](../architecture/decisions/0007-gate-3-session-control-primitives.md)).
-6. Stable runtime observations and event envelopes.
-7. Spatial transfer consequences from published layout.
-8. Public-contract, recovery, persistence, and packaging hardening.
-
-A deferred work-decomposition / lot-and-batch execution capability may be inserted after the core gates or promoted into the critical path when a supported consumer requires one accepted order to expose multiple independently dispatchable execution units. It is not part of item 4 / Gate 2.
+6. **W1 — intra-order work decomposition / lot-and-batch execution. Active next slice.** Required by the current fixed 20-unit reference challenge; define independently dispatchable execution units under one accepted Order and prove §10.2. See [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md).
+7. Stable runtime observations and event envelopes.
+8. Spatial transfer consequences from published layout.
+9. Public-contract, recovery, persistence, and packaging hardening.
 
 ### 13.3 First runtime milestone
 
@@ -670,24 +703,26 @@ This milestone deliberately excludes changing the canonical-model boundary, layo
 | Decision | Trigger for resolution |
 |---|---|
 | Final aggregate/type boundaries for order and work execution | Gate 1 implementation |
-| Intra-order work decomposition / lot-and-batch execution | A supported consumer requires one accepted order to expose multiple independently dispatchable execution units |
+| Intra-order work decomposition / lot-and-batch execution | **Activated** by the current fixed 20-unit factory-design reference challenge; see ADR-0009 and §14.1 |
 | Capability pools versus explicit eligible-instance sets | A concrete scheduling/control use case cannot be expressed cleanly by explicit eligibility |
-| Deterministic dispatch policy | Resolved by Gate 2 / ADR-0005; revisit only if a concrete workload requires a different ranking policy |
+| Deterministic dispatch policy | Resolved by Gate 2 / ADR-0005 and ADR-0009; revisit only if a concrete workload requires a different ranking policy |
 | Session interface/module ownership | Resolved by Gate 3 / ADR-0007; revisit only if a concrete consumer proves `FactoryRuntime` is no longer the right boundary |
 | Tick/event-count advancement semantics | Interactive/headless responsiveness tests |
 | Observation decomposition | First reference consumer and capability-boundary review |
 | Spatial metric/transfer policy | Layout benchmark prototype |
 | Public compatibility policy | Before external consumer contract publication |
 
-### 14.1 Deferred execution capability — work decomposition / lot-and-batch execution
+### 14.1 W1 — active execution capability: work decomposition / lot-and-batch execution
 
-Intra-order parallelism is a **deferred Engine execution capability**, not unfinished Gate 2 work.
+Intra-order parallelism is a **separate active Engine execution capability**, not unfinished Gate 2 work. [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md) records the dispatch-vs-decomposition boundary and activation of this capability.
 
-Activation trigger:
+The generic activation trigger is:
 
 > A supported consumer requires one accepted production order of quantity N to expose multiple independently dispatchable execution units so equivalent resources can process different portions of that order concurrently.
 
-When activated, the capability must define production semantics before implementation, including at minimum:
+That trigger is already met by the current factory-design reference challenge: one fixed production requirement for 20 units must be able to benefit from installing a second eligible cutter without the game manufacturing several independent Arcogine Orders. Therefore W1 is the next active Engine semantic slice and must complete before Gate 4.
+
+W1 must define production semantics before implementation, including at minimum:
 
 ```text
 Production Order
@@ -712,11 +747,13 @@ Questions to resolve include:
 - event/observation correlation across Order, Job, and any new execution-unit identity;
 - deterministic interaction with setup/changeover, material, transfer, or other constraints if those capabilities exist when this work is activated.
 
-Do not assume "one quantity unit = one execution object." The first implementation should be driven by the concrete consumer/workload that activates the capability.
+Do not assume "one quantity unit = one execution object." The first implementation should be driven by the concrete fixed-contract reference workload that activated the capability.
 
 This capability does **not** automatically include material-lot tracking, inventory allocation, setup optimization, transfer batching, or generalized production scheduling. Those remain separate unless the activating use case proves they are inseparable.
 
-If activated before Gate 5 is complete, place it in the critical path where its new identities and observations can use the stabilized Gate 4 contract rather than inventing parallel ad-hoc correlation semantics. Prefer implementing it after Gate 4 unless the concrete use case demonstrates an earlier dependency.
+W1 is placed **before Gate 4** deliberately. W1 establishes the execution identities, parent/child correlation, progress, and completion semantics that Gate 4 must then expose as stable observations and event envelopes. Gate 4 must not freeze a public contract around the current one-Job-per-Order shape and force W1 to retrofit identity later.
+
+Minimum W1 completion evidence is the fixed-contract benchmark in §10.2. Until that benchmark passes, Gate 4 is not the next active Engine gate and playable/runtime-integrated game work remains blocked.
 
 The canonical model/run/runtime boundary is tracked by [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md). Operational execution-context/trust/command/deployment/reconciliation decisions belong to the sibling operational track and should receive their own ADRs when hard-to-reverse contracts are selected. Record additional accepted Engine decisions as ADRs rather than expanding this plan into a decision log.
 

--- a/docs/planning/factory-simulation-engine-readiness.md
+++ b/docs/planning/factory-simulation-engine-readiness.md
@@ -138,6 +138,8 @@ Gate 5        Spatial runtime consequences
 Game consumer may begin
 ```
 
+A deferred execution capability may be promoted into this critical path only when a supported consumer requires it; see §14.1 for intra-order work decomposition / lot-and-batch execution. It is not a hidden completion condition for Gate 2.
+
 Distribution hardening follows the core gates. A first UI experiment may begin after these gates; a distributable client additionally requires the contract, recovery, persistence, and packaging work in Section 11.
 
 ## 5. Gate 1 — Explicit production workload and execution model
@@ -191,9 +193,9 @@ Job (mutable execution)
 
 The second Gate 1 slice added an explicit, consumer-neutral workload-submission entry point: `FactoryRuntime.submitWorkload(productId, quantity, unitPrice)`. `FactoryRuntime` wraps a `FactoryHandler` together with a `Scheduler` it owns internally, so a caller supplies only product/quantity/commercial intent -- never a mutable `Scheduler` or an authoritative simulation time, which stayed internal event-engine plumbing rather than becoming part of the workload boundary. Both `FactoryRuntime.submitWorkload` and the economy-driven `OrderCreation` event resolve to the same package-private `FactoryHandler.submitOrder(productId, quantity, unitPrice, currentTime, scheduler)` acceptance operation -- `FactoryHandler.handleEvent` delegates to it for that event rather than duplicating the logic, and it is not exposed outside the `factory.process` package. `FactoryHandler` already had no compile-time dependency on economy/pricing/demand/agents; this slice makes explicit submission a supported, named entry point instead of something only reachable by hand-constructing an internal event payload and owning a `Scheduler`. `FactoryRuntime` is only constructed from a published model, via `FactoryRuntime.forModel(FactoryModelVersion)` (internally using `FactoryRuntimeAssembler`) -- never wrapped around an already-live `FactoryHandler` some other scheduler might also be driving, so it always owns the exclusive factory/scheduler pair it advances and event ordering stays globally authoritative. It also does not expose the mutable `FactoryHandler` directly; callers observe state through `FactoryRuntime`'s own read-only projections (`ordersView`, `jobsView`, `job`, `machinesView`, `backlog`, `avgLeadTime`, `throughput`, `completedSalesValue`, `completedSales`). A headless test (`ExplicitWorkloadSubmissionTest`) builds a runtime this way and submits workload directly, with no `DemandModel`, `PricingState`, or agent in the loop, and proves repeated identical submissions are deterministic. `FactoryRuntime.advance()` pumps exactly one pending event at a time so a headless caller can drive submitted workload to completion without reaching into scheduler internals; this is deliberately not a general session/advancement API -- that remains Gate 3 work. Economy-driven scenarios continue to work unchanged: `DemandModel.generateOrders` still schedules `OrderCreation` events, which route through the same `submitOrder` logic.
 
-The third Gate 1 slice made order quantity consume proportional production work. `FactoryHandler.submitOrder` now sizes a job's routing to `routing.stepCount() * quantity` instead of `routing.stepCount()`: the job repeats its routing once per unit of quantity, and dispatch/completion resolve each job-global step back to its underlying `RoutingStep` by `stepIndex % routing.stepCount()`. This was chosen over multiplying each step's fixed `duration` by quantity, and over creating one `Job`/`JobId` per unit, because it gives countable progress (`Job.currentStep()` is a job-global counter that advances once per routing step executed, i.e. `routing.stepCount()` times per unit) without multiplying `Order`/`Job` object volume per unit of quantity -- a 100,000-unit order still creates exactly one `Order` and one `Job`, just with a larger `totalSteps` counter -- and it keeps a straightforward seam for Gate 2 to later dispatch remaining repetitions to available capacity in parallel. This deliberately does not bound *event* volume the same way: `TaskStart`/`TaskEnd` events are still scheduled once per routing step per unit (quantity-proportional), because that is the mechanism that makes quantity actually consume proportional machine-occupied time; only object allocation (`Order`/`Job`/`JobId`) stays flat. The externally visible `TaskStart`/`TaskEnd.stepIndex` continues to carry the routing-local index (`stepIndex % routing.stepCount()`), not the job-global counter, so that event field's existing meaning is unchanged. `Job` remains strictly one-to-one with `Order` under this model, so `OrderCompleted`'s existing `jobId` correlation field stays unambiguous and did not need to change; `OrderCompleted` still fires exactly once per order, only after the job's full (quantity-scaled) routing completes. `completedSales`/`backlog`/`avgLeadTime` keep their existing per-order (per-job) counting semantics -- quantity now changes *how long* a job occupies a machine and stays in backlog, not what those counts measure. Both the economy-driven `OrderCreation` path and `FactoryRuntime.submitWorkload` resolve to this same `submitOrder` operation, so they share identical proportional-quantity semantics. See `ProportionalQuantityWorkTest` for the headless proof, including a multi-step, multi-quantity execution that exercises the `stepIndex` modulo wrap-around directly (quantity 10 taking ten times the machine-occupied ticks of quantity 1, determinism, single completion, and economy/explicit-path equivalence).
+The third Gate 1 slice made order quantity consume proportional production work. `FactoryHandler.submitOrder` now sizes a job's routing to `routing.stepCount() * quantity` instead of `routing.stepCount()`: the job repeats its routing once per unit of quantity, and dispatch/completion resolve each job-global step back to its underlying `RoutingStep` by `stepIndex % routing.stepCount()`. This was chosen over multiplying each step's fixed `duration` by quantity, and over creating one `Job`/`JobId` per unit, because it gives countable progress (`Job.currentStep()` is a job-global counter that advances once per routing step executed, i.e. `routing.stepCount()` times per unit) without multiplying `Order`/`Job` object volume per unit of quantity -- a 100,000-unit order still creates exactly one `Order` and one `Job`, just with a larger `totalSteps` counter. This deliberately does not bound *event* volume the same way: `TaskStart`/`TaskEnd` events are still scheduled once per routing step per unit (quantity-proportional), because that is the mechanism that makes quantity actually consume proportional machine-occupied time; only object allocation (`Order`/`Job`/`JobId`) stays flat. The externally visible `TaskStart`/`TaskEnd.stepIndex` continues to carry the routing-local index (`stepIndex % routing.stepCount()`), not the job-global counter, so that event field's existing meaning is unchanged. `Job` remains strictly one-to-one with `Order` under this model, so `OrderCompleted`'s existing `jobId` correlation field stays unambiguous and did not need to change; `OrderCompleted` still fires exactly once per order, only after the job's full (quantity-scaled) routing completes. `completedSales`/`backlog`/`avgLeadTime` keep their existing per-order (per-job) counting semantics -- quantity now changes *how long* a job occupies a machine and stays in backlog, not what those counts measure. Both the economy-driven `OrderCreation` path and `FactoryRuntime.submitWorkload` resolve to this same `submitOrder` operation, so they share identical proportional-quantity semantics. See `ProportionalQuantityWorkTest` for the headless proof, including a multi-step, multi-quantity execution that exercises the `stepIndex` modulo wrap-around directly (quantity 10 taking ten times the machine-occupied ticks of quantity 1, determinism, single completion, and economy/explicit-path equivalence).
 
-One accepted order corresponds to exactly one execution job (the routing repeats within that job rather than spawning multiple jobs). This is the deliberate current model, not an unfinished corner: it gives countable per-unit progress and a straightforward Gate 2 dispatch seam (§5.2 above) without multiplying `Order`/`Job` object volume per unit of quantity. Multiple execution objects per order only become necessary if a future quantity/dispatch model requires them (for example, dispatching remaining repetitions across parallel equivalent capacity in Gate 2) -- nothing in Gate 1 requires that shape today.
+One accepted order corresponds to exactly one execution job (the routing repeats within that job rather than spawning multiple jobs). This is the deliberate current model, not an unfinished corner: it gives countable per-unit progress without multiplying `Order`/`Job` object volume per unit of quantity. Multiple execution objects per order become necessary only if a future work-decomposition model requires independently dispatchable lots/batches/execution units within one accepted order; that capability is deferred under §14.1 and is not part of Gate 2.
 
 The existing `OrderCompleted` event retains `jobId`, not an explicit `orderId`, as its correlation field. Under the 1 Order <-> 1 Job invariant this model keeps, that correlation is unambiguous and fully supported: a consumer resolves `OrderCompleted.jobId` through `FactoryRuntime.job(jobId)` to a `JobView`, whose `orderId()` identifies the accepted `Order` the completion belongs to. `Gate1EngineReadinessAcceptanceTest` proves this path end to end through `FactoryRuntime` alone. Adding an explicit `orderId` field to the event payload is a stable-event-contract concern -- it belongs to the later Gate 4 (`§8`) work on event envelopes, not Gate 1: Gate 1 only requires that completion be derivable and observable through a supported observation, which it is.
 
@@ -231,8 +233,6 @@ Gate 1 is satisfied when:
 7. **Determinism.** The strongest ordered-stream proof reaches the full `FactoryRuntime` contract, not just the `FactoryHandler`/`Scheduler` seam: `Gate1EngineReadinessAcceptanceTest.identicalWorkloadFromTwoFreshRuntimesProducesIdenticalOrderedEventStreamsAndTerminalState` drains the entire ordered event stream from two independently constructed, fresh `FactoryRuntime`s given the same published model and workload and asserts the streams are identical, plus identical terminal state (job completion, lead time, backlog, completed sales count/value, average lead time). `ExplicitWorkloadSubmissionTest.repeatedIdenticalSubmissionsAreDeterministic` and `ProportionalQuantityWorkTest.identicalWorkloadProducesIdenticalOrderedResults` remain as lower-level determinism evidence at the `FactoryHandler`/`Scheduler` seam.
 8. **Economy-driven workload shares the same accepted-order/proportional-work path.** Both the economy-driven `OrderCreation` event and `FactoryRuntime.submitWorkload` resolve to the same package-private `FactoryHandler.submitOrder`. Existing regression evidence: `ProportionalQuantityWorkTest.economyDrivenOrderCreationFollowsTheSameProportionalWorkSemanticsAsQuantityOne` and `.explicitAndEconomyPathsProduceIdenticalProportionalWorkForTheSameQuantity` prove the two paths share identical proportional-work semantics; `OrderLifecycleIntegrationTest` (`interfaces/api`) proves the full economy-driven `OrderCreation -> Factory -> OrderCompleted -> Finance` chain end to end through the real wired `IntegratedHandler`; `DemandModelTest` proves the economy demand loop schedules `OrderCreation` events, which route through the identical acceptance path. This evidence was judged sufficient as-is -- no additional economy scenario test was needed to close this criterion.
 
-With Gate 1 closed, **Gate 2 (capability-based deterministic dispatch, §6) is the next active gate.**
-
 ## 6. Gate 2 — Capability-based deterministic dispatch
 
 ### 6.1 Goal
@@ -262,15 +262,15 @@ assignment
 dispatch decision
 ```
 
-### 6.2 Current problem (resolved by the first Gate 2 slice)
+### 6.2 Current problem (resolved)
 
 A routing step used to point to one concrete `MachineId`, so a second equivalent machine could not naturally participate in the route -- even though `OperationStepDefinition.eligibleResources` was already `Set<MachineId>`, `FactoryModelValidator` rejected any step naming more than one, and `FactoryRuntimeAssembler`/`RoutingStep` collapsed to a single machine.
 
-The first Gate 2 slice removed that restriction: `RoutingStep` now carries `Set<MachineId> eligibleMachines`, and `FactoryHandler` selects among them deterministically at dispatch time. See ADR-0005 for the full decision and its alternatives.
+Gate 2 removed that restriction: `RoutingStep` now carries `Set<MachineId> eligibleMachines`, and `FactoryHandler` selects among them deterministically at dispatch time. See ADR-0005 for the full decision and its alternatives.
 
 ### 6.3 Deterministic dispatch
 
-The accepted first-slice policy (ADR-0005), applied in `FactoryHandler.selectMachine`:
+The accepted policy (ADR-0005), applied in `FactoryHandler.selectMachine`:
 
 1. eligible;
 2. online (an eligible machine that is `Offline` is excluded from selection while any eligible machine is online);
@@ -280,19 +280,21 @@ The accepted first-slice policy (ADR-0005), applied in `FactoryHandler.selectMac
 
 Projected-completion-time ranking, resource pools, and capability taxonomies were considered and deliberately deferred (see ADR-0005's alternatives) -- none are required by the acceptance criteria below. A future slice that adds load-aware ranking should update or supersede ADR-0005 rather than reinterpreting this policy silently.
 
+Gate 2 is about **dispatch**, not work decomposition: the runtime selects an eligible resource for an independently dispatchable unit of work that already exists. Whether one accepted production order should be split into several concurrently executable lots/batches/execution units is a separate production-semantic capability (§14.1).
+
 ### 6.4 Acceptance criteria
 
 Gate 2 is satisfied when:
 
 1. Runtime consumes model-side resource definitions and installed instances rather than redefining them. **Satisfied** (unchanged by this slice -- `FactoryRuntimeAssembler` builds `Machine`s directly from `ResourceDefinition`).
 2. Two equivalent eligible resource instances can both execute the same operation. **Satisfied** -- proved at both the `FactoryHandler` seam (`MultiResourceDispatchTest`) and end to end through the published-model boundary (`Gate2MultiResourceDispatchAcceptanceTest`, driven entirely through `FactoryRuntime`).
-3. Both resources are used when workload justifies parallel capacity. **Satisfied for independent orders/jobs**: `Gate2MultiResourceDispatchAcceptanceTest.publishedMultiEligibleModelSurvivesAssemblyAndDispatchesBothOrdersConcurrently` proves two independent orders occupy both eligible machines at once, through `FactoryRuntime` alone. **Not yet proved for a single quantity-scaled order.** `submitOrder` still creates exactly one `Job` per order, and `handleTaskEnd` advances that job's repeated routing strictly one step at a time -- a fixed-contract workload expressed as one large-quantity order (rather than many independent orders) cannot yet exploit a second eligible machine's parallel capacity within that one job. Closing that gap would require either intra-job execution parallelism or multiple execution objects per order, both of which the original Gate 2 audit named as non-goals for this slice (see "multiple Jobs per Order" and "per-unit execution objects" in the plan's non-goals). This remains open for a later slice if a concrete workload requires it; it is not claimed satisfied by this slice.
+3. Both resources are used when workload justifies parallel capacity. **Satisfied** for sufficient independently dispatchable work: `Gate2MultiResourceDispatchAcceptanceTest.publishedMultiEligibleModelSurvivesAssemblyAndDispatchesBothOrdersConcurrently` proves two independent orders occupy both eligible machines at once, through `FactoryRuntime` alone. Gate 2 does not require one quantity-scaled order to be decomposed into several concurrent execution units; that is deferred under §14.1.
 4. Equal candidates resolve reproducibly through a stable tie-break rule. **Satisfied** -- `MultiResourceDispatchTest.equalCandidatesResolveDeterministicallyToTheLowestMachineId` and `Gate2MultiResourceDispatchAcceptanceTest.identicalWorkloadFromTwoFreshRuntimesResolvesToTheSameMachineAssignments`.
-5. Adding a second compatible resource changes queueing, utilization, throughput, or completion time in an appropriate workload. **Satisfied for independent orders/jobs**, under the same scope note as criterion 3: both machines' queues stay empty under concurrent independent orders where a single-machine model would have queued the second one. Not yet proved for a single quantity-scaled order, for the same reason as criterion 3.
+5. Adding a second compatible resource changes queueing, utilization, throughput, or completion time in an appropriate workload. **Satisfied**: under concurrent independent orders, both machines' queues stay empty where a single-machine model would queue the second order. The criterion requires an appropriate workload with sufficient independently dispatchable work; it does not require intra-order work decomposition.
 6. Removing/disabling one instance does not require changing the product definition. **Satisfied**, including the machine-recovery lifecycle: `MultiResourceDispatchTest.machineComingBackOnlineDispatchesWorkThatWasStrandedWaitingOnAnotherMachine` and `Gate2MultiResourceDispatchAcceptanceTest.bringingAnEligibleMachineOnlineDispatchesWorkStrandedWaitingForTheOtherMachine` prove that work waiting because one eligible machine was offline is not pinned to whichever other machine happened to be checked when it started waiting -- `FactoryHandler` reconsiders it against its whole eligible set whenever any eligible machine frees up or comes online (see `pendingMultiEligible`/`tryDispatchPendingMultiEligible`), so a machine that was offline when a job first waited can still pick it up once it recovers. `Gate2MultiResourceDispatchAcceptanceTest.offlineEligibleMachineIsExcludedAndRemovingItDoesNotRequireChangingTheProductDefinition` proves the product/operation definition is untouched, only runtime machine availability changes. `Gate2MultiResourceDispatchAcceptanceTest.disjointPendingPoolDispatchesEvenWhileAnEarlierUnrelatedPoolIsStillFull` proves the pending backlog does not head-of-line block: an undispatchable entry waiting on one still-fully-busy eligible pool does not stop a later entry with a disjoint eligible pool from dispatching the moment its own pool frees up.
 7. Resource capability, operational status, and queue state remain distinct concepts. **Satisfied** -- `OperationStepDefinition.eligibleResources` (model eligibility), `MachineState` (operational status), and `Machine`'s per-machine queue plus `FactoryHandler`'s cross-machine pending backlog (runtime queue state) remain separate types; this slice does not merge them.
 
-This closes the first Gate 2 slice as scoped by ADR-0005, for independent-order/job parallelism proved end to end through `FactoryRuntime`. Criteria 3 and 5 remain explicitly open for intra-job (single quantity-scaled order) parallel dispatch -- that is a distinct, larger design question this slice does not resolve or claim to. Also left for a later slice if a concrete need arises: load-aware ranking beyond queue depth, and resource pools/capability taxonomies.
+**Gate 2 is complete.** All seven criteria have executable evidence for deterministic resource selection and parallel-capacity use across independently dispatchable work. Intra-order parallelism is not an unfinished Gate 2 condition; it is a deferred work-decomposition / lot-and-batch execution capability with its own activation trigger (§14.1). Also deferred unless a concrete need arises: load-aware ranking beyond queue depth and resource pools/capability taxonomies.
 
 ## 7. Gate 3 — Consumer-neutral simulation session
 
@@ -531,8 +533,8 @@ The gates are proven before a game client exists. Model variants are published t
 Product
     CUT -> ASSEMBLE -> INSPECT
 
-Production order
-    20 units
+Production workload
+    two or more independent orders/jobs totaling 20 units
 
 Published model A
     one cutter
@@ -548,10 +550,12 @@ Published model B
 Expected evidence:
 
 - both runs are deterministic;
-- model B dispatches work to both cutters;
+- model B dispatches independently dispatchable work to both cutters;
 - cutter queueing, throughput, utilization, or total completion time changes;
 - if assembly becomes the new bottleneck, supported observations expose it;
 - no product definition is rewritten to name the second cutter.
+
+This benchmark intentionally does not require one quantity-scaled order to split across both cutters. If a supported consumer later requires that behavior, activate the deferred work-decomposition capability in §14.1.
 
 ### 10.2 Layout benchmark
 
@@ -634,11 +638,13 @@ Scenario factory semantics
 1. Separate accepted immutable order intent from mutable job execution. **Implemented as the first behavior-preserving Gate 1 slice.**
 2. Add explicit workload submission independent of the economy/pricing loop. **Implemented as the second Gate 1 slice** (`FactoryRuntime.submitWorkload`, backed by package-private `FactoryHandler.submitOrder`).
 3. Make quantity consume proportional production work and allow multiple work items/jobs per order where required. **Implemented as the third Gate 1 slice**: a job's routing repeats once per unit of quantity (`totalSteps = routing.stepCount() * quantity`) rather than spawning multiple `Job`/`JobId` aggregates, giving a job-global executed-step counter (`Job.currentStep()`) from which per-unit progress can be derived, while keeping `Job` one-to-one with `Order`.
-4. Capability/eligibility-driven deterministic dispatch.
+4. Capability/eligibility-driven deterministic dispatch. **Implemented as Gate 2**: published multi-resource eligibility survives into runtime routing, independently dispatchable work is selected deterministically across equivalent resources, and queue/recovery semantics are covered by `MultiResourceDispatchTest` and `Gate2MultiResourceDispatchAcceptanceTest` (see ADR-0005).
 5. Consumer-neutral session and bounded advancement. **Implemented as the Gate 3 slice** (`FactoryRuntime.modelVersion()`, `advanceUntil(SimTime, long)`, `reset()`, `submitWorkload`/`setMachineAvailability` returning `CommandResult<T>`, `pendingWorkView()`; see [ADR-0007](../architecture/decisions/0007-gate-3-session-control-primitives.md)).
 6. Stable runtime observations and event envelopes.
 7. Spatial transfer consequences from published layout.
 8. Public-contract, recovery, persistence, and packaging hardening.
+
+A deferred work-decomposition / lot-and-batch execution capability may be inserted after the core gates or promoted into the critical path when a supported consumer requires one accepted order to expose multiple independently dispatchable execution units. It is not part of item 4 / Gate 2.
 
 ### 13.3 First runtime milestone
 
@@ -664,14 +670,53 @@ This milestone deliberately excludes changing the canonical-model boundary, layo
 | Decision | Trigger for resolution |
 |---|---|
 | Final aggregate/type boundaries for order and work execution | Gate 1 implementation |
-| Unit work items versus capacity-consuming batches | Quantity prototype and expected scale |
-| Capability pools versus explicit eligible-instance sets | Gate 2 scheduling/control requirements |
-| Deterministic dispatch policy | First equivalent-resource benchmark |
-| Session interface/module ownership | Gate 3 implementation |
+| Intra-order work decomposition / lot-and-batch execution | A supported consumer requires one accepted order to expose multiple independently dispatchable execution units |
+| Capability pools versus explicit eligible-instance sets | A concrete scheduling/control use case cannot be expressed cleanly by explicit eligibility |
+| Deterministic dispatch policy | Resolved by Gate 2 / ADR-0005; revisit only if a concrete workload requires a different ranking policy |
+| Session interface/module ownership | Resolved by Gate 3 / ADR-0007; revisit only if a concrete consumer proves `FactoryRuntime` is no longer the right boundary |
 | Tick/event-count advancement semantics | Interactive/headless responsiveness tests |
 | Observation decomposition | First reference consumer and capability-boundary review |
 | Spatial metric/transfer policy | Layout benchmark prototype |
 | Public compatibility policy | Before external consumer contract publication |
+
+### 14.1 Deferred execution capability — work decomposition / lot-and-batch execution
+
+Intra-order parallelism is a **deferred Engine execution capability**, not unfinished Gate 2 work.
+
+Activation trigger:
+
+> A supported consumer requires one accepted production order of quantity N to expose multiple independently dispatchable execution units so equivalent resources can process different portions of that order concurrently.
+
+When activated, the capability must define production semantics before implementation, including at minimum:
+
+```text
+Production Order
+    ↓
+execution decomposition policy
+    ↓
+Lot / batch / execution unit(s)
+    ↓
+operation instances
+    ↓
+deterministic Gate 2 dispatch across eligible resources
+```
+
+Questions to resolve include:
+
+- whether order quantity is divisible at every operation or only at declared decomposition points;
+- the identity and lifecycle of independently dispatchable execution units;
+- lot/batch sizing and whether transfer batches differ from production batches;
+- precedence when different units of one order are at different operations concurrently;
+- partial and aggregate progress semantics;
+- aggregate order completion and failure semantics;
+- event/observation correlation across Order, Job, and any new execution-unit identity;
+- deterministic interaction with setup/changeover, material, transfer, or other constraints if those capabilities exist when this work is activated.
+
+Do not assume "one quantity unit = one execution object." The first implementation should be driven by the concrete consumer/workload that activates the capability.
+
+This capability does **not** automatically include material-lot tracking, inventory allocation, setup optimization, transfer batching, or generalized production scheduling. Those remain separate unless the activating use case proves they are inseparable.
+
+If activated before Gate 5 is complete, place it in the critical path where its new identities and observations can use the stabilized Gate 4 contract rather than inventing parallel ad-hoc correlation semantics. Prefer implementing it after Gate 4 unless the concrete use case demonstrates an earlier dependency.
 
 The canonical model/run/runtime boundary is tracked by [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md). Operational execution-context/trust/command/deployment/reconciliation decisions belong to the sibling operational track and should receive their own ADRs when hard-to-reverse contracts are selected. Record additional accepted Engine decisions as ADRs rather than expanding this plan into a decision log.
 


### PR DESCRIPTION
## Summary

Reconciles Engine Readiness, the factory-design game contract, and ADR history after review.

- preserve ADR-0005 as historical record and mark it superseded only through metadata
- add ADR-0009 to separate deterministic resource dispatch from intra-order work decomposition
- mark Gate 2 complete for independently dispatchable work without pretending single-order parallelism already exists
- make work decomposition an explicit **required pre-playable Engine capability** for the current fixed 20-unit reference challenge
- keep the game/challenge workload as one fixed production requirement; the game may not manufacture independent Arcogine Orders merely to obtain parallel capacity
- place the activated work-decomposition capability before Gate 4 closure so Gate 4 can stabilize the resulting execution identities/correlation
- reconcile the game consumer and vertical-slice planning with that dependency
- add CI enforcement for Accepted/Superseded ADR immutability

## Architectural boundary

Gate 2 answers:

> Given an independently dispatchable unit of work, which eligible resource executes it deterministically?

Work decomposition answers:

> How does one accepted production requirement expose several independently dispatchable execution units while preserving parent intent, progress, precedence, and completion semantics?

Those are separate concerns. Gate 2 is complete; the current game reference challenge independently activates the second capability as a pre-playable requirement.

## ADR history

ADR-0005 is no longer rewritten. Its original body is preserved; only:

- `Status: Superseded`
- `Superseded by: ADR-0009`

are added/changed. ADR-0009 records the new scope/closure decision and declares `Supersedes: ADR-0005`.

## ADR immutability enforcement

The PR adds `.github/scripts/check-adr-immutability.py` plus executable tests and runs them through the always-required classifier/gate path.

For ADRs that are Accepted or Superseded on the PR base, CI rejects:

- body/decision edits;
- deletion/rename;
- invalid status changes;
- supersession without a new matching ADR in the same change.

The only permitted in-place transition for an Accepted ADR is metadata-only `Accepted -> Superseded` with a new ADR that points back via `Supersedes:`. Proposed ADRs remain editable until acceptance.

## Scope

No runtime behavior changes. This PR changes architecture/planning records and repository CI policy only. Work decomposition itself remains a subsequent implementation slice.

## Validation

- branch remains based on current `main`
- ADR-0005 net diff is supersession metadata only
- game/Engine planning now agree that the fixed reference challenge requires Arcogine-owned work decomposition before playable integration
- CI guard has dedicated positive/negative tests and runs in the required `gate` path
