### PR TITLE
docs: establish ADR-0008 controlled revision identity and lineage

### DIFF
--- a/docs/architecture/decisions/0008-controlled-revision-identity-and-lineage.md
+++ b/docs/architecture/decisions/0008-controlled-revision-identity-and-lineage.md
@@ -1,0 +1,421 @@
+# ADR-0008: Controlled revision identity and lineage
+
+Status: Accepted
+Date: 2026-08-28
+
+## Context
+
+[ADR-0004](0004-model-identity-revision-lineage-and-external-change-control.md) established that semantic identity and controlled revision identity are different concerns. [ADR-0006](0006-durable-semantic-fingerprint-contract.md) then established the first durable semantic fingerprint contract, `factory-model:v1`.
+
+The remaining Governance G1 identity gap is historical identity: Arcogine needs to distinguish one controlled occurrence of semantic content from another even when the semantic content is equal.
+
+For example, the following history is valid and must remain representable:
+
+```text
+Revision A    fingerprint F1
+    |
+    v
+Revision B    fingerprint F2
+    |
+    v
+Revision C    fingerprint F1
+```
+
+A and C identify equal semantic content under the same fingerprint policy, but they are not the same historical revision. C may be a rollback, re-publication, re-application, or another later controlled occurrence. Reusing A's identity for C would erase the fact that B existed between them and would make later authorization, conformance, deployment, audit, and evidence records ambiguous.
+
+The required invariant is therefore:
+
+> **Durable semantic identity is not historical revision identity.**
+
+The revision identifier must also remain independent of human version labels, authorship, timestamps, parents, external workflow identifiers, approval state, deployment state, and any particular persistence technology. Those facts may be associated with a revision, but none of them defines which historical occurrence the revision is.
+
+At the same time, the first controlled-revision contract should not prematurely implement a source-control system. Arcogine does not yet require branch objects, merge commits, rebase/cherry-pick semantics, generic patching, or a revision DAG with arbitrary parent cardinality. The contract should preserve paths to those capabilities without making them part of G1.2.
+
+Controlled revision identity and lineage are also a Governance and GRC substrate rather than a compliance result. They make exact historical configuration states addressable by later ChangeSets, requirements, conformance evaluations, evidence uses, authorization records, deployments, exceptions, and audit projections. A revision's existence does not itself mean that the revision was approved, deployed, conformant, certified, or compliant with any external framework.
+
+Related documents:
+
+- [ADR-0004: Model identity, revision lineage, and external change control](0004-model-identity-revision-lineage-and-external-change-control.md)
+- [ADR-0006: Durable semantic fingerprint contract](0006-durable-semantic-fingerprint-contract.md)
+- [Governance and Conformance Architecture](../governance-conformance.md)
+- [Governance and Conformance Capability Plan](../../planning/governance-conformance-capability.md)
+
+## Decision
+
+### `ControlledRevisionId` is opaque historical identity
+
+A `ControlledRevisionId` identifies exactly one immutable controlled historical occurrence.
+
+It is not derived from, and must not encode semantic meaning from:
+
+- `ModelFingerprint`;
+- a human version/revision label;
+- parent revision identity;
+- author or recorder identity;
+- creation, publication, recording, or deployment time;
+- an external issue, ticket, change-request, or workflow identifier;
+- approval, authorization, conformance, or deployment state.
+
+Equality of `ControlledRevisionId` means equality of the historical revision record. The same identifier must never be rebound to a different fingerprint, lineage, or required provenance.
+
+### The initial identifier mechanism is UUID version 4
+
+The first `ControlledRevisionId` representation is an RFC 9562 UUID version 4.
+
+UUIDv4 is chosen because it is standardized, cross-language, independently generatable, and carries no model, lineage, actor, workflow, or clock semantics. Canonical textual rendering uses the conventional lowercase hyphenated UUID form.
+
+UUID ordering has no domain meaning. Revision chronology and lineage are explicit facts, not properties inferred from identifier sort order.
+
+Time-ordered identifier schemes are deliberately not used for this contract. In particular, UUIDv7 and ULID embed timestamp information into the identifier. That would make time partially observable through identity despite the revision already carrying explicit recording provenance, and would conflict with the invariant that revision identity is not derived from time.
+
+A persistence implementation may use an internal sequence, clustered key, or other physical indexing aid for storage locality. Such an internal key is not `ControlledRevisionId` and must not escape as the durable historical identity.
+
+### A controlled revision has one semantic fingerprint
+
+The minimum controlled-revision record is conceptually:
+
+```text
+ControlledRevision
+    id: ControlledRevisionId
+    modelFingerprint: ModelFingerprint
+    parentRevisionIds: 0..1 ControlledRevisionId
+    provenance:
+        recordedAt
+        recorder
+```
+
+Every controlled revision references exactly one `ModelFingerprint`.
+
+The fingerprint answers:
+
+> What canonical semantic content does this revision represent under the named fingerprint policy?
+
+The revision ID answers:
+
+> Which controlled historical occurrence of that semantic content is being referenced?
+
+Therefore:
+
+```text
+same fingerprint  does not imply  same revision ID
+same revision ID  implies          the same immutable revision record
+```
+
+`ControlledRevisionId` generation must not consume or derive from the fingerprint.
+
+A revision does not contain multiple alternate fingerprints for the same semantic state. If Arcogine later needs to relate fingerprints produced under different policies, that relationship must be represented explicitly rather than mutating or multiplying the semantic identity stored in an existing historical revision.
+
+This ADR also does not introduce a generic model/schema-version field. `ModelFingerprint.policyVersion` already versions the fingerprint semantics. A separate domain model or serialization schema version should be added only when a concrete cross-domain contract requires it; it must not be invented as part of historical revision identity.
+
+### G1.2 supports zero or one parent
+
+A root revision has no parent. A non-root revision has one parent.
+
+The contract is structurally expressed as `parentRevisionIds` so that parent cardinality can be extended later without redefining historical revision identity, but the G1.2 capability accepts at most one parent.
+
+```text
+root:
+    parentRevisionIds = []
+
+current descendant:
+    parentRevisionIds = [R1]
+
+not supported in G1.2:
+    parentRevisionIds = [R1, R2]
+```
+
+Multiple children may reference the same parent, so divergence/branch-shaped history is representable without branch objects:
+
+```text
+       R2
+      /
+R1 --+
+      \
+       R3
+```
+
+The current `0..1` parent rule is a capability constraint, not a permanent assertion that controlled history is intrinsically single-parent. Future branch refs, tags, multi-parent merge revisions, primary-parent rules, or other source-control-like topology may extend the model through a later decision.
+
+G1.2 does not define merge semantics, parent ordering for multi-parent revisions, branch names, branch heads, conflict resolution, rebase, or cherry-pick semantics.
+
+### Lineage integrity is explicit
+
+A revision must not name itself as a parent.
+
+When an authoritative revision store accepts a non-root revision, the named parent must already be an accepted revision in that revision authority. Under that append-only acceptance rule, cycles cannot be introduced by ordinary revision creation.
+
+Repository-level parent existence, uniqueness, and cycle integrity belong to the authoritative persistence boundary. A standalone revision value object can enforce local shape invariants such as non-null fields, no self-parent, and parent cardinality, but it cannot by itself prove global graph integrity.
+
+Lineage is independent of fingerprint policy version. A parent and child may reference fingerprints produced under different policy versions when a later migration/evolution contract permits that history; the revision relation itself does not derive from fingerprint equality.
+
+### Rollback is an ordinary new revision
+
+Rollback does not have a special identity type.
+
+If history moves from semantic content F1 to F2 and later restores F1, Arcogine records a new historical revision:
+
+```text
+R1 -> F1
+ |
+ v
+R2 -> F2
+ |
+ v
+R3 -> F1
+```
+
+`R3` is distinct from `R1` even though their fingerprints are equal.
+
+Arcogine must not implement rollback by reusing `R1`'s revision ID, mutating `R2`, or moving history backward. Whether a later semantic transition was intentionally a rollback is change rationale and belongs to future ChangeSet/change provenance semantics rather than the minimum revision identity contract.
+
+### Minimum provenance records when Arcogine accepted the revision and who/what recorded it
+
+A controlled revision carries minimum recording provenance:
+
+```text
+RevisionProvenance
+    recordedAt
+    recorder
+```
+
+`recordedAt` means:
+
+> the instant at which Arcogine's revision authority accepted the immutable revision record into controlled history.
+
+It is not the time an editor first changed the model, the time a candidate was proposed, an approval time, a deployment time, or an external ticket timestamp.
+
+`recorder` identifies the human, service, agent, import process, or other source that caused Arcogine to record the revision. The minimum contract may represent that identity with a small source/subject value such as:
+
+```text
+RevisionRecorder
+    source
+    subject
+```
+
+This is recording provenance, not authorization. A recorder is not thereby an approver, reviewer, owner, or deployer.
+
+`recordedAt` is explicit provenance and does not participate in `ControlledRevisionId` generation or lineage ordering. The durable persistence slice must preserve its value; exact database/serialization representation and precision are persistence concerns unless a later interoperability contract requires stronger normalization.
+
+### The controlled revision core is immutable
+
+Once an authoritative revision record is accepted, the following facts are immutable:
+
+- `ControlledRevisionId`;
+- `ModelFingerprint`;
+- parent revision IDs;
+- `recordedAt`;
+- `recorder`.
+
+The same revision ID must always resolve to the same immutable values.
+
+Corrections must not silently rewrite an accepted revision. If future requirements need correction, supersession, annotation, or administrative repair, those mechanisms must be explicit and separately attributable.
+
+Human labels, tags, descriptions, workflow state, and other presentation or organizational metadata are not part of the immutable identity core. Their own mutability/versioning policy is deferred until required.
+
+### External workflow references are associations, not revision identity/core state
+
+This ADR refines ADR-0004's statement that a controlled revision may carry an external change reference: the durable relationship is allowed, but it is not part of the minimum immutable `ControlledRevision` record established by G1.2.
+
+A later capability may associate a revision with an external authority and identifier, conceptually:
+
+```text
+RevisionExternalReference
+    revisionId
+    externalAuthority
+    externalId
+```
+
+That relationship may be created after the revision itself and may participate in future governed-change provenance. It never determines model content, fingerprint equality, revision identity, or lineage.
+
+No Jira-specific or other vendor-specific workflow semantics are introduced by this ADR.
+
+### Approval, authorization, conformance, deployment, and evidence remain separate records
+
+A controlled revision exists whether or not it is later:
+
+- evaluated for conformance;
+- approved or rejected;
+- covered by another form of authorization;
+- deployed;
+- linked to external workflow;
+- used by a simulation or runtime;
+- cited as evidence.
+
+Those records may reference `ControlledRevisionId` and, where useful, `ModelFingerprint`. None of them is part of revision identity and none is required for the revision to exist.
+
+Controlled revision identity and lineage therefore provide **configuration-history and evidence-addressability primitives**. They do not themselves represent authorization, conformance, certification, deployment state, or compliance with an external framework.
+
+This separation allows a later governance graph such as:
+
+```text
+                  Requirement / Assertion
+                           |
+                           v
+R40 -> R41 -> R42 -> R43   Evaluation / Finding
+             |             EvidenceUse
+             +-----------> Authorization
+             +-----------> Deployment
+             +-----------> External change reference
+```
+
+The horizontal dimension is configuration history. The attached records are governance, evidence, and operational facts about that history.
+
+### The revision record does not choose model-artifact persistence
+
+A controlled revision references semantic content through `ModelFingerprint`; this ADR does not require serialized model bytes, an artifact URI, or a content-addressed blob to be embedded in the revision record.
+
+However, downstream historical change attribution cannot be considered complete if Arcogine can identify `R42 -> F1` but cannot recover the exact semantic state represented by F1. A subsequent G1 persistence/artifact-resolution slice must define how an authoritative controlled revision can resolve to the exact semantic state required for historical reconstruction.
+
+That later work may choose a repository, artifact store, content-addressed store, event store, or another persistence mechanism. ADR-0008 does not select the technology.
+
+### Authoritative historical identity begins at persistence acceptance
+
+`ControlledRevisionId` is intended to survive process, deployment, and storage boundaries.
+
+Creating a revision-shaped value in memory does not by itself make it an authoritative historical fact. A controlled revision becomes authoritative when its immutable record is accepted by Arcogine's authoritative revision store.
+
+The persistence contract must eventually guarantee at least:
+
+- revision-ID uniqueness;
+- immutable ID-to-record binding;
+- stable revision-to-fingerprint binding;
+- stable revision-to-provenance binding;
+- parent existence/integrity under the accepted lineage policy;
+- durable resolution sufficient for downstream historical use.
+
+This ADR defines those semantic obligations but does not select the repository API, database, transaction mechanism, retention policy, indexing strategy, or artifact format.
+
+### Future Git-like capabilities are not precluded
+
+This decision intentionally preserves later paths to concepts analogous to source-control systems without adopting source-control semantics prematurely.
+
+A future decision may add:
+
+- mutable branch/ref pointers to immutable controlled revisions;
+- tags/labels referencing revisions;
+- multi-parent merge revisions;
+- domain-specific merge/conflict semantics;
+- cherry-pick/reapplication semantics through ChangeSets;
+- revision-record integrity digests or signatures;
+- import/migration mechanisms for externally established history.
+
+Such mechanisms must remain separate from the distinction established here:
+
+```text
+ModelFingerprint       = semantic content identity
+ControlledRevisionId   = historical occurrence identity
+```
+
+The UUID revision ID itself is not a cryptographic commitment to revision contents. If stronger tamper-evident history is required, Arcogine may later hash/sign a canonical revision record while retaining `ControlledRevisionId` as the stable referential identity.
+
+## Alternatives considered
+
+### Derive the revision ID from `ModelFingerprint`
+
+Rejected because equal semantic content may legitimately occur at multiple points in controlled history. A fingerprint-derived revision ID would collapse `F1 -> F2 -> F1` into one historical identity for the two F1 occurrences.
+
+### Use a deterministic/name-based UUID
+
+Rejected because the identifier would necessarily be derived from some combination of content, lineage, actor, time, labels, or external data. Those facts must remain independently modelable rather than becoming revision identity.
+
+### Use UUIDv7
+
+Rejected for the initial durable contract because UUIDv7 embeds a timestamp. Database locality is useful but insufficient reason to make time part of the durable public identifier. Physical storage can add locality independently.
+
+### Use ULID
+
+Rejected for the same semantic reason as UUIDv7: the identifier embeds time. It also provides less platform-native support than UUID across Arcogine's likely implementation environments.
+
+### Use a database sequence as the public revision identity
+
+Rejected because it couples identity allocation to one persistence authority/technology and makes distributed/offline creation harder. A database sequence remains permissible as an internal physical key.
+
+### Make human version labels the revision identity
+
+Rejected because labels are presentation/workflow conveniences, may be renamed or scoped, and do not reliably identify historical occurrences across systems.
+
+### Make arbitrary multi-parent lineage part of G1.2
+
+Rejected because Arcogine does not yet have a concrete merge workflow or semantic merge contract. Supporting arbitrary DAG topology now would force decisions about parent ordering, merge meaning, conflict handling, and ChangeSet semantics before they are required.
+
+The current schema remains structurally extensible through `parentRevisionIds`, while G1.2 enforces `0..1` parents.
+
+### Model rollback as a special revision type
+
+Rejected because rollback does not change what historical identity means. It is an ordinary new occurrence whose semantic content happens to equal an earlier state. Rollback intent belongs to change provenance when that capability exists.
+
+### Put ChangeSet or external workflow references in the minimum immutable revision record
+
+Rejected because those relationships may not exist when a revision is recorded and may be established or corrected later. Making them immutable core fields would either force premature data or require mutation/new revisions for metadata linkage.
+
+### Embed the full semantic model/artifact in `ControlledRevision`
+
+Rejected because historical identity does not require choosing a storage/serialization mechanism. Artifact retention and exact-state resolution are necessary follow-up persistence concerns, but not identity fields.
+
+### Use the revision ID itself as a cryptographic hash of the revision record
+
+Rejected for G1.2 because referential identity and cryptographic integrity are distinct requirements. UUIDv4 provides stable opaque identity; a later integrity digest/signature can commit to canonical revision metadata without making every revision-reference contract content-addressed.
+
+## Consequences
+
+- Arcogine can represent repeated semantic states at distinct points in controlled history without ambiguity.
+- `ModelFingerprint` and `ControlledRevisionId` have non-overlapping meanings that downstream governance, runtime, and audit records can retain together.
+- The initial revision ID is simple, opaque, standardized, and independent of content, lineage, time, actors, and external workflow.
+- Revision records are immutable historical facts once accepted by the authoritative revision store.
+- G1.2 can implement the value contracts and local invariants without pretending that an in-memory collection is durable persistence.
+- G1.2 supports roots, linear history, and divergence, while merge/multi-parent semantics remain deferred but not structurally foreclosed.
+- Rollback/reversion preserves history rather than rewinding or mutating it.
+- External change workflow, approval/authorization, conformance, deployment, evidence, labels, and ChangeSets remain separate relationships/artifacts.
+- Controlled revision history can serve as an addressable substrate for later GRC and standards mappings without claiming compliance by virtue of revision existence.
+- A later persistence decision remains required to establish the authoritative revision store and exact historical semantic-state/artifact resolution.
+- A later integrity decision may add canonical revision-record digests/signatures without changing public revision identity.
+
+The costs are an additional identifier alongside the semantic fingerprint, explicit lineage/provenance records, and UUIDv4's lack of natural database ordering. Those costs are preferable to conflating semantic equality with governed history or encoding storage/workflow assumptions into durable identity.
+
+## Non-goals
+
+This ADR does not define:
+
+- a controlled revision repository implementation;
+- database, event-store, or artifact-store technology;
+- serialized model retention or content-addressed artifact storage;
+- generic semantic `ChangeSet` representation;
+- branch names, mutable refs, tags, or head selection;
+- merge, rebase, cherry-pick, or conflict-resolution semantics;
+- approval or authorization policy;
+- deployment lifecycle/application mechanics;
+- conformance evaluation, evidence, findings, or exceptions;
+- external workflow schemas or vendor-specific integrations;
+- human revision-label policy;
+- cryptographic revision-record digests or signatures;
+- Challenge Readiness versioning/identity;
+- a shared all-domain evaluation/evidence framework.
+
+## G1 delivery boundary
+
+With this ADR accepted, the G1 work can be split without reopening identity semantics:
+
+```text
+G1.1  Durable semantic fingerprint
+      established by ADR-0006 and implementation
+
+G1.2  Controlled revision value contract
+      ControlledRevisionId
+      immutable ControlledRevision
+      one ModelFingerprint
+      current 0..1 parent lineage
+      recording provenance
+      rollback-as-new-revision semantics
+
+G1.3  Authoritative persistence and historical resolution
+      durable revision repository
+      repository-level lineage integrity
+      exact revision -> semantic state/artifact resolution
+      downstream provenance integration
+```
+
+G1 remains incomplete until the G1.3 persistence/resolution obligations required by downstream historical reconstruction are satisfied.
+
+## Charter alignment
+
+This decision supports the Product Charter's causality and provenance direction by making exact historical configuration occurrences independently addressable from their semantic content. It also preserves domain boundaries: semantic content remains owned by the authoritative domain/fingerprint policy, Governance owns controlled revision history and its interpretation, external workflow systems may own organizational process state, and Operational Execution remains authoritative for deployment/application/runtime facts.

