### PR TITLE
docs(agents): define consistency finding lifecycle

### DIFF
--- a/.github/agents/consistency.agent.md
+++ b/.github/agents/consistency.agent.md
@@ -341,6 +341,41 @@ Status: OPEN | IN_FLIGHT
 
 Do not manufacture `Introduced by` attribution when history does not establish it.
 
+## Finding lifecycle and triage
+
+Detection is separate from disposition. A consistency run reports evidence-backed findings; it does not silently decide product/architecture intent or close its own findings.
+
+When a prior run or finding ledger is available, carry every unresolved finding forward and re-evaluate it against the new head even when its introducing commit predates the incremental baseline. Do not drop a finding merely because it falls outside the current compare range.
+
+After a run, each finding may be triaged to one of these dispositions:
+
+- `CONFIRMED` - the inconsistency is real and requires a correction or an explicit accepted-debt decision.
+- `FALSE_POSITIVE` - the comparison misunderstood authority, scope, lifecycle state, compatibility debt, or historical context; withdraw the finding and record the reason.
+- `DUPLICATE` - the same underlying inconsistency is already represented by another finding; identify the canonical finding.
+- `IN_FLIGHT` - an open PR contains a plausible correction, but `main` still contains the inconsistency.
+- `NEEDS_DECISION` - the evidence reveals a genuine ambiguity or incompatible intent that requires a product/architecture decision before one side can be called wrong.
+- `ACCEPTED_DEBT` - the inconsistency is real but has been explicitly accepted for later correction; preserve the rationale and any tracking reference.
+
+For a `CONFIRMED` finding, identify the correction owner using the existing resolution classes:
+
+```text
+CODE | CURRENT_DOCS | PLANNING | ADR | TEST/EVIDENCE | MULTIPLE
+```
+
+Do not equate an open corrective PR with resolution. `IN_FLIGHT` remains open until the correction reaches `main` (or the relevant authoritative branch for an explicitly scoped PR-forward review).
+
+On a later run, verify each carried finding and report one of:
+
+- `RESOLVED` - current authoritative evidence no longer contains the inconsistency.
+- `STILL_OPEN` - the inconsistency remains on the reviewed head.
+- `IN_FLIGHT` - the inconsistency remains on the reviewed head but an open PR plausibly corrects it.
+
+Only evidence on the reviewed head can establish `RESOLVED`; a PR title, body, review comment, or green CI result cannot do so by itself.
+
+Finding IDs such as `CONS-001` are run-local unless an external workflow deliberately persists them. If a finding becomes durable work, prefer the stable GitHub issue/PR identity as the long-lived reference rather than inventing a repository-global custom sequence. When comparing later runs, match findings by semantic subject and evidence, not by coincidental run-local number.
+
+If no prior report or ledger is available, do not invent historical disposition. State that carry-forward status could not be reconstructed and evaluate the current repository normally.
+
 ## Run report
 
 Start or end every review with a compact run summary:


### PR DESCRIPTION
## Summary

Defines the missing post-review lifecycle for repository Consistency findings without changing the agent's read-only-by-default posture.

- separate detection from human/project disposition
- require unresolved findings to carry forward across incremental review baselines
- define triage dispositions: `CONFIRMED`, `FALSE_POSITIVE`, `DUPLICATE`, `IN_FLIGHT`, `NEEDS_DECISION`, and `ACCEPTED_DEBT`
- retain the existing correction-owner classes (`CODE`, `CURRENT_DOCS`, `PLANNING`, `ADR`, `TEST/EVIDENCE`, `MULTIPLE`)
- define later verification outcomes: `RESOLVED`, `STILL_OPEN`, and `IN_FLIGHT`
- require evidence on the reviewed head before a finding can be called resolved; an open PR, PR description, or green CI is not sufficient
- clarify that `CONS-###` identifiers are run-local unless an external workflow persists them, and durable work should prefer GitHub issue/PR identity
- explicitly avoid inventing historical disposition when a prior report/ledger is unavailable

## Why

The first calibration run produced multiple `CONS-###` findings, but the original agent contract specified how to detect and report inconsistencies without specifying what happens next. That left remediation, false-positive calibration, carry-forward behavior, and closure verification undefined.

This PR closes that procedural gap while keeping consistency review diagnostic rather than self-remediating.

## Non-goals

- no repository-owned finding database or ledger
- no baseline persistence implementation
- no scheduled execution
- no automatic issue creation
- no automatic remediation or merge behavior

## Validation

- branch is based on current `main` and is not behind at PR creation time
- net diff is one repository-owned agent file
- existing authority, evidence, severity, false-positive, and resolution policies are preserved