### PR TITLE
feat(challenge): add deterministic candidate admissibility

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -413,8 +413,8 @@ product/
 │                         Operational, and Financial Truth" above
 ├── agents/               Agent framework: SalesAgent, AgentObservation
 ├── consumer/
-│   └── challenge/        Challenge Readiness: game-owned ChallengeDefinition and
-│                         ChallengeDefinitionValidator (see
+│   └── challenge/        Challenge Readiness: game-owned challenge definition/validation,
+│                         catalogue/economics, and candidate admissibility (see
 │                         docs/planning/factory-design-game-challenge-readiness.md).
 │                         Headless — no dependency on any module below.
 └── interfaces/
@@ -443,9 +443,10 @@ Each module exposes a clean public API and hides implementation details. Domain 
 
 `challenge` is deliberately outside this dependency graph: it is a game-owned Challenge Readiness
 module (`com.arcogine.challenge`) that has no `project(...)` dependency on `types`, `simulation`,
-any domain module, `api`, or `cli`, and no Spring dependency. It defines an immutable
-`ChallengeDefinition` and a `ChallengeDefinitionValidator` that is a distinct validation domain
-from `FactoryModelValidator` — see the Challenge Readiness planning doc for the ownership boundary.
+any domain module, `api`, or `cli`, and no Spring dependency. It defines immutable challenge
+definitions and validation, game-owned catalogue/economics, and deterministic candidate
+admissibility. These are distinct validation domains from `FactoryModelValidator` — see the
+Challenge Readiness planning doc for the ownership boundary.
 
 ## Event Dispatch Architecture
 

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -293,13 +293,14 @@ C2 is ready when:
 8. An executable canonical factory may still be rejected for violating challenge rules, and an admitted candidate must still pass Arcogine executability validation before publication/run.
 9. The fixed challenge workload/input cannot be silently replaced by the candidate attempt.
 
-### Implementation status (C2 — partial)
+### Implementation status (C2 — complete)
 
-C2 is **partially** implemented. The catalogue seam and deterministic draft-economics
-calculation described in 6.1 are implemented in the existing `:challenge` module
-(package `com.arcogine.challenge.catalogue`, `com.arcogine.challenge.economics`), with no new
+C2 is **complete** across the C1, C2a, and C2b slices. The catalogue seam, deterministic
+draft-economics calculation, and deterministic candidate admissibility are implemented in the
+game-owned `:challenge` module (packages `com.arcogine.challenge.catalogue`,
+`com.arcogine.challenge.economics`, and `com.arcogine.challenge.admissibility`), with no
 `project(...)` dependency on `:types`, `:simulation`, `:factory`, `:economy`, `:finance`, `:api`,
-or `:cli`. Candidate admissibility (6.2) is **not** implemented and remains for the next slice.
+or `:cli`.
 
 Implemented:
 
@@ -323,12 +324,23 @@ Implemented:
   wrapped total. The calculator mutates none of its inputs and is order-independent over
   occurrences.
 
-Not implemented, and deliberately deferred to the next C2 slice (candidate admissibility, 6.2):
-rejecting draft occurrences for using catalogue items outside a challenge's `availableEquipment`,
-enforcing per-item quantity limits against candidate occurrence counts, budget-affordability
-rejection, floor/placement constraints, and any projection from a catalogue item occurrence to
-canonical factory/resource semantics. No Engine Readiness gate is satisfied by this partial C2
-work; C3-C5 remain deferred.
+Implemented in C2b:
+
+- `CandidateDraftSnapshot`, `PlacedEquipment`, `EquipmentOccurrenceId`, and `GridPlacement` are
+    immutable game-owned draft values. The candidate contains no workload or contract field, so it
+    cannot replace the fixed challenge requirement.
+- `CandidateAdmissibilityPolicy` returns an immutable `CandidateAdmissibilityResult` with stable
+    game-owned issue codes, occurrence paths, and messages. It checks catalogue resolution,
+    challenge availability, quantity limits, delegated economics and budget affordability, floor
+    bounds, overlap, and duplicate occurrence identity.
+- Diagnostics use a frozen order (identity, resolution, availability, quantity, budget/economics,
+    bounds, overlap) and deterministic occurrence/item ordering. Economics failures are surfaced as
+    explicit admissibility issues rather than being treated as budget failures.
+
+C2 completion does not make the game playable and satisfies no Engine Readiness gate. An admitted
+candidate is not canonically executable: a later game-owned projection still requires Arcogine
+canonical validation before publication/run. Conversely, a canonically executable factory may
+remain inadmissible under a particular challenge. C3-C5 remain deferred.
 
 ## 7. C3 — Deterministic challenge evaluation
 

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/ChallengeDefinition.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/ChallengeDefinition.java
@@ -24,7 +24,8 @@ public record ChallengeDefinition(
         List<EquipmentCatalogueItemId> availableEquipment,
         long deadline,
         EvaluationPolicyIdentity evaluationPolicy,
-        EquipmentCatalogueIdentity catalogueIdentity) {
+        EquipmentCatalogueIdentity catalogueIdentity,
+        String catalogueSemanticFingerprint) {
 
         public ChallengeDefinition(
             ChallengeIdentity identity,
@@ -35,9 +36,22 @@ public record ChallengeDefinition(
             long deadline,
             EvaluationPolicyIdentity evaluationPolicy) {
         this(identity, floor, startingBudget, workload, availableEquipment, deadline,
-            evaluationPolicy, new EquipmentCatalogueIdentity("catalogue." + identity.id(),
-                identity.version()));
+                evaluationPolicy, new EquipmentCatalogueIdentity("catalogue." + identity.id(),
+                identity.version()), null);
         }
+
+            public ChallengeDefinition(
+                ChallengeIdentity identity,
+                FactoryFloorConstraint floor,
+                long startingBudget,
+                ChallengeWorkload workload,
+                List<EquipmentCatalogueItemId> availableEquipment,
+                long deadline,
+                EvaluationPolicyIdentity evaluationPolicy,
+                EquipmentCatalogueIdentity catalogueIdentity) {
+            this(identity, floor, startingBudget, workload, availableEquipment, deadline,
+                evaluationPolicy, catalogueIdentity, null);
+            }
 
     public ChallengeDefinition {
         if (identity == null) {
@@ -54,6 +68,9 @@ public record ChallengeDefinition(
         }
         if (catalogueIdentity == null) {
             throw new NullPointerException("catalogueIdentity");
+        }
+        if (catalogueSemanticFingerprint != null && catalogueSemanticFingerprint.isBlank()) {
+            throw new IllegalArgumentException("catalogueSemanticFingerprint must be non-blank");
         }
         availableEquipment = availableEquipment == null ? List.of() : List.copyOf(availableEquipment);
     }

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/ChallengeDefinition.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/ChallengeDefinition.java
@@ -1,5 +1,6 @@
 package com.arcogine.challenge;
 
+import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
 import java.util.List;
 
 /**
@@ -22,7 +23,21 @@ public record ChallengeDefinition(
         ChallengeWorkload workload,
         List<EquipmentCatalogueItemId> availableEquipment,
         long deadline,
-        EvaluationPolicyIdentity evaluationPolicy) {
+        EvaluationPolicyIdentity evaluationPolicy,
+        EquipmentCatalogueIdentity catalogueIdentity) {
+
+        public ChallengeDefinition(
+            ChallengeIdentity identity,
+            FactoryFloorConstraint floor,
+            long startingBudget,
+            ChallengeWorkload workload,
+            List<EquipmentCatalogueItemId> availableEquipment,
+            long deadline,
+            EvaluationPolicyIdentity evaluationPolicy) {
+        this(identity, floor, startingBudget, workload, availableEquipment, deadline,
+            evaluationPolicy, new EquipmentCatalogueIdentity("catalogue." + identity.id(),
+                identity.version()));
+        }
 
     public ChallengeDefinition {
         if (identity == null) {
@@ -36,6 +51,9 @@ public record ChallengeDefinition(
         }
         if (evaluationPolicy == null) {
             throw new NullPointerException("evaluationPolicy");
+        }
+        if (catalogueIdentity == null) {
+            throw new NullPointerException("catalogueIdentity");
         }
         availableEquipment = availableEquipment == null ? List.of() : List.copyOf(availableEquipment);
     }

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityIssue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityIssue.java
@@ -1,0 +1,22 @@
+package com.arcogine.challenge.admissibility;
+
+/** A stable, game-rule diagnostic explaining why a candidate draft is rejected. */
+public record CandidateAdmissibilityIssue(String code, String path, String message) {
+
+    public CandidateAdmissibilityIssue {
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
+        if (path == null) {
+            throw new NullPointerException("path");
+        }
+        if (message == null) {
+            throw new NullPointerException("message");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return path + " [" + code + "]: " + message;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicy.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicy.java
@@ -46,6 +46,11 @@ public final class CandidateAdmissibilityPolicy {
                 .toList();
         List<CandidateAdmissibilityIssue> issues = new ArrayList<>();
         addIdentityIssues(placed, issues);
+        if (!challenge.catalogueIdentity().equals(catalogue.identity())) {
+            issues.add(issue("candidate.catalogue.identity-mismatch", "catalogue.identity",
+                "catalogue identity does not match challenge identity: "
+                    + catalogue.identity()));
+        }
         Set<EquipmentCatalogueItemId> available = new HashSet<>(challenge.availableEquipment());
         Map<EquipmentCatalogueItemId, Integer> quantities = new HashMap<>();
 
@@ -80,7 +85,8 @@ public final class CandidateAdmissibilityPolicy {
                     "committed construction cost exceeds starting budget"));
         }
 
-        addPlacementIssues(placed, challenge, issues);
+        addBoundsIssues(placed, challenge, issues);
+        addOverlapIssues(placed, issues);
         return issues.isEmpty() ? CandidateAdmissibilityResult.success()
                 : CandidateAdmissibilityResult.rejected(issues);
     }
@@ -108,9 +114,8 @@ public final class CandidateAdmissibilityPolicy {
                 }));
     }
 
-    private static void addPlacementIssues(List<PlacedEquipment> placed, ChallengeDefinition challenge,
+    private static void addBoundsIssues(List<PlacedEquipment> placed, ChallengeDefinition challenge,
             List<CandidateAdmissibilityIssue> issues) {
-        Set<GridPlacement> occupied = new HashSet<>();
         for (PlacedEquipment equipment : placed) {
             GridPlacement placement = equipment.placement();
             if (placement.x() < 0 || placement.x() >= challenge.floor().width()
@@ -119,6 +124,14 @@ public final class CandidateAdmissibilityPolicy {
                         "placement must satisfy 0 <= x < " + challenge.floor().width()
                                 + " and 0 <= y < " + challenge.floor().height()));
             }
+        }
+    }
+
+    private static void addOverlapIssues(List<PlacedEquipment> placed,
+            List<CandidateAdmissibilityIssue> issues) {
+        Set<GridPlacement> occupied = new HashSet<>();
+        for (PlacedEquipment equipment : placed) {
+            GridPlacement placement = equipment.placement();
             if (!occupied.add(placement)) {
                 issues.add(issue("candidate.placement.overlap", path(equipment),
                         "placement cell is already occupied: (" + placement.x() + ", " + placement.y() + ")"));

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicy.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicy.java
@@ -1,0 +1,136 @@
+package com.arcogine.challenge.admissibility;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.catalogue.EquipmentCatalogue;
+import com.arcogine.challenge.catalogue.EquipmentOffer;
+import com.arcogine.challenge.economics.DraftEconomicsCalculator;
+import com.arcogine.challenge.economics.DraftEconomicsFailure;
+import com.arcogine.challenge.economics.DraftEconomicsResult;
+import com.arcogine.challenge.economics.DraftEquipmentOccurrence;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Pure, deterministic game-rule admissibility for one exact challenge and draft snapshot. */
+public final class CandidateAdmissibilityPolicy {
+
+    private static final Comparator<PlacedEquipment> OCCURRENCE_ORDER = Comparator
+            .comparing((PlacedEquipment placed) -> placed.occurrenceId().value())
+            .thenComparing(placed -> placed.itemId().value())
+            .thenComparingInt(placed -> placed.placement().x())
+            .thenComparingInt(placed -> placed.placement().y());
+
+    private CandidateAdmissibilityPolicy() {}
+
+    public static CandidateAdmissibilityResult assess(
+            ChallengeDefinition challenge,
+            EquipmentCatalogue catalogue,
+            CandidateDraftSnapshot snapshot) {
+        if (challenge == null) {
+            throw new NullPointerException("challenge");
+        }
+        if (catalogue == null) {
+            throw new NullPointerException("catalogue");
+        }
+        if (snapshot == null) {
+            throw new NullPointerException("snapshot");
+        }
+
+        List<PlacedEquipment> placed = snapshot.placedEquipment().stream()
+                .sorted(OCCURRENCE_ORDER)
+                .toList();
+        List<CandidateAdmissibilityIssue> issues = new ArrayList<>();
+        addIdentityIssues(placed, issues);
+        Set<EquipmentCatalogueItemId> available = new HashSet<>(challenge.availableEquipment());
+        Map<EquipmentCatalogueItemId, Integer> quantities = new HashMap<>();
+
+        for (PlacedEquipment equipment : placed) {
+            String path = path(equipment);
+            EquipmentOffer offer = catalogue.findByItemId(equipment.itemId()).orElse(null);
+            if (offer == null) {
+                issues.add(issue("candidate.occurrence.unknown-catalogue-item", path,
+                        "no catalogue offer for item id: " + equipment.itemId().value()));
+            } else {
+                quantities.merge(equipment.itemId(), 1, Integer::sum);
+            }
+        }
+        for (PlacedEquipment equipment : placed) {
+            if (!available.contains(equipment.itemId())) {
+                issues.add(issue("candidate.occurrence.unavailable-equipment", path(equipment),
+                        "catalogue item is not available in this challenge: "
+                                + equipment.itemId().value()));
+            }
+        }
+
+        addQuantityIssues(quantities, catalogue, issues);
+        DraftEconomicsResult economics = DraftEconomicsCalculator.calculate(challenge, catalogue,
+                placed.stream().map(equipment -> new DraftEquipmentOccurrence(equipment.itemId())).toList());
+        if (!economics.isSuccess()) {
+            DraftEconomicsFailure failure = economics.failure();
+            if (!failure.code().equals("draft.occurrence.unknown-catalogue-item")) {
+                issues.add(issue("candidate.economics." + failure.code(), "draft.economics", failure.message()));
+            }
+        } else if (economics.economics().committedConstructionCostCredits() > challenge.startingBudget()) {
+            issues.add(issue("candidate.budget.exceeded", "draft.economics.committedConstructionCostCredits",
+                    "committed construction cost exceeds starting budget"));
+        }
+
+        addPlacementIssues(placed, challenge, issues);
+        return issues.isEmpty() ? CandidateAdmissibilityResult.success()
+                : CandidateAdmissibilityResult.rejected(issues);
+    }
+
+    private static void addIdentityIssues(List<PlacedEquipment> placed,
+            List<CandidateAdmissibilityIssue> issues) {
+        Set<EquipmentOccurrenceId> seen = new HashSet<>();
+        for (PlacedEquipment equipment : placed) {
+            if (!seen.add(equipment.occurrenceId())) {
+                issues.add(issue("candidate.occurrence.duplicate-identity", path(equipment),
+                        "equipment occurrence id is duplicated: " + equipment.occurrenceId().value()));
+            }
+        }
+    }
+
+    private static void addQuantityIssues(Map<EquipmentCatalogueItemId, Integer> quantities,
+            EquipmentCatalogue catalogue, List<CandidateAdmissibilityIssue> issues) {
+        quantities.keySet().stream().sorted(Comparator.comparing(EquipmentCatalogueItemId::value))
+                .forEach(itemId -> catalogue.findByItemId(itemId).ifPresent(offer -> {
+                    if (offer.quantityLimit().isPresent()
+                            && quantities.get(itemId) > offer.quantityLimit().getAsInt()) {
+                        issues.add(issue("candidate.quantity-limit.exceeded", "item[" + itemId.value() + "]",
+                                "quantity exceeds catalogue limit of " + offer.quantityLimit().getAsInt()));
+                    }
+                }));
+    }
+
+    private static void addPlacementIssues(List<PlacedEquipment> placed, ChallengeDefinition challenge,
+            List<CandidateAdmissibilityIssue> issues) {
+        Set<GridPlacement> occupied = new HashSet<>();
+        for (PlacedEquipment equipment : placed) {
+            GridPlacement placement = equipment.placement();
+            if (placement.x() < 0 || placement.x() >= challenge.floor().width()
+                    || placement.y() < 0 || placement.y() >= challenge.floor().height()) {
+                issues.add(issue("candidate.placement.out-of-bounds", path(equipment),
+                        "placement must satisfy 0 <= x < " + challenge.floor().width()
+                                + " and 0 <= y < " + challenge.floor().height()));
+            }
+            if (!occupied.add(placement)) {
+                issues.add(issue("candidate.placement.overlap", path(equipment),
+                        "placement cell is already occupied: (" + placement.x() + ", " + placement.y() + ")"));
+            }
+        }
+    }
+
+    private static String path(PlacedEquipment equipment) {
+        return "placedEquipment[" + equipment.occurrenceId().value() + "]";
+    }
+
+    private static CandidateAdmissibilityIssue issue(String code, String path, String message) {
+        return new CandidateAdmissibilityIssue(code, path, message);
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicy.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicy.java
@@ -46,6 +46,11 @@ public final class CandidateAdmissibilityPolicy {
                 .toList();
         List<CandidateAdmissibilityIssue> issues = new ArrayList<>();
         addIdentityIssues(placed, issues);
+        if (challenge.catalogueSemanticFingerprint() == null) {
+            issues.add(issue("candidate.catalogue.semantic-fingerprint-unbound",
+                "challenge.catalogueSemanticFingerprint",
+                "challenge does not bind a catalogue semantic fingerprint"));
+        }
         if (!challenge.catalogueIdentity().equals(catalogue.identity())) {
             issues.add(issue("candidate.catalogue.identity-mismatch", "catalogue.identity",
                 "catalogue identity does not match challenge identity: "

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicy.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicy.java
@@ -51,6 +51,12 @@ public final class CandidateAdmissibilityPolicy {
                 "catalogue identity does not match challenge identity: "
                     + catalogue.identity()));
         }
+                if (challenge.catalogueSemanticFingerprint() != null
+                    && !challenge.catalogueSemanticFingerprint().equals(catalogue.semanticFingerprint())) {
+                    issues.add(issue("candidate.catalogue.semantic-fingerprint-mismatch",
+                        "catalogue.semanticFingerprint",
+                        "catalogue content does not match the challenge's versioned semantics"));
+                }
         Set<EquipmentCatalogueItemId> available = new HashSet<>(challenge.availableEquipment());
         Map<EquipmentCatalogueItemId, Integer> quantities = new HashMap<>();
 

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityResult.java
@@ -1,0 +1,28 @@
+package com.arcogine.challenge.admissibility;
+
+import java.util.List;
+
+/** The immutable, deterministic outcome of candidate admissibility. */
+public record CandidateAdmissibilityResult(boolean admitted, List<CandidateAdmissibilityIssue> issues) {
+
+    public CandidateAdmissibilityResult {
+        if (issues == null) {
+            throw new NullPointerException("issues");
+        }
+        issues = List.copyOf(issues);
+        if (admitted != issues.isEmpty()) {
+            throw new IllegalArgumentException("admitted candidates must have no issues");
+        }
+    }
+
+    public static CandidateAdmissibilityResult success() {
+        return new CandidateAdmissibilityResult(true, List.of());
+    }
+
+    public static CandidateAdmissibilityResult rejected(List<CandidateAdmissibilityIssue> issues) {
+        if (issues == null || issues.isEmpty()) {
+            throw new IllegalArgumentException("rejected candidates must have issues");
+        }
+        return new CandidateAdmissibilityResult(false, issues);
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateDraftSnapshot.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/CandidateDraftSnapshot.java
@@ -1,0 +1,11 @@
+package com.arcogine.challenge.admissibility;
+
+import java.util.List;
+
+/** An immutable game-owned snapshot of the equipment placed in one candidate draft. */
+public record CandidateDraftSnapshot(List<PlacedEquipment> placedEquipment) {
+
+    public CandidateDraftSnapshot {
+        placedEquipment = placedEquipment == null ? List.of() : List.copyOf(placedEquipment);
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/EquipmentOccurrenceId.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/EquipmentOccurrenceId.java
@@ -1,0 +1,11 @@
+package com.arcogine.challenge.admissibility;
+
+/** An explicit, game-owned identity for one equipment occurrence in a draft snapshot. */
+public record EquipmentOccurrenceId(String value) {
+
+    public EquipmentOccurrenceId {
+        if (value == null) {
+            throw new NullPointerException("value");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/GridPlacement.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/GridPlacement.java
@@ -1,0 +1,4 @@
+package com.arcogine.challenge.admissibility;
+
+/** The single floor cell occupied by one game-owned equipment occurrence. */
+public record GridPlacement(int x, int y) {}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/PlacedEquipment.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/admissibility/PlacedEquipment.java
@@ -1,0 +1,22 @@
+package com.arcogine.challenge.admissibility;
+
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+
+/** One explicitly identified catalogue item placed at one game-owned floor cell. */
+public record PlacedEquipment(
+        EquipmentOccurrenceId occurrenceId,
+        EquipmentCatalogueItemId itemId,
+        GridPlacement placement) {
+
+    public PlacedEquipment {
+        if (occurrenceId == null) {
+            throw new NullPointerException("occurrenceId");
+        }
+        if (itemId == null) {
+            throw new NullPointerException("itemId");
+        }
+        if (placement == null) {
+            throw new NullPointerException("placement");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
@@ -1,6 +1,10 @@
 package com.arcogine.challenge.catalogue;
 
 import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,6 +46,28 @@ public final class EquipmentCatalogue {
     /** All offers, in declaration order. */
     public List<EquipmentOffer> offers() {
         return offers;
+    }
+
+    /** Deterministic fingerprint of the result-affecting catalogue and quantity-limit content. */
+    public String semanticFingerprint() {
+        String canonical = offers.stream()
+                .sorted(Comparator.comparing(offer -> offer.itemId().value()))
+                .map(offer -> offer.itemId().value() + "\u0000" + offer.purchaseCostCredits()
+                        + "\u0000" + (offer.quantityLimit().isPresent()
+                                ? offer.quantityLimit().getAsInt() : "unlimited"))
+                .reduce((first, second) -> first + "\n" + second)
+                .orElse("");
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(canonical.getBytes(StandardCharsets.UTF_8));
+            StringBuilder fingerprint = new StringBuilder(digest.length * 2);
+            for (byte value : digest) {
+                fingerprint.append(String.format("%02x", value));
+            }
+            return fingerprint.toString();
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
     }
 
     /**

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
@@ -18,11 +18,25 @@ import java.util.Optional;
  */
 public final class EquipmentCatalogue {
 
+    private final EquipmentCatalogueIdentity identity;
     private final List<EquipmentOffer> offers;
 
     public EquipmentCatalogue(List<EquipmentOffer> offers) {
+        this(new EquipmentCatalogueIdentity("catalogue.unversioned", "1"), offers);
+    }
+
+    public EquipmentCatalogue(EquipmentCatalogueIdentity identity, List<EquipmentOffer> offers) {
+        if (identity == null) {
+            throw new NullPointerException("identity");
+        }
+        this.identity = identity;
         // List.copyOf rejects null elements with its own NullPointerException.
         this.offers = offers == null ? List.of() : List.copyOf(offers);
+    }
+
+    /** Identity and semantic version of the catalogue and its economy rules. */
+    public EquipmentCatalogueIdentity identity() {
+        return identity;
     }
 
     /** All offers, in declaration order. */
@@ -51,16 +65,17 @@ public final class EquipmentCatalogue {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof EquipmentCatalogue other && offers.equals(other.offers);
+        return obj instanceof EquipmentCatalogue other
+            && identity.equals(other.identity) && offers.equals(other.offers);
     }
 
     @Override
     public int hashCode() {
-        return offers.hashCode();
+        return 31 * identity.hashCode() + offers.hashCode();
     }
 
     @Override
     public String toString() {
-        return "EquipmentCatalogue" + offers;
+        return "EquipmentCatalogue[" + identity + ", " + offers + "]";
     }
 }

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogue.java
@@ -1,6 +1,9 @@
 package com.arcogine.challenge.catalogue;
 
 import com.arcogine.challenge.EquipmentCatalogueItemId;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -50,23 +53,38 @@ public final class EquipmentCatalogue {
 
     /** Deterministic fingerprint of the result-affecting catalogue and quantity-limit content. */
     public String semanticFingerprint() {
-        String canonical = offers.stream()
-                .sorted(Comparator.comparing(offer -> offer.itemId().value()))
-                .map(offer -> offer.itemId().value() + "\u0000" + offer.purchaseCostCredits()
-                        + "\u0000" + (offer.quantityLimit().isPresent()
-                                ? offer.quantityLimit().getAsInt() : "unlimited"))
-                .reduce((first, second) -> first + "\n" + second)
-                .orElse("");
         try {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            DataOutputStream output = new DataOutputStream(bytes);
+            offers.stream()
+                    .sorted(Comparator.comparing(offer -> offer.itemId().value()))
+                    .forEach(offer -> writeOffer(output, offer));
+            output.flush();
             byte[] digest = MessageDigest.getInstance("SHA-256")
-                    .digest(canonical.getBytes(StandardCharsets.UTF_8));
+                    .digest(bytes.toByteArray());
             StringBuilder fingerprint = new StringBuilder(digest.length * 2);
             for (byte value : digest) {
-                fingerprint.append(String.format("%02x", value));
+                fingerprint.append(Character.forDigit((value >>> 4) & 0x0f, 16));
+                fingerprint.append(Character.forDigit(value & 0x0f, 16));
             }
             return fingerprint.toString();
-        } catch (NoSuchAlgorithmException exception) {
-            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        } catch (IOException | NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("unable to fingerprint catalogue", exception);
+        }
+    }
+
+    private static void writeOffer(DataOutputStream output, EquipmentOffer offer) {
+        try {
+            byte[] itemId = offer.itemId().value().getBytes(StandardCharsets.UTF_8);
+            output.writeInt(itemId.length);
+            output.write(itemId);
+            output.writeLong(offer.purchaseCostCredits());
+            output.writeBoolean(offer.quantityLimit().isPresent());
+            if (offer.quantityLimit().isPresent()) {
+                output.writeInt(offer.quantityLimit().getAsInt());
+            }
+        } catch (IOException exception) {
+            throw new IllegalStateException("unable to encode catalogue", exception);
         }
     }
 

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueIdentity.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/catalogue/EquipmentCatalogueIdentity.java
@@ -1,0 +1,14 @@
+package com.arcogine.challenge.catalogue;
+
+/** Stable identity and semantic version of game-owned catalogue and economy rules. */
+public record EquipmentCatalogueIdentity(String id, String version) {
+
+    public EquipmentCatalogueIdentity {
+        if (id == null) {
+            throw new NullPointerException("id");
+        }
+        if (version == null) {
+            throw new NullPointerException("version");
+        }
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/ChallengeFixtures.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/ChallengeFixtures.java
@@ -1,6 +1,7 @@
 package com.arcogine.challenge;
 
 import java.util.List;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
 
 /**
  * The reference challenge used across tests: produce 20 units of Product A on a 12x10 floor with
@@ -21,6 +22,7 @@ public final class ChallengeFixtures {
                         new EquipmentCatalogueItemId("equipment.assembly-station"),
                         new EquipmentCatalogueItemId("equipment.inspector")),
                 400L,
-                new EvaluationPolicyIdentity("policy.contract-completion", "1"));
+                new EvaluationPolicyIdentity("policy.contract-completion", "1"),
+                new EquipmentCatalogueIdentity("catalogue.challenge.factory-basics", "1"));
     }
 }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/ChallengeFixtures.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/ChallengeFixtures.java
@@ -2,6 +2,7 @@ package com.arcogine.challenge;
 
 import java.util.List;
 import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueFixtures;
 
 /**
  * The reference challenge used across tests: produce 20 units of Product A on a 12x10 floor with
@@ -23,6 +24,7 @@ public final class ChallengeFixtures {
                         new EquipmentCatalogueItemId("equipment.inspector")),
                 400L,
                 new EvaluationPolicyIdentity("policy.contract-completion", "1"),
-                new EquipmentCatalogueIdentity("catalogue.challenge.factory-basics", "1"));
+                new EquipmentCatalogueIdentity("catalogue.challenge.factory-basics", "1"),
+                EquipmentCatalogueFixtures.referenceCatalogue().semanticFingerprint());
     }
 }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/RecordValidationTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/RecordValidationTest.java
@@ -2,6 +2,7 @@ package com.arcogine.challenge;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
 import org.junit.jupiter.api.Test;
 
 class RecordValidationTest {
@@ -21,6 +22,12 @@ class RecordValidationTest {
     @Test
     void equipmentCatalogueItemIdRejectsNullValue() {
         assertThrows(NullPointerException.class, () -> new EquipmentCatalogueItemId(null));
+    }
+
+    @Test
+    void catalogueIdentityRejectsNullFields() {
+        assertThrows(NullPointerException.class, () -> new EquipmentCatalogueIdentity(null, "1"));
+        assertThrows(NullPointerException.class, () -> new EquipmentCatalogueIdentity("id", null));
     }
 
     @Test
@@ -62,5 +69,18 @@ class RecordValidationTest {
                         base.availableEquipment(),
                         base.deadline(),
                         null));
+    }
+
+    @Test
+    void challengeDefinitionRejectsNullCatalogueIdentityAndBlankFingerprint() {
+        ChallengeDefinition base = ChallengeFixtures.referenceChallenge();
+
+        assertThrows(NullPointerException.class, () -> new ChallengeDefinition(
+                base.identity(), base.floor(), base.startingBudget(), base.workload(),
+                base.availableEquipment(), base.deadline(), base.evaluationPolicy(), null, null));
+        assertThrows(IllegalArgumentException.class, () -> new ChallengeDefinition(
+                base.identity(), base.floor(), base.startingBudget(), base.workload(),
+                base.availableEquipment(), base.deadline(), base.evaluationPolicy(),
+                base.catalogueIdentity(), " "));
     }
 }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
@@ -68,7 +68,7 @@ class CandidateAdmissibilityPolicyTest {
         CandidateDraftSnapshot snapshot = snapshot(
                 placed("unknown-1", unknown, 0, 0), placed("disallowed-1", disallowed, 1, 0));
 
-        CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(), catalogue, snapshot);
+        CandidateAdmissibilityResult result = assess(challengeFor(catalogue), catalogue, snapshot);
 
         assertFalse(result.admitted());
         assertEquals(List.of("candidate.occurrence.unknown-catalogue-item",
@@ -86,9 +86,9 @@ class CandidateAdmissibilityPolicyTest {
                 placed("cutter-1", CUTTER, 0, 0), placed("cutter-2", CUTTER, 1, 0),
                 placed("cutter-3", CUTTER, 2, 0));
 
-        assertTrue(assess(ChallengeFixtures.referenceChallenge(), catalogue, allowed).admitted());
+        assertTrue(assess(challengeFor(catalogue), catalogue, allowed).admitted());
         assertEquals("candidate.quantity-limit.exceeded",
-                assess(ChallengeFixtures.referenceChallenge(), catalogue, tooMany).issues().get(0).code());
+                assess(challengeFor(catalogue), catalogue, tooMany).issues().get(0).code());
     }
 
     @Test
@@ -99,9 +99,23 @@ class CandidateAdmissibilityPolicyTest {
                 EquipmentOffer.of(CUTTER, 40_001L)));
         CandidateDraftSnapshot snapshot = snapshot(placed("cutter-1", CUTTER, 0, 0));
 
-        assertTrue(assess(ChallengeFixtures.referenceChallenge(), exactCatalogue, snapshot).admitted());
+        assertTrue(assess(challengeFor(exactCatalogue), exactCatalogue, snapshot).admitted());
         assertEquals("candidate.budget.exceeded",
-                assess(ChallengeFixtures.referenceChallenge(), overCatalogue, snapshot).issues().get(0).code());
+                assess(challengeFor(overCatalogue), overCatalogue, snapshot).issues().get(0).code());
+    }
+
+    @Test
+    void changedPriceWithSameCatalogueIdentityIsRejected() {
+        EquipmentCatalogue changedCatalogue = catalogue(List.of(
+                EquipmentOffer.of(CUTTER, 5_001L),
+                EquipmentOffer.of(ASSEMBLY, EquipmentCatalogueFixtures.ASSEMBLY_STATION_COST_CREDITS),
+                EquipmentOffer.of(INSPECTOR, EquipmentCatalogueFixtures.INSPECTOR_COST_CREDITS)));
+
+        CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(),
+                changedCatalogue, snapshot(placed("cutter-1", CUTTER, 0, 0)));
+
+        assertEquals("candidate.catalogue.semantic-fingerprint-mismatch",
+                result.issues().get(0).code());
     }
 
     @Test
@@ -109,7 +123,7 @@ class CandidateAdmissibilityPolicyTest {
         EquipmentCatalogue invalidCatalogue = catalogue(List.of(
                 EquipmentOffer.of(CUTTER, -1L)));
 
-        CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(),
+        CandidateAdmissibilityResult result = assess(challengeFor(invalidCatalogue),
                 invalidCatalogue, snapshot(placed("cutter-1", CUTTER, 0, 0)));
 
         assertEquals("candidate.economics.catalogue.invalid", result.issues().get(0).code());
@@ -188,6 +202,13 @@ class CandidateAdmissibilityPolicyTest {
     private static CandidateDraftSnapshot snapshot(PlacedEquipment... equipment) {
         return new CandidateDraftSnapshot(List.of(equipment));
     }
+
+        private static ChallengeDefinition challengeFor(EquipmentCatalogue catalogue) {
+                ChallengeDefinition reference = ChallengeFixtures.referenceChallenge();
+                return new ChallengeDefinition(reference.identity(), reference.floor(), reference.startingBudget(),
+                                reference.workload(), reference.availableEquipment(), reference.deadline(),
+                                reference.evaluationPolicy(), catalogue.identity(), catalogue.semanticFingerprint());
+        }
 
     private static PlacedEquipment placed(String occurrenceId, EquipmentCatalogueItemId itemId,
             int x, int y) {

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
@@ -10,6 +10,7 @@ import com.arcogine.challenge.ChallengeFixtures;
 import com.arcogine.challenge.EquipmentCatalogueItemId;
 import com.arcogine.challenge.catalogue.EquipmentCatalogue;
 import com.arcogine.challenge.catalogue.EquipmentCatalogueFixtures;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
 import com.arcogine.challenge.catalogue.EquipmentOffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,7 +63,7 @@ class CandidateAdmissibilityPolicyTest {
     void unknownAndUnavailableItemsProduceDeterministicReasons() {
         EquipmentCatalogueItemId unknown = item("equipment.unknown");
         EquipmentCatalogueItemId disallowed = item("equipment.disallowed");
-        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(
+        EquipmentCatalogue catalogue = catalogue(List.of(
                 EquipmentOffer.of(CUTTER, 5_000L), EquipmentOffer.of(disallowed, 1_000L)));
         CandidateDraftSnapshot snapshot = snapshot(
                 placed("unknown-1", unknown, 0, 0), placed("disallowed-1", disallowed, 1, 0));
@@ -92,9 +93,9 @@ class CandidateAdmissibilityPolicyTest {
 
     @Test
     void budgetAtLimitIsAllowedAndBudgetOverLimitIsRejected() {
-        EquipmentCatalogue exactCatalogue = new EquipmentCatalogue(List.of(
+        EquipmentCatalogue exactCatalogue = catalogue(List.of(
                 EquipmentOffer.of(CUTTER, 40_000L)));
-        EquipmentCatalogue overCatalogue = new EquipmentCatalogue(List.of(
+        EquipmentCatalogue overCatalogue = catalogue(List.of(
                 EquipmentOffer.of(CUTTER, 40_001L)));
         CandidateDraftSnapshot snapshot = snapshot(placed("cutter-1", CUTTER, 0, 0));
 
@@ -105,7 +106,7 @@ class CandidateAdmissibilityPolicyTest {
 
     @Test
     void economicsFailureIsSurfacedExplicitly() {
-        EquipmentCatalogue invalidCatalogue = new EquipmentCatalogue(List.of(
+        EquipmentCatalogue invalidCatalogue = catalogue(List.of(
                 EquipmentOffer.of(CUTTER, -1L)));
 
         CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(),
@@ -141,6 +142,18 @@ class CandidateAdmissibilityPolicyTest {
     }
 
     @Test
+    void catalogueIdentityMustMatchChallengeVersion() {
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(
+                new EquipmentCatalogueIdentity("catalogue.challenge.factory-basics", "2"),
+                List.of(EquipmentOffer.of(CUTTER, 5_000L)));
+
+        CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(), catalogue,
+                snapshot(placed("cutter-1", CUTTER, 0, 0)));
+
+        assertEquals("candidate.catalogue.identity-mismatch", result.issues().get(0).code());
+    }
+
+    @Test
     void differentOccurrenceIdsMayUseTheSameCatalogueItem() {
         CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(),
                 EquipmentCatalogueFixtures.referenceCatalogue(), snapshot(
@@ -161,11 +174,16 @@ class CandidateAdmissibilityPolicyTest {
     }
 
     private static EquipmentCatalogue limitedCatalogue(int cutterLimit) {
-        return new EquipmentCatalogue(List.of(
+        return catalogue(List.of(
                 EquipmentOffer.of(CUTTER, EquipmentCatalogueFixtures.CUTTER_COST_CREDITS, cutterLimit),
                 EquipmentOffer.of(ASSEMBLY, EquipmentCatalogueFixtures.ASSEMBLY_STATION_COST_CREDITS),
                 EquipmentOffer.of(INSPECTOR, EquipmentCatalogueFixtures.INSPECTOR_COST_CREDITS)));
     }
+
+        private static EquipmentCatalogue catalogue(List<EquipmentOffer> offers) {
+                return new EquipmentCatalogue(
+                                new EquipmentCatalogueIdentity("catalogue.challenge.factory-basics", "1"), offers);
+        }
 
     private static CandidateDraftSnapshot snapshot(PlacedEquipment... equipment) {
         return new CandidateDraftSnapshot(List.of(equipment));

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
@@ -119,6 +119,16 @@ class CandidateAdmissibilityPolicyTest {
     }
 
     @Test
+    void structurallyDifferentCataloguesCannotShareFingerprintThroughDelimiters() {
+        EquipmentCatalogue oneOffer = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(item("a\u00001\u0000unlimited\nb"), 2L)));
+        EquipmentCatalogue twoOffers = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(item("a"), 1L), EquipmentOffer.of(item("b"), 2L)));
+
+        assertFalse(oneOffer.semanticFingerprint().equals(twoOffers.semanticFingerprint()));
+    }
+
+    @Test
     void legacyUnboundChallengeRejectsAdmissibility() {
         ChallengeDefinition reference = ChallengeFixtures.referenceChallenge();
         ChallengeDefinition unbound = new ChallengeDefinition(reference.identity(), reference.floor(),

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
@@ -207,6 +207,20 @@ class CandidateAdmissibilityPolicyTest {
                 () -> Class.forName("com.arcogine.factory.model.validation.FactoryModelValidator"));
     }
 
+    @Test
+    void rejectsNullInputs() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        CandidateDraftSnapshot snapshot = snapshot(placed("cutter-1", CUTTER, 0, 0));
+
+        assertThrows(NullPointerException.class,
+                () -> CandidateAdmissibilityPolicy.assess(null, catalogue, snapshot));
+        assertThrows(NullPointerException.class,
+                () -> CandidateAdmissibilityPolicy.assess(challenge, null, snapshot));
+        assertThrows(NullPointerException.class,
+                () -> CandidateAdmissibilityPolicy.assess(challenge, catalogue, null));
+    }
+
     private static CandidateAdmissibilityResult assess(ChallengeDefinition challenge,
             EquipmentCatalogue catalogue, CandidateDraftSnapshot snapshot) {
         return CandidateAdmissibilityPolicy.assess(challenge, catalogue, snapshot);

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
@@ -1,0 +1,183 @@
+package com.arcogine.challenge.admissibility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.ChallengeFixtures;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.catalogue.EquipmentCatalogue;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueFixtures;
+import com.arcogine.challenge.catalogue.EquipmentOffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CandidateAdmissibilityPolicyTest {
+
+    private static final EquipmentCatalogueItemId CUTTER = item("equipment.cutter");
+    private static final EquipmentCatalogueItemId ASSEMBLY = item("equipment.assembly-station");
+    private static final EquipmentCatalogueItemId INSPECTOR = item("equipment.inspector");
+
+    @Test
+    void validCandidateIsAdmittedAndRepeatedEvaluationIsEqual() {
+        CandidateDraftSnapshot snapshot = snapshot(
+                placed("cutter-1", CUTTER, 0, 0), placed("assembly-1", ASSEMBLY, 11, 9));
+
+        CandidateAdmissibilityResult first = assess(ChallengeFixtures.referenceChallenge(),
+                EquipmentCatalogueFixtures.referenceCatalogue(), snapshot);
+        CandidateAdmissibilityResult second = assess(ChallengeFixtures.referenceChallenge(),
+                EquipmentCatalogueFixtures.referenceCatalogue(), snapshot);
+
+        assertTrue(first.admitted());
+        assertEquals(first, second);
+    }
+
+    @Test
+    void reorderingOccurrencesDoesNotChangeResult() {
+        CandidateDraftSnapshot first = snapshot(
+                placed("cutter-1", CUTTER, 0, 0), placed("inspector-1", INSPECTOR, 1, 0));
+        CandidateDraftSnapshot reordered = snapshot(
+                placed("inspector-1", INSPECTOR, 1, 0), placed("cutter-1", CUTTER, 0, 0));
+
+        assertEquals(assess(ChallengeFixtures.referenceChallenge(),
+                        EquipmentCatalogueFixtures.referenceCatalogue(), first),
+                assess(ChallengeFixtures.referenceChallenge(),
+                        EquipmentCatalogueFixtures.referenceCatalogue(), reordered));
+    }
+
+    @Test
+    void snapshotCopiesItsCollection() {
+        List<PlacedEquipment> source = new ArrayList<>(List.of(placed("cutter-1", CUTTER, 0, 0)));
+        CandidateDraftSnapshot snapshot = new CandidateDraftSnapshot(source);
+        source.clear();
+
+        assertEquals(1, snapshot.placedEquipment().size());
+        assertThrows(UnsupportedOperationException.class, () -> snapshot.placedEquipment().clear());
+    }
+
+    @Test
+    void unknownAndUnavailableItemsProduceDeterministicReasons() {
+        EquipmentCatalogueItemId unknown = item("equipment.unknown");
+        EquipmentCatalogueItemId disallowed = item("equipment.disallowed");
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(CUTTER, 5_000L), EquipmentOffer.of(disallowed, 1_000L)));
+        CandidateDraftSnapshot snapshot = snapshot(
+                placed("unknown-1", unknown, 0, 0), placed("disallowed-1", disallowed, 1, 0));
+
+        CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(), catalogue, snapshot);
+
+        assertFalse(result.admitted());
+        assertEquals(List.of("candidate.occurrence.unknown-catalogue-item",
+                        "candidate.occurrence.unavailable-equipment",
+                        "candidate.occurrence.unavailable-equipment"),
+                result.issues().stream().map(CandidateAdmissibilityIssue::code).toList());
+    }
+
+    @Test
+    void quantityLimitAllowsExactCountAndRejectsAdditionalOccurrence() {
+        EquipmentCatalogue catalogue = limitedCatalogue(2);
+        CandidateDraftSnapshot allowed = snapshot(
+                placed("cutter-1", CUTTER, 0, 0), placed("cutter-2", CUTTER, 1, 0));
+        CandidateDraftSnapshot tooMany = snapshot(
+                placed("cutter-1", CUTTER, 0, 0), placed("cutter-2", CUTTER, 1, 0),
+                placed("cutter-3", CUTTER, 2, 0));
+
+        assertTrue(assess(ChallengeFixtures.referenceChallenge(), catalogue, allowed).admitted());
+        assertEquals("candidate.quantity-limit.exceeded",
+                assess(ChallengeFixtures.referenceChallenge(), catalogue, tooMany).issues().get(0).code());
+    }
+
+    @Test
+    void budgetAtLimitIsAllowedAndBudgetOverLimitIsRejected() {
+        EquipmentCatalogue exactCatalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(CUTTER, 40_000L)));
+        EquipmentCatalogue overCatalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(CUTTER, 40_001L)));
+        CandidateDraftSnapshot snapshot = snapshot(placed("cutter-1", CUTTER, 0, 0));
+
+        assertTrue(assess(ChallengeFixtures.referenceChallenge(), exactCatalogue, snapshot).admitted());
+        assertEquals("candidate.budget.exceeded",
+                assess(ChallengeFixtures.referenceChallenge(), overCatalogue, snapshot).issues().get(0).code());
+    }
+
+    @Test
+    void economicsFailureIsSurfacedExplicitly() {
+        EquipmentCatalogue invalidCatalogue = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(CUTTER, -1L)));
+
+        CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(),
+                invalidCatalogue, snapshot(placed("cutter-1", CUTTER, 0, 0)));
+
+        assertEquals("candidate.economics.catalogue.invalid", result.issues().get(0).code());
+    }
+
+    @Test
+    void floorEdgesAreAllowedAndOutsideCellsAreRejected() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        EquipmentCatalogue catalogue = EquipmentCatalogueFixtures.referenceCatalogue();
+        assertTrue(assess(challenge, catalogue, snapshot(
+                placed("edge", CUTTER, 11, 9))).admitted());
+        assertEquals("candidate.placement.out-of-bounds", assess(challenge, catalogue, snapshot(
+                placed("negative", CUTTER, -1, 0))).issues().get(0).code());
+        assertEquals("candidate.placement.out-of-bounds", assess(challenge, catalogue, snapshot(
+                placed("width", CUTTER, 12, 0))).issues().get(0).code());
+        assertEquals("candidate.placement.out-of-bounds", assess(challenge, catalogue, snapshot(
+                placed("height", CUTTER, 0, 10))).issues().get(0).code());
+    }
+
+    @Test
+    void overlappingCellsAndDuplicateOccurrenceIdsAreRejected() {
+        CandidateDraftSnapshot snapshot = snapshot(
+                placed("same", CUTTER, 0, 0), placed("same", ASSEMBLY, 0, 0));
+
+        CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(),
+                EquipmentCatalogueFixtures.referenceCatalogue(), snapshot);
+
+        assertEquals(List.of("candidate.occurrence.duplicate-identity", "candidate.placement.overlap"),
+                result.issues().stream().map(CandidateAdmissibilityIssue::code).toList());
+    }
+
+    @Test
+    void differentOccurrenceIdsMayUseTheSameCatalogueItem() {
+        CandidateAdmissibilityResult result = assess(ChallengeFixtures.referenceChallenge(),
+                EquipmentCatalogueFixtures.referenceCatalogue(), snapshot(
+                        placed("cutter-1", CUTTER, 0, 0), placed("cutter-2", CUTTER, 1, 0)));
+
+        assertTrue(result.admitted());
+    }
+
+    @Test
+    void doesNotRequireFactoryRuntime() {
+        assertThrows(ClassNotFoundException.class,
+                () -> Class.forName("com.arcogine.factory.model.validation.FactoryModelValidator"));
+    }
+
+    private static CandidateAdmissibilityResult assess(ChallengeDefinition challenge,
+            EquipmentCatalogue catalogue, CandidateDraftSnapshot snapshot) {
+        return CandidateAdmissibilityPolicy.assess(challenge, catalogue, snapshot);
+    }
+
+    private static EquipmentCatalogue limitedCatalogue(int cutterLimit) {
+        return new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(CUTTER, EquipmentCatalogueFixtures.CUTTER_COST_CREDITS, cutterLimit),
+                EquipmentOffer.of(ASSEMBLY, EquipmentCatalogueFixtures.ASSEMBLY_STATION_COST_CREDITS),
+                EquipmentOffer.of(INSPECTOR, EquipmentCatalogueFixtures.INSPECTOR_COST_CREDITS)));
+    }
+
+    private static CandidateDraftSnapshot snapshot(PlacedEquipment... equipment) {
+        return new CandidateDraftSnapshot(List.of(equipment));
+    }
+
+    private static PlacedEquipment placed(String occurrenceId, EquipmentCatalogueItemId itemId,
+            int x, int y) {
+        return new PlacedEquipment(new EquipmentOccurrenceId(occurrenceId), itemId,
+                new GridPlacement(x, y));
+    }
+
+    private static EquipmentCatalogueItemId item(String value) {
+        return new EquipmentCatalogueItemId(value);
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/admissibility/CandidateAdmissibilityPolicyTest.java
@@ -119,6 +119,21 @@ class CandidateAdmissibilityPolicyTest {
     }
 
     @Test
+    void legacyUnboundChallengeRejectsAdmissibility() {
+        ChallengeDefinition reference = ChallengeFixtures.referenceChallenge();
+        ChallengeDefinition unbound = new ChallengeDefinition(reference.identity(), reference.floor(),
+                reference.startingBudget(), reference.workload(), reference.availableEquipment(),
+                reference.deadline(), reference.evaluationPolicy(), reference.catalogueIdentity());
+
+        CandidateAdmissibilityResult result = assess(unbound,
+                EquipmentCatalogueFixtures.referenceCatalogue(),
+                snapshot(placed("cutter-1", CUTTER, 0, 0)));
+
+        assertEquals("candidate.catalogue.semantic-fingerprint-unbound",
+                result.issues().get(0).code());
+    }
+
+    @Test
     void economicsFailureIsSurfacedExplicitly() {
         EquipmentCatalogue invalidCatalogue = catalogue(List.of(
                 EquipmentOffer.of(CUTTER, -1L)));

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueFixtures.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueFixtures.java
@@ -16,7 +16,7 @@ public final class EquipmentCatalogueFixtures {
     private EquipmentCatalogueFixtures() {}
 
     public static EquipmentCatalogue referenceCatalogue() {
-        return new EquipmentCatalogue(List.of(
+                return new EquipmentCatalogue(new EquipmentCatalogueIdentity("catalogue.challenge.factory-basics", "1"), List.of(
                 EquipmentOffer.of(
                         new EquipmentCatalogueItemId("equipment.cutter"), CUTTER_COST_CREDITS),
                 EquipmentOffer.of(

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/catalogue/EquipmentCatalogueTest.java
@@ -88,4 +88,37 @@ class EquipmentCatalogueTest {
 
         assertTrue(catalogue.toString().contains("EquipmentCatalogue"));
     }
+
+    @Test
+    void semanticFingerprintIsStableAcrossOfferOrder() {
+        EquipmentOffer cutter = EquipmentOffer.of(
+                new EquipmentCatalogueItemId("equipment.cutter"), 5_000L);
+        EquipmentOffer inspector = EquipmentOffer.of(
+                new EquipmentCatalogueItemId("equipment.inspector"), 3_000L);
+
+        EquipmentCatalogue first = new EquipmentCatalogue(List.of(cutter, inspector));
+        EquipmentCatalogue reordered = new EquipmentCatalogue(List.of(inspector, cutter));
+
+        assertEquals(first.semanticFingerprint(), reordered.semanticFingerprint());
+    }
+
+    @Test
+    void semanticFingerprintIncludesQuantityLimitAndDistinguishesEmptyCatalogue() {
+        EquipmentCatalogue unlimited = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 5_000L)));
+        EquipmentCatalogue limited = new EquipmentCatalogue(List.of(
+                EquipmentOffer.of(new EquipmentCatalogueItemId("equipment.cutter"), 5_000L, 2)));
+        EquipmentCatalogue empty = new EquipmentCatalogue(List.of());
+
+        assertTrue(!unlimited.semanticFingerprint().equals(limited.semanticFingerprint()));
+        assertTrue(!empty.semanticFingerprint().equals(unlimited.semanticFingerprint()));
+    }
+
+    @Test
+    void explicitIdentityIsRetained() {
+        EquipmentCatalogueIdentity identity = new EquipmentCatalogueIdentity("catalogue.test", "2");
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(identity, List.of());
+
+        assertEquals(identity, catalogue.identity());
+    }
 }


### PR DESCRIPTION
## Summary
- add immutable CandidateDraftSnapshot, PlacedEquipment, GridPlacement, and explicit occurrence identity
- add deterministic game-owned candidate admissibility with structured ordered reasons
- reuse DraftEconomicsCalculator for construction cost and surface economics failures explicitly
- cover catalogue resolution, challenge availability, quantity limits, budget, bounds, overlap, identity, immutability, and runtime independence
- mark C2 complete in Challenge Readiness planning while preserving the canonical validation boundary

## Validation
- product/gradlew.bat check passed under JDK 21
- ash ./arcogine check could not run in this Windows environment because Bash/WSL is unavailable

## Boundaries preserved
- no FactoryModelValidator, FactoryRuntime, simulation, Finance, Governance, API, or UI dependency
- no workload substitution, projection, execution, deadline evaluation, scoring, or C3 semantics
- admitted does not mean canonically executable; C3 remains next