--- a/docs/architecture/governance-conformance.md
+++ b/docs/architecture/governance-conformance.md
@@ -3,7 +3,7 @@
 > **Status:** Proposed architectural reference  
 > **Scope:** Cross-domain model history, semantic change, requirements, conformance, evidence, and governance over Arcogine's canonical business semantics  
 > **Authority:** Proposed architecture; this document does not claim current compliance, audit, or certification capability  
-> **Related:** [Product Charter](../product/charter.md), [Architecture Overview](overview.md), [Factory Design Architecture](factory-design.md), [Operational Execution and Digital Twin Architecture](operational-execution-digital-twin.md), [ADR-0003](decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [Standards Alignment](standards-alignment.md), [Governance and Conformance Capability Plan](../planning/governance-conformance-capability.md)
+> **Related:** [Product Charter](../product/charter.md), [Architecture Overview](overview.md), [Factory Design Architecture](factory-design.md), [Operational Execution and Digital Twin Architecture](operational-execution-digital-twin.md), [ADR-0003](decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0006](decisions/0006-durable-semantic-fingerprint-contract.md), [ADR-0008](decisions/0008-controlled-revision-identity-and-lineage.md), [Standards Alignment](standards-alignment.md), [Governance and Conformance Capability Plan](../planning/governance-conformance-capability.md)
 
 ## 1. Architectural position
 
@@ -88,7 +88,7 @@ One underlying business fact or control may satisfy multiple framework requireme
 
 ## 4. Semantic identity and controlled lineage precede audit claims
 
-[ADR-0004](decisions/0004-model-identity-revision-lineage-and-external-change-control.md) separates two identities that governance must not collapse:
+[ADR-0004](decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0006](decisions/0006-durable-semantic-fingerprint-contract.md), and [ADR-0008](decisions/0008-controlled-revision-identity-and-lineage.md) establish two identities that governance must not collapse:
 
 ```text
 ModelFingerprint
@@ -96,23 +96,52 @@ ModelFingerprint
     answers: "what exact design/state?"
 
 ControlledRevision
-    durable historical configuration artifact
+    immutable historical configuration occurrence
     revision ID
-    model fingerprint
-    parent revision(s)
-    schema/model version where applicable
-    creation/publication provenance
-    author or decision source
-    ChangeSet reference
-    external change reference
-    answers: "which controlled historical state?"
+    exactly one model fingerprint
+    zero or one parent in the current capability
+    recording provenance: recordedAt + recorder
+    answers: "which controlled historical occurrence?"
 ```
 
-Approval, deployment, conformance evaluation, and simulation execution are separate artifacts that may reference a controlled revision; they are not properties required for the revision to exist.
+The current `0..1` parent rule is a capability constraint, not a permanent assertion that revision history is intrinsically single-parent. Divergence is already representable because multiple revisions may share the same parent. Branch refs, tags, multi-parent merge revisions, merge/conflict semantics, and stronger cryptographic revision-record integrity may be added later without changing the distinction between semantic identity and historical revision identity.
 
-Equal semantic content may therefore occur in distinct controlled revisions. For example, an intentional rollback can create a later revision with the same model fingerprint as an earlier revision while remaining a distinct governed event in history.
+The minimum revision core deliberately does **not** contain a `ChangeSet`, external change reference, approval/authorization state, deployment state, human version label, framework/compliance state, or serialized model artifact. Those are separate relationships or follow-on capabilities.
 
-The current `FactoryModelVersion.contentHash()` is only the implemented proving ground for content-derived identity. It remains an internal, provisional policy until canonicalization, ordering semantics, fingerprint format/versioning, and cross-process compatibility are specified. It must not be described as an audit-grade durable fingerprint merely because it uses SHA-256.
+Equal semantic content may therefore occur in distinct controlled revisions. A rollback illustrates the invariant:
+
+```text
+R1 -> F1
+ |
+ v
+R2 -> F2
+ |
+ v
+R3 -> F1
+```
+
+`R1` and `R3` have equal semantic fingerprints but distinct controlled revision IDs. The later occurrence does not inherit the historical governance meaning of the earlier one merely because the semantic content is equal.
+
+Controlled revision identity and lineage form the **configuration-history and evidence-addressability substrate**. They let later records point at an exact historical occurrence, but they do not themselves mean that the revision was approved, authorized, conformant, certified, deployed, or compliant with an external framework.
+
+This creates two complementary dimensions:
+
+```text
+Configuration history
+
+R40 --------> R41 --------> R42 --------> R43
+                              |
+                              +--> ChangeSet / rationale
+                              +--> conformance evaluation / finding
+                              +--> authorization decision
+                              +--> deployment record
+                              +--> evidence use
+                              +--> external workflow reference
+```
+
+The horizontal dimension is immutable revision lineage. The attached records are governance, evidence, and operational facts about that history.
+
+A controlled revision becomes an authoritative historical fact only when its immutable record is accepted by Arcogine's authoritative revision store. ADR-0008 defines the required identity, immutability, lineage, and provenance semantics, but does not choose the persistence technology. A subsequent G1 persistence slice must also ensure that an authoritative revision can resolve to the exact semantic state/artifact needed for historical reconstruction.
 
 The system should eventually answer:
 
@@ -189,6 +218,8 @@ justification, automated policy)
         v
 Operational deployment record, when deployed
 ```
+
+External workflow references are associations to revisions/changes, not fields that define controlled revision identity. This allows a revision to be recorded before an external ticket is linked and prevents workflow metadata changes from mutating immutable configuration history.
 
 The external reference tracks or governs the change. Arcogine should not duplicate ticket comments, project-management state, or vendor-specific workflow terminology unless those facts become necessary to a cross-system governance contract.
 
@@ -377,15 +408,22 @@ Current factory work establishes:
 canonical semantic model
 immutable publication
 structural validation
-provisional content-derived identity
+durable factory-model:v1 semantic fingerprint
 runtime instantiation from a published model
-handler-level runtime provenance
+runtime/result provenance work in progress
 ```
 
-It does **not** yet provide a durable fingerprint contract, controlled revision repository, approval/deployment lifecycle, or generic conformance engine. Those capabilities should be added when concrete requirements justify them, following their actual dependency order:
+ADR-0006 and its implementation establish the durable factory-model fingerprint contract. ADR-0008 now establishes the controlled revision identity/lineage decision, but the controlled revision value model and authoritative revision persistence are not yet implemented. Arcogine therefore still does **not** have an authoritative controlled revision repository or generic conformance engine.
+
+The Governance dependency remains:
 
 ```text
-G1 fingerprint/revision
+G1.1 durable semantic fingerprint        complete
+    ↓
+G1.2 controlled revision value contract  next implementation slice
+    ↓
+G1.3 authoritative persistence +
+     historical semantic-state resolution
     ↓
 G2 ChangeSet
     ↓
@@ -407,12 +445,12 @@ This proposal does not mean that Arcogine currently:
 - continuously observes cloud, identity, HR, source-control, ticketing, or industrial systems;
 - owns all operational truth in connected systems;
 - replaces Jira or enterprise GRC workflow;
-- has durable model persistence or controlled revision lineage today;
-- has a durable cross-process model fingerprint contract today;
+- has an implemented controlled revision value model or authoritative revision repository;
+- has durable exact historical semantic-state/artifact resolution for controlled revisions;
 - has a generic conformance engine today;
 - has production actuation or digital-twin reconciliation today.
 
-Standards/reference alignment and semantic mappings remain distinct from tested conformance claims.
+Standards/reference alignment and semantic mappings remain distinct from tested conformance claims. Controlled revision identity/lineage is an enabling configuration-management primitive, not evidence that any external standard or control has been satisfied.
 
 ## 15. Architectural review checklist
 
@@ -431,16 +469,19 @@ When governance or compliance work is proposed, ask:
 11. Are modeled intent and observed reality explicit and independently attributable?
 12. Is an external observation kept revision-independent until an `EvidenceUse`/interpretation binds it when appropriate?
 13. Are historical results reproducible rather than dependent on today's mutable mappings?
+14. Is a workflow/change reference being treated as an association rather than an immutable identity field of the revision?
+15. Does a proposed lineage extension preserve the distinction between semantic identity and historical occurrence identity?
 
 ## 16. ADR triggers
 
-[ADR-0004](decisions/0004-model-identity-revision-lineage-and-external-change-control.md) already fixes the semantic-identity versus controlled-revision distinction and the external change-control boundary.
+[ADR-0004](decisions/0004-model-identity-revision-lineage-and-external-change-control.md) fixes the semantic-identity versus controlled-revision distinction and the external change-control boundary. [ADR-0006](decisions/0006-durable-semantic-fingerprint-contract.md) fixes the first durable fingerprint contract. [ADR-0008](decisions/0008-controlled-revision-identity-and-lineage.md) fixes controlled revision identity, current lineage cardinality, rollback semantics, immutable recording provenance, and the persistence boundary.
 
 Create or revise ADRs when implementation commits to hard-to-reverse choices about:
 
-- the durable fingerprint canonicalization/format/compatibility contract;
-- concrete controlled revision identifiers and persistence/lineage semantics;
-- parent/branch/merge relationships between controlled revisions;
+- authoritative controlled revision persistence and exact historical semantic-state/artifact resolution;
+- extending current `0..1` lineage to multi-parent merge semantics;
+- branch/ref/tag semantics over controlled revisions;
+- cryptographic revision-record integrity/signature semantics;
 - canonical semantic `ChangeSet` representation;
 - temporal semantics for modeled facts and observations;
 - requirement/assertion evaluation contracts;

--- a/docs/planning/governance-conformance-capability.md
+++ b/docs/planning/governance-conformance-capability.md
@@ -3,7 +3,7 @@
 > **Status:** Proposed  
 > **Scope:** Establish the cross-domain substrate for durable semantic identity, controlled revision history, semantic change, requirements, conformance, evidence, and governed change  
 > **Authority:** Planning only; this document defines delivery dependencies and readiness criteria, not current product capability  
-> **Related:** [Governance and Conformance Architecture](../architecture/governance-conformance.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [Product Charter](../product/charter.md), [Factory Design Capability Plan](factory-design-capability.md), [Factory Design Architecture](../architecture/factory-design.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Standards Alignment](../architecture/standards-alignment.md)
+> **Related:** [Governance and Conformance Architecture](../architecture/governance-conformance.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md), [ADR-0008](../architecture/decisions/0008-controlled-revision-identity-and-lineage.md), [Product Charter](../product/charter.md), [Factory Design Capability Plan](factory-design-capability.md), [Factory Design Architecture](../architecture/factory-design.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Standards Alignment](../architecture/standards-alignment.md)
 
 ## 1. Purpose
 
@@ -48,23 +48,28 @@ The implemented seam currently provides:
 FactoryModel
     -> structural validation
     -> immutable publication
-    -> provisional content-derived identity
+    -> durable factory-model:v1 semantic fingerprint
     -> runtime instantiation
-    -> handler-level provenance
+    -> runtime/result provenance work in progress
 ```
 
-That seam must not be blocked by the generic governance initiative. In particular, the current `FactoryModelVersion.contentHash()` is not yet a durable cross-process fingerprint contract, and the current factory model has no controlled revision repository.
+ADR-0006 and its implementation establish the durable semantic fingerprint contract. ADR-0008 establishes the controlled revision identity and lineage decision, but the controlled revision value model and authoritative revision persistence are not yet implemented.
 
-The governance use case now provides a concrete cross-consumer reason to pursue work previously deferred in the factory plan. The dependency order matters here, and matches the G1-G9 sequence in §4 below, not the order these concerns happen to be listed elsewhere:
+The governance use case provides the concrete cross-consumer reason to complete the remaining G1 work. The dependency order matters here, and matches the G1-G9 sequence in §4 below:
 
 ```text
-durable semantic fingerprint + controlled revision lineage (G1)
+G1.1 durable semantic fingerprint                 complete
           ↓
-semantic ChangeSet (G2)
+G1.2 controlled revision identity/value contract  next
           ↓
-requirement-based conformance/evidence (G3-G5)
+G1.3 authoritative revision persistence +
+     exact historical semantic-state resolution
           ↓
-review/authorization/governed-change integration (G6)
+G2 semantic ChangeSet
+          ↓
+G3-G5 requirement-based conformance/evidence
+          ↓
+G6 review/authorization/governed-change integration
 ```
 
 Evaluating a proposed change's conformance before it is authorized is the strategic point (see [architecture §11](../architecture/governance-conformance.md#11-pre-change-conformance-is-strategically-important)); an authorization/deployment integration that isn't preceded by conformance evaluation would authorize changes Arcogine hasn't yet assessed.
@@ -111,10 +116,13 @@ Operational work may proceed headlessly with clearly scoped synthetic revision, 
 2. Do not create a monolithic `BusinessModel`. Each domain retains authoritative ownership of its facts.
 3. Distinguish modeled intent from observed reality. Structural facts may be provable from Arcogine state; operational assertions may require external evidence.
 4. Reuse external workflow systems where they already own organizational process state. Jira may remain authoritative for issue workflow while Arcogine owns semantic impact, evidence use, and controlled revision lineage.
-5. Keep semantic identity and controlled revision identity separate as required by [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md).
-6. Treat external requirement provenance as versioned input in addition to Arcogine's own requirement and assertion versioning. A standards-family label is not sufficient when an evaluation depends on a specific issuing authority, designation, edition/version, clause/locator, or adoption/profile.
-7. Do not bind raw external operational observations to a model fingerprint/revision at source. The revision relationship belongs to `EvidenceUse`, reconciliation, deployment correlation, or another interpretation record when applicable.
-8. Governance authorization and Operational deployment application are separate concerns. Governance may reference the deployment record but does not define adapter/application mechanics.
+5. Keep semantic identity and controlled revision identity separate as required by [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md) and concretized by [ADR-0008](../architecture/decisions/0008-controlled-revision-identity-and-lineage.md).
+6. Treat controlled revision lineage as configuration history and evidence addressability, not as approval, deployment, certification, or compliance state.
+7. Keep `ChangeSet`, external workflow references, authorization decisions, deployments, evidence uses, labels, and framework mappings outside the minimum immutable controlled-revision identity core.
+8. Treat external requirement provenance as versioned input in addition to Arcogine's own requirement and assertion versioning. A standards-family label is not sufficient when an evaluation depends on a specific issuing authority, designation, edition/version, clause/locator, or adoption/profile.
+9. Do not bind raw external operational observations to a model fingerprint/revision at source. The revision relationship belongs to `EvidenceUse`, reconciliation, deployment correlation, or another interpretation record when applicable.
+10. Governance authorization and Operational deployment application are separate concerns. Governance may reference the deployment record but does not define adapter/application mechanics.
+11. Preserve future lineage extensions without implementing generic source-control semantics prematurely. G1.2 supports `0..1` parent today; branch refs, tags, multi-parent merges, and cryptographic revision-record integrity are deferred rather than forbidden.
 
 ## 4. Delivery sequence
 
@@ -144,60 +152,128 @@ G1-G5 are architectural substrate. G6-G7 establish governance workflow integrati
 
 ### Current status
 
-**Partial.** ADR-0006 is implemented for the factory-model:v1 durable semantic fingerprint. The
-typed fingerprint and canonical binary encoding now coexist with the legacy `contentHash()`;
-controlled revision identity and lineage remain deferred to a subsequent ADR and implementation
-slice. G1 is therefore not complete until that revision and later persistence work exists.
+**Partial.** G1.1 is complete: ADR-0006 and the `factory-model:v1` implementation establish the durable semantic fingerprint contract.
+
+**G1.2 is decision-complete but not yet implemented.** ADR-0008 establishes `ControlledRevisionId`, the minimum immutable revision record, current `0..1` parent lineage, rollback-as-new-revision semantics, recording provenance, and the separation from ChangeSet/workflow/authorization/deployment/conformance state.
+
+**G1.3 remains outstanding.** Arcogine still needs authoritative durable controlled-revision persistence, repository-level lineage integrity, exact revision-to-semantic-state/artifact resolution, and downstream provenance integration before G1 can be considered complete.
 
 ### Goal
 
-Promote the current provisional content-derived identity into an explicit durable semantic fingerprint contract, and introduce a separate controlled revision lifecycle for historical lineage.
-
-The conceptual split is:
+Provide two durable, non-conflated identities and the historical substrate required by later governance work:
 
 ```text
 ModelFingerprint
     deterministic identity of canonical semantic content
 
 ControlledRevisionId
-    identity of one persisted historical configuration artifact
+    opaque identity of one controlled historical occurrence
 
 ControlledRevision
     revision ID
-    model fingerprint
-    parent revision(s)
-    schema/model version where applicable
-    publication/creation provenance
-    author or decision source
-    external change reference, when applicable
+    exactly one model fingerprint
+    parent revision IDs: 0..1 in the current capability
+    recording provenance:
+        recordedAt
+        recorder
 ```
 
-Authorization and deployment are separate records referencing a controlled revision. They are not components of semantic identity and are not prerequisites for a revision to exist.
+The invariant is:
+
+> **Durable semantic identity is not historical revision identity.**
+
+Equal semantic content may appear in multiple controlled revisions. A revision's existence does not imply approval, authorization, deployment, conformance, certification, or compliance.
+
+### G1.1 — Durable semantic fingerprint
+
+**Status: Complete.**
+
+ADR-0006 defines the versioned, cross-process `ModelFingerprint` contract and the first `factory-model:v1` policy. The implementation supplies the typed fingerprint and canonical binary encoding while retaining legacy `contentHash()` compatibility where needed.
+
+G1.1 remains the semantic-content identity layer only. It does not identify historical occurrences.
+
+### G1.2 — Controlled revision identity and value contract
+
+**Status: Decision complete; implementation next.**
+
+ADR-0008 fixes the following contract:
+
+- `ControlledRevisionId` uses UUIDv4 as opaque durable historical identity;
+- revision identity is not derived from fingerprint, parent, actor, timestamp, human label, or external workflow ID;
+- every controlled revision references exactly one `ModelFingerprint`;
+- root revisions have zero parents and current descendants have one parent;
+- current `0..1` parent cardinality is a capability constraint, not a permanent architectural limit;
+- multiple children may share a parent, so divergence is representable;
+- multi-parent merge semantics, branch refs, tags, rebase/cherry-pick semantics, and cryptographic record integrity are deferred but not precluded;
+- rollback/reversion creates a new revision and may legitimately reuse an earlier fingerprint;
+- minimum provenance records `recordedAt` and the human/service/agent/import source that recorded the revision;
+- ID, fingerprint, lineage, and required recording provenance are immutable once accepted by the authoritative revision store;
+- `ChangeSet`, external workflow references, approval/authorization, deployment, conformance/evidence, labels, and model artifact storage are not fields in the minimum immutable revision core.
+
+The first implementation slice should be deliberately narrow:
+
+```text
+:types
+    ControlledRevisionId
+
+:governance
+    ControlledRevision
+    RevisionProvenance
+    RevisionRecorder (or equivalently narrow recorder value)
+```
+
+The implementation should prove local value invariants and the `F1 -> F2 -> F1` historical case. It should not create a fake in-memory repository merely to claim durable persistence.
+
+### G1.3 — Authoritative persistence and historical semantic-state resolution
+
+**Status: Outstanding.**
+
+A controlled revision becomes an authoritative historical fact only when its immutable record is accepted by Arcogine's authoritative revision store. G1.3 must establish the durable persistence boundary without reopening the identity semantics fixed by ADR-0008.
+
+G1.3 must provide or prove:
+
+- durable revision-ID uniqueness and stable ID-to-record binding;
+- immutable revision-to-fingerprint and revision-to-provenance relationships;
+- repository-level parent existence and lineage integrity;
+- exact controlled-revision resolution to the semantic state/artifact required for historical reconstruction;
+- persistence semantics sufficient for later ChangeSet reconstruction, conformance attribution, and downstream revision-ID provenance.
+
+G1.3 may require a follow-up ADR when the implementation commits to hard-to-reverse repository, artifact-retention/resolution, integrity, or migration semantics. ADR-0008 intentionally does not choose a database, event store, repository API, blob/artifact format, or physical indexing strategy.
 
 ### Required properties
 
 - Equal semantic content can have the same model fingerprint across distinct controlled revisions.
 - A later rollback may therefore have the same fingerprint as an earlier revision while remaining historically distinct.
-- The durable fingerprint policy must specify canonicalization, ordering semantics, algorithm/format versioning, and compatibility guarantees.
-- The durable fingerprint policy must specify which fields are semantic versus non-semantic, including whether names and allocated IDs participate in semantic identity, and how semantic fields are normalized, and must define the relationship between Java equality and fingerprint equality.
 - Controlled revision identity must not be inferred from the fingerprint or a human label such as `v7`.
+- The same controlled revision ID must always identify the same immutable revision record.
+- Revision lineage must be explicit and independent of fingerprint equality.
+- A revision must not name itself as parent; the authoritative store must preserve parent existence/integrity under the accepted lineage policy.
+- Recording provenance identifies when Arcogine accepted the historical record and who/what recorded it, without implying authorization.
 - Human version/revision labels may exist for presentation but are not fundamental identity.
+- External workflow references are associations, not revision identity.
+- Authorization, deployment, conformance, evidence, and framework/compliance state remain separate records/projections.
 
 ### Acceptance criteria
 
 G1 is ready when:
 
-1. A durable semantic fingerprint contract is explicitly specified and testable across supported process/version boundaries.
-2. Controlled revisions have durable identities independent of process memory and semantic fingerprint equality.
-3. Revision lineage identifies predecessor/parent relationships under the chosen policy.
-4. Semantic content remains immutable for a published/referenced revision.
-5. Provenance records who or what created/published the revision and when.
-6. Authorization and deployment records can independently reference a revision.
-7. A downstream result can retain the semantic fingerprint and, when applicable, the controlled revision ID.
+1. A durable semantic fingerprint contract is explicitly specified and testable across supported process/version boundaries. **Satisfied by G1.1.**
+2. Controlled revision identity/value semantics are implemented according to ADR-0008, including UUIDv4 identity, exactly one fingerprint, current `0..1` parent lineage, rollback-as-new-revision, and immutable recording provenance. **G1.2.**
+3. Controlled revisions have authoritative durable identities independent of process memory and semantic fingerprint equality. **G1.3.**
+4. The authoritative store enforces revision-ID uniqueness, immutable ID-to-record binding, and parent existence/integrity under the chosen lineage policy. **G1.3.**
+5. An authoritative controlled revision can resolve to the exact semantic state/artifact needed for historical reconstruction. **G1.3.**
+6. Authorization and deployment records can independently reference a revision without becoming revision identity. **Boundary fixed by ADR-0008; downstream integration may land later.**
+7. A downstream result can retain the semantic fingerprint and, when applicable, the controlled revision ID. **Downstream integration after G1.2/G1.3 contracts exist.**
 
-### ADR trigger
+### ADR status
 
-[ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md) already fixes the semantic separation. A follow-up ADR is warranted before implementation commits to the concrete durable fingerprint format, revision identifier scheme, persistence model, or lineage rules.
+The identity decisions are no longer open:
+
+- ADR-0004 fixes semantic identity vs. controlled revision identity and the external workflow authority boundary;
+- ADR-0006 fixes the durable semantic fingerprint contract;
+- ADR-0008 fixes controlled revision identity, current lineage semantics, rollback, minimum provenance, immutability, and the persistence boundary.
+
+A new ADR is needed only if G1.3 commits to a hard-to-reverse persistence/artifact-resolution/integrity choice or if future work extends lineage into multi-parent merge/ref semantics.
 
 ## 6. G2 — Semantic ChangeSet and impact model
 
@@ -406,6 +482,8 @@ Operational deployment record, when deployed
 
 Jira or another workflow system may remain authoritative for issue workflow, assignments, discussions, and transitions. Arcogine retains the stable external reference and the technical/governance facts required to explain the semantic change and its resulting revision.
 
+External change references are separate associations/provenance records, not immutable identity fields of `ControlledRevision`.
+
 If Arcogine later owns an authorization decision itself, that decision must be modeled explicitly with actor, authority, and provenance rather than inferred from mutable UI state.
 
 The Operational Execution capability owns applying the authorized revision to a target, adapter/profile/transformation provenance, effective applied-artifact/external-version identity, operational verification/result facts, and reconciliation. G6 owns the governed-change/authorization interpretation and references that operational deployment record when it exists.
@@ -414,7 +492,7 @@ The Operational Execution capability owns applying the authorized revision to a 
 
 G6 is ready when:
 
-1. A `ChangeSet`/revision can reference an external change request.
+1. A `ChangeSet`/revision can reference an external change request through a separate association/provenance relationship.
 2. Impact and conformance information can be surfaced into the change workflow.
 3. Approval/authorization records reference the relevant controlled revision rather than defining revision identity.
 4. Operational deployment, when it occurs, is separately attributable to the deployed revision through a referenced Operational Execution deployment record.
@@ -518,7 +596,7 @@ G9 is ready when:
 
 The first milestone should deliberately avoid a full external compliance framework:
 
-> **Take a proposed semantic change to an Arcogine model, derive its candidate fingerprint, persist a controlled revision linked to an external change request, evaluate one Arcogine-native requirement before authorization/deployment, record the authorization decision separately, and reconstruct why the resulting semantic state was considered conformant.**
+> **Take a proposed semantic change to an Arcogine model, derive its candidate fingerprint, persist a controlled revision linked through a separate association to an external change request, evaluate one Arcogine-native requirement before authorization/deployment, record the authorization decision separately, and reconstruct why the resulting semantic state was considered conformant.**
 
 A concrete example could be an ownership requirement once the relevant owner/authority semantics exist.
 
@@ -527,12 +605,14 @@ Definition of done:
 ```text
 Durable semantic fingerprint contract exists
 Controlled revision identity exists
+Authoritative controlled revision persistence exists
+Exact historical semantic state is resolvable
 Base revision -> ChangeSet -> candidate revision is attributable
 Affected entity is identified
 One versioned requirement applies
 Pre-change assertion evaluates deterministically
 Finding is produced if violated
-External change-request provenance can be linked
+External change-request provenance can be linked separately
 Authorization is a separate record referencing the revision
 Deployment is not required to prove the milestone
 Historical evaluation remains attributable after later changes
@@ -564,10 +644,14 @@ As implementation progresses:
 - update [`../architecture/overview.md`](../architecture/overview.md) only with established current-state behavior;
 - update [`../architecture/governance-conformance.md`](../architecture/governance-conformance.md) when this proposed direction changes materially;
 - keep [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md) as the authority for semantic identity vs. revision identity and the external change-control boundary;
+- keep [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md) as the authority for the durable semantic fingerprint contract;
+- keep [ADR-0008](../architecture/decisions/0008-controlled-revision-identity-and-lineage.md) as the authority for controlled revision identity, current lineage cardinality, rollback, recording provenance, immutability, and the persistence boundary;
 - update factory/domain architecture docs when identity/change requirements alter those models;
 - update the sibling [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md) when Governance G1/G2/G4/G5 contract availability changes its blocked/fixture-backed criteria;
 - update [`../architecture/standards-alignment.md`](../architecture/standards-alignment.md) when Arcogine moves from reference/mapping toward an actual tested conformance profile;
-- create ADRs for the concrete durable fingerprint contract, controlled revision persistence/lineage scheme, semantic `ChangeSet` contracts, temporal evidence semantics, and hard-to-reverse external protocols when implementation commits to them;
+- create a follow-up ADR for G1.3 only when implementation commits to hard-to-reverse persistence, artifact-resolution, migration, retention, or revision-record-integrity semantics;
+- create later lineage ADRs only when concrete branch/ref/multi-parent merge semantics are required;
+- create ADRs for semantic `ChangeSet` contracts, temporal evidence semantics, and hard-to-reverse external protocols when implementation commits to them;
 - update product/reference docs only for capabilities that actually ship.
 
 Once this initiative is complete or superseded, retain durable decisions in ADR/current architecture and retire or reduce this planning artifact.


### PR DESCRIPTION
## Summary

- add accepted ADR-0008 for controlled revision identity and lineage
- define `ControlledRevisionId` as opaque UUIDv4 historical identity independent of `ModelFingerprint`
- define the minimum immutable controlled-revision record, current `0..1` parent capability, rollback semantics, and recording provenance
- explicitly preserve future branch/ref/tag/multi-parent merge and cryptographic-integrity paths without implementing them in G1.2
- keep ChangeSet, external workflow references, authorization, deployment, conformance/evidence, labels, and model artifact storage outside the minimum revision core
- frame controlled revision lineage as configuration-history/evidence-addressability substrate rather than compliance or approval state
- align Governance architecture with ADR-0008
- split Governance G1 planning into G1.1 fingerprint complete, G1.2 revision value contract next, and G1.3 authoritative persistence/historical semantic-state resolution outstanding

## Scope

Documentation/architecture only. No production implementation or persistence changes are included.

## Follow-up

Next implementation slice is G1.2: `ControlledRevisionId` plus the narrow immutable controlled-revision/provenance value contract. G1.3 then establishes authoritative durable persistence and exact historical semantic-state/artifact resolution.