### PR TITLE
docs: define W1 intra-order execution decomposition

### DIFF
--- a/docs/architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md
+++ b/docs/architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md
@@ -271,7 +271,11 @@ Creating one lightweight `Job` per quantity unit changes resident execution-obje
 
 That cost is accepted for W1 because any coarser chunk size would be arbitrary without a domain input that actually defines lot or batch size. Decomposing according to available resource count would also be incorrect because it would couple work decomposition to resource dispatch and make work identity change when the factory design changes.
 
-Implementation acceptance must therefore include a large-order non-functional benchmark (for example quantity 100,000) to measure memory and execution impact. If that evidence shows an unacceptable practical limit, the follow-up design must address representation efficiency without silently inventing batch semantics.
+Implementation acceptance must therefore include a large-order non-functional benchmark (for example quantity 100,000) to measure memory and execution impact. That benchmark informs the supported materialization envelope; it is not itself the admission contract.
+
+Before mutating runtime state, workload acceptance must deterministically verify that the requested quantity is within a supported child-materialization envelope. A quantity above that envelope must be rejected through the existing structured command-error semantics before creating the `Order`, order-execution aggregate, child `Job`s, assignments, pending work, or command-produced events. The concrete bound is an implementation/configuration/model decision and is intentionally not frozen by this ADR, but it must be deterministic for the same accepted model/runtime configuration and must be established from evidence rather than ambient heap availability or allocation failure.
+
+This admission rule preserves Gate 3's zero-partial-mutation rejection guarantee and prevents environment-dependent allocation failure from becoming a de facto workload limit. If benchmarking shows that the desired supported envelope is impractical with unit `Job` materialization, the follow-up design must address representation efficiency without silently inventing batch semantics.
 
 A future accepted lot/batch capability may allow one `Job` to represent `executionQuantity > 1` when the production domain provides an explicit lot/batch rule. W1 deliberately leaves that seam open but does not define such a rule now.
 
@@ -307,6 +311,7 @@ Rejected. Those are legitimate future manufacturing concepts but are not require
 - `OrderCompleted` gains explicit `OrderId` correlation and remains exactly once per order.
 - Gate 4 can now stabilize observations and event envelopes against a known execution-identity model rather than the obsolete 1:1 assumption.
 - Resident `Job` count becomes quantity-proportional for W1 and must be measured with a large-order benchmark.
+- Workload acceptance must establish and enforce a deterministic supported child-materialization envelope before mutation; ambient memory exhaustion is not an admissible workload-limit mechanism.
 - Real lot/batch semantics remain open and require a separate accepted decision if introduced.
 
 ## Acceptance evidence required before W1 is complete
@@ -324,7 +329,8 @@ The implementation slice must prove at least:
 9. two fresh identical runtimes produce identical child identities, assignments, event streams, and terminal aggregate state;
 10. quantity 1 still creates one child job and behaves as the degenerate case of the same model;
 11. Gate 2 independent-order dispatch, offline/recovery, reset/replay, bounded advancement, and rejected-submission atomicity remain covered;
-12. a large-order benchmark records the practical cost of unit decomposition.
+12. a large-order benchmark records the practical cost of unit decomposition and justifies the chosen supported child-materialization envelope;
+13. quantities above that supported envelope are deterministically rejected before mutation through the structured command-result/error contract, with zero partial `Order`, aggregate, `Job`, queue, pending-work, assignment, or event state.
 
 ## Explicit non-goals
 

--- a/docs/architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md
+++ b/docs/architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md
@@ -1,0 +1,347 @@
+# ADR-0010: Intra-order execution decomposition and work-item identity
+
+Status: Accepted
+Date: 2026-08-28
+
+## Context
+
+ADR-0009 separated two production concerns that had previously been conflated:
+
+```text
+work decomposition
+    what independently dispatchable execution units exist?
+
+resource dispatch
+    which eligible resource executes one such unit?
+```
+
+Gate 2 is complete at the dispatch boundary. The remaining W1 question is therefore not how to rank eligible resources, but how one accepted production `Order` with quantity greater than one becomes independently dispatchable runtime work without moving authoritative production semantics into the game or another consumer.
+
+The current implementation has one immutable `Order` and one mutable `Job` per accepted workload. Quantity is represented by repeating the product routing inside that one `Job`: a quantity-20 order for a three-step routing executes 60 task steps sequentially. This makes quantity consume proportional production work, but it also means one order cannot use two equivalent resources concurrently because only one `JobId` exists to dispatch at a time.
+
+The factory-design reference challenge makes this limitation concrete. The game owns one fixed requirement to produce 20 units of Product A through `CUT -> ASSEMBLE -> INSPECT`, and one credible player strategy is to install a second cutter. The game must not fabricate multiple Arcogine `Order`s merely to make that strategy effective. Arcogine therefore needs an accepted intra-order decomposition contract before Gate 4 stabilizes externally visible execution identities and event correlation.
+
+The existing runtime already provides an important architectural seam:
+
+- `Order` is immutable accepted production intent;
+- `Job` is mutable executable work and already carries the identity used by machine queues, active-machine state, pending multi-eligible work, and task events;
+- `Order` was deliberately modeled so that multiple jobs may later reference the same order;
+- Gate 2 dispatch already operates correctly once several independently dispatchable `Job`s exist.
+
+The design therefore needs to choose the smallest execution shape that enables the reference workload while preserving determinism, aggregate order semantics, and future room for real lot/batch concepts.
+
+## Decision
+
+### 1. One accepted Order owns one order-level execution aggregate and one or more Jobs
+
+The accepted runtime shape is:
+
+```text
+Order
+    immutable production intent
+    OrderId
+    product
+    requested quantity
+    created/released time
+    commercial facts
+        |
+        v
+Order execution aggregate
+    identity: the same OrderId
+    released quantity
+    completed quantity
+    completion time
+        |
+        +---- Job 1
+        +---- Job 2
+        +---- ...
+        +---- Job N
+```
+
+The order-level execution aggregate does **not** receive a second independent identifier. `OrderId` already identifies the accepted production requirement and is sufficient to correlate aggregate progress and completion.
+
+The aggregate may be represented internally by dedicated mutable state or by equivalent authoritative state owned by the factory runtime. The architectural requirement is the responsibility boundary, not a mandatory Java class name.
+
+### 2. JobId is the independently dispatchable work-item identity
+
+`JobId` becomes the identity of one independently dispatchable work item within an accepted order.
+
+A `Job` owns mutable execution state for that work item:
+
+- parent `OrderId` / referenced `Order`;
+- deterministic ordinal within the order;
+- execution quantity represented by the work item;
+- current routing step;
+- assignment / current machine;
+- status and timing;
+- completion state.
+
+No new `ExecutionUnitId`, `LotId`, or `BatchId` is introduced for W1. Machine queues, active-machine state, `pendingMultiEligible`, and `TaskStart` / `TaskEnd` continue to use `JobId` as their concrete execution identity.
+
+### 3. W1 decomposes quantity N into N unit-quantity Jobs
+
+For the first supported intra-order decomposition contract, accepting an `Order` with quantity `N` deterministically creates exactly `N` child `Job`s, each representing execution quantity `1`.
+
+Each child `Job` traverses the product routing exactly once and independently:
+
+```text
+Order quantity = N
+routing = step 0 -> step 1 -> ... -> step R-1
+
+creates
+
+Job ordinal 0: step 0 -> step 1 -> ... -> step R-1
+Job ordinal 1: step 0 -> step 1 -> ... -> step R-1
+...
+Job ordinal N-1: step 0 -> step 1 -> ... -> step R-1
+```
+
+This reifies the `N` routing passes already implicit in the current quantity-scaled single-Job implementation. It does not introduce an arbitrary batch size or invent material-lot semantics.
+
+For W1, every accepted child is released for dispatch as part of the atomic order-acceptance operation. `releasedQuantity == requestedQuantity` immediately after successful acceptance.
+
+### 4. ordinalWithinOrder is deterministic ordering metadata, not identity
+
+Each child work item has a zero-based immutable ordinal within its parent order, assigned in ascending order at acceptance.
+
+The ordinal exists to make decomposition and replay ordering explicit and inspectable. It is not globally unique, is not a substitute for `JobId`, and must not be treated as a durable cross-session identifier.
+
+Child creation, `JobId` allocation, and initial dispatch attempts occur in ascending `ordinalWithinOrder` order.
+
+### 5. Aggregate order progress is quantity-based
+
+The order-level execution aggregate tracks at least:
+
+```text
+requestedQuantity
+releasedQuantity
+completedQuantity
+completedAt
+```
+
+For W1:
+
+- `requestedQuantity` comes from immutable `Order.quantity`;
+- `releasedQuantity` is the number of child work items released for execution and equals requested quantity immediately after acceptance;
+- `completedQuantity` increments exactly once when a child `Job` completes its final routing step;
+- the order is complete exactly when `completedQuantity == requestedQuantity`;
+- `completedAt` is the simulation time of that aggregate transition.
+
+A child `Job` completing one intermediate routing step does not change completed quantity.
+
+### 6. Each Job progresses through one routing independently
+
+The current quantity-scaled `Job.totalSteps = routing.stepCount() * order.quantity` representation is superseded for W1 execution.
+
+Each child `Job` instead has one routing traversal:
+
+```text
+Job.totalSteps = routing.stepCount()
+Job.currentStep = routing-local execution progress
+```
+
+A job cannot begin routing step `k + 1` until its own step `k` completes. Sibling jobs of the same order have no additional precedence relationship in W1 and may therefore occupy different eligible resources concurrently.
+
+No cross-job batching, synchronization barrier, split/merge rule, or transfer-batch constraint is introduced by this decision.
+
+### 7. Existing Gate 2 dispatch policy is reused unchanged
+
+W1 creates independently dispatchable work; it does not redefine resource selection.
+
+Every released child `Job` is dispatched using the existing deterministic Gate 2 policy:
+
+```text
+eligible
+    -> online
+    -> able to accept work immediately
+    -> shallowest queue
+    -> lowest MachineId
+```
+
+`pendingMultiEligible` retains its existing semantics and continues to hold `JobId`-identified waiting work.
+
+A second equivalent machine can therefore improve execution of one order only because W1 supplies multiple dispatchable sibling jobs; the selector itself remains unchanged.
+
+### 8. Order completion is emitted exactly once
+
+Completing the final routing step of a child `Job` performs one aggregate progress transition.
+
+Only the transition from:
+
+```text
+completedQuantity = requestedQuantity - 1
+```
+
+to:
+
+```text
+completedQuantity = requestedQuantity
+```
+
+may emit the order-completion event.
+
+Exactly one `OrderCompleted` event is emitted for one accepted `Order`, regardless of child count.
+
+To remove the ambiguity created by several `JobId`s belonging to one order, W1 evolves the completion payload to carry explicit order identity while retaining the completing child correlation:
+
+```text
+OrderCompleted(
+    OrderId orderId,
+    JobId jobId,
+    ProductId productId,
+    long quantity,
+    double unitPrice
+)
+```
+
+`jobId` identifies the child whose final completion caused the aggregate order to become complete. `orderId` identifies the completed production requirement.
+
+`TaskStart` and `TaskEnd` may retain their current `JobId`, `MachineId`, and routing-local `stepIndex` fields for W1. Gate 4 remains responsible for any later stable event-envelope design; this ADR does not require adding `OrderId` to every task event.
+
+### 9. Order-level business and performance semantics remain order-level
+
+Introducing several `Job`s underneath one `Order` must not silently redefine existing business/performance measures.
+
+For W1:
+
+- backlog remains the count of incomplete accepted orders, not the count of child jobs;
+- completed sales remains the count of completed orders;
+- completed sales value is posted exactly once per completed order at the full order value;
+- average lead time remains order lead time from order acceptance/release to aggregate order completion;
+- throughput metrics that currently count completed orders remain order-count metrics unless a later explicit contract introduces unit-throughput measures.
+
+Compatibility adapters that currently project full parent order quantity or value from every `Job` must be changed deliberately. In particular, no child job may independently cause the full order value to be posted or reported as if it were a separate sale.
+
+### 10. FactoryRuntime keeps one workload-submission result and gains aggregate execution observation
+
+`FactoryRuntime.submitWorkload(...)` continues to accept one production requirement and return one accepted `OrderId`.
+
+A successful submission may now schedule initial events for multiple child jobs. A rejected submission remains atomic and must leave no partial accepted state:
+
+- no `Order`;
+- no order-execution aggregate;
+- no child `Job`s;
+- no machine assignment/queue mutation;
+- no `pendingMultiEligible` entries;
+- no command-produced runtime events.
+
+The supported runtime observation surface must expose order-level execution progress in an equivalent shape to:
+
+```text
+OrderExecutionView(
+    OrderId orderId,
+    long requestedQuantity,
+    long releasedQuantity,
+    long completedQuantity,
+    SimTime completedAt,
+    boolean complete
+)
+```
+
+The exact Java representation may differ, but a consumer must not need to infer aggregate completion by counting arbitrary child-job states itself.
+
+### 11. Deterministic decomposition and replay are required
+
+For the same published model, runtime state, seed, workload, and ordered commands, W1 must reproduce the same:
+
+- child count;
+- child ordinals;
+- `JobId` allocation sequence;
+- initial dispatch order;
+- machine assignments;
+- queue/pending ordering;
+- task-event ordering;
+- aggregate progress transitions;
+- order-completion event.
+
+The required ordering rules are:
+
+1. create and allocate child jobs in ascending `ordinalWithinOrder` order;
+2. attempt initial dispatch in that same order;
+3. preserve existing per-machine FIFO queue semantics;
+4. preserve existing deterministic `pendingMultiEligible` reconsideration semantics;
+5. preserve `MachineId` as the final resource-selection tie-breaker;
+6. preserve scheduler insertion order as the tie-breaker for events at the same simulation time.
+
+Hash/set iteration order must not become a semantic tie-breaker.
+
+### 12. Unit decomposition is the minimum supported W1 policy, not a generalized batch model
+
+Creating one lightweight `Job` per quantity unit changes resident execution-object scaling from approximately O(orders) to O(quantity), while event work was already O(quantity * routing steps) in the existing quantity-scaled implementation.
+
+That cost is accepted for W1 because any coarser chunk size would be arbitrary without a domain input that actually defines lot or batch size. Decomposing according to available resource count would also be incorrect because it would couple work decomposition to resource dispatch and make work identity change when the factory design changes.
+
+Implementation acceptance must therefore include a large-order non-functional benchmark (for example quantity 100,000) to measure memory and execution impact. If that evidence shows an unacceptable practical limit, the follow-up design must address representation efficiency without silently inventing batch semantics.
+
+A future accepted lot/batch capability may allow one `Job` to represent `executionQuantity > 1` when the production domain provides an explicit lot/batch rule. W1 deliberately leaves that seam open but does not define such a rule now.
+
+## Alternatives considered
+
+### Keep one parent Job and introduce a new ExecutionUnit identity below it
+
+Rejected for W1. The current runtime already treats `JobId` as the identity that machines, queues, pending work, and task events execute. Preserving `Job` as a parent aggregate would require threading a new identity through all of those structures while retaining two mutable execution layers with overlapping responsibilities. The concrete requirement does not justify that complexity.
+
+### Use one Job per arbitrary chunk of quantity
+
+Rejected. No accepted domain fact currently supplies a batch size. Choosing a fixed chunk size would invent production semantics; choosing a chunk size from resource count would incorrectly make decomposition depend on dispatch capacity.
+
+### Keep one Job and allow one Job to execute on several machines concurrently
+
+Rejected. The current `Job` lifecycle and task correlation model represent one mutable work item with one current routing progression. Making one `JobId` simultaneously own several active operations would blur work identity, precedence, machine assignment, event correlation, and completion accounting.
+
+### Have the game submit several Orders
+
+Rejected by ADR-0009 for the current reference challenge. The game owns the fixed production requirement, not Arcogine's internal decomposition of that requirement.
+
+### Introduce generalized lots, batches, material genealogy, and split/merge now
+
+Rejected. Those are legitimate future manufacturing concepts but are not required to prove the current 20-unit fixed-contract capacity trade-off.
+
+## Consequences
+
+- The former one-`Order`-to-one-`Job` runtime invariant becomes historical implementation shape rather than intended architecture once W1 is implemented.
+- `JobId` has a clear semantic meaning: identity of one independently dispatchable execution work item.
+- One order can use several equivalent resources concurrently without changing Gate 2 dispatch policy.
+- Aggregate order progress and completion become explicit instead of being synonymous with one job's progress.
+- Existing job-oriented API/DTO compatibility projections require review because parent quantity/value can no longer safely be interpreted as child-job quantity/value.
+- `OrderCompleted` gains explicit `OrderId` correlation and remains exactly once per order.
+- Gate 4 can now stabilize observations and event envelopes against a known execution-identity model rather than the obsolete 1:1 assumption.
+- Resident `Job` count becomes quantity-proportional for W1 and must be measured with a large-order benchmark.
+- Real lot/batch semantics remain open and require a separate accepted decision if introduced.
+
+## Acceptance evidence required before W1 is complete
+
+The implementation slice must prove at least:
+
+1. accepting quantity 20 creates exactly one `Order` and exactly 20 sibling `Job`s under that order;
+2. the child ordinals and `JobId` allocation are deterministic;
+3. each child traverses `CUT -> ASSEMBLE -> INSPECT` in order and exactly once;
+4. two eligible cutters can simultaneously execute different children of that same order;
+5. aggregate progress advances from 0 through 20 completed units and completion occurs only at 20;
+6. exactly one `OrderCompleted` is emitted with explicit `OrderId` and the completing child `JobId`;
+7. completed-sales count/value, backlog, and lead-time semantics remain order-level and are not multiplied by child count;
+8. the one-cutter and two-cutter reference models produce observably different queue/utilization/completion behavior for the same single order;
+9. two fresh identical runtimes produce identical child identities, assignments, event streams, and terminal aggregate state;
+10. quantity 1 still creates one child job and behaves as the degenerate case of the same model;
+11. Gate 2 independent-order dispatch, offline/recovery, reset/replay, bounded advancement, and rejected-submission atomicity remain covered;
+12. a large-order benchmark records the practical cost of unit decomposition.
+
+## Explicit non-goals
+
+This decision does not define:
+
+- material-lot identity or genealogy;
+- configurable production batch sizes;
+- transfer batches;
+- split/merge processing;
+- inventory allocation or BOM consumption;
+- setup-family optimization or campaign scheduling;
+- resource pools beyond current explicit eligibility;
+- priority, due-date, or generalized scheduling policy;
+- durable cross-session `JobId` identity;
+- Gate 4's final event-envelope contract;
+- game scoring, challenge evaluation, or player-owned workload decomposition.
+
+## Charter alignment
+
+The decision keeps executable production semantics inside Arcogine while preserving the consumer boundary established by the product and planning documents. A consumer states one production requirement; Arcogine deterministically turns that requirement into executable work, dispatches it, and reports aggregate outcome. The model is intentionally minimal: it enables the proven reference requirement without prematurely introducing a generalized manufacturing-execution ontology.

--- a/docs/architecture/isa-95-semantic-mapping.md
+++ b/docs/architecture/isa-95-semantic-mapping.md
@@ -3,7 +3,7 @@
 > **Status:** Maintained architectural reference  
 > **Scope:** Mapping between Arcogine manufacturing-domain semantics and ISA-95 / IEC 62264 concepts  
 > **Authority:** Describes current mappings, deliberate divergences, and design constraints; it does not establish ISA-95 conformance  
-> **Related:** [Product Charter](../product/charter.md), [Architecture Overview](overview.md), [Standards Alignment](standards-alignment.md), [Factory-Design Game Consumer Initiative](../planning/factory-design-game-consumer.md)
+> **Related:** [Product Charter](../product/charter.md), [Architecture Overview](overview.md), [Standards Alignment](standards-alignment.md), [Factory-Design Game Consumer Initiative](../planning/factory-design-game-consumer.md), [ADR-0010](decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md)
 
 ## 1. Purpose
 
@@ -100,7 +100,7 @@ The correct characterization is therefore:
 
 ## 5. Current concept mapping register
 
-This table is the maintained working register. Update it when the domain model changes; do not preserve obsolete mappings merely for historical continuity.
+This table is the maintained working register. Because ADR-0010 establishes architecture ahead of its implementation, rows below distinguish current runtime behavior from accepted W1 direction where that difference matters.
 
 | Arcogine concept | Current meaning | Closest ISA-95 semantic role | Mapping | Disposition | Current limitation or direction |
 |---|---|---|---|---|---|
@@ -117,18 +117,19 @@ This table is the maintained working register. Update it when the domain model c
 | Scenario `operations_definition` | Named ordered set of process segments | Operations Definition / Work Definition | Good vocabulary mapping | Adopt | Runtime equivalent is simplified `Routing` |
 | Runtime `Routing` | Immutable ordered list of routing steps | Simplified Operations/Work Definition | Partial | Alias | Lacks explicit resource requirements, parameters, alternatives, and version semantics |
 | Scenario `process_segment` | Named step, concrete equipment ID, and duration | Process Segment analogue | Partial vocabulary mapping | Adopt at scenario boundary | A true process segment is more abstract than one concrete machine assignment |
-| Runtime `RoutingStep` | Step ID, name, concrete `MachineId`, and duration | Simplified work step / Process Segment analogue | Weak–partial | Refactor | Direct machine binding prevents capability pools and equivalent-resource dispatch |
-| `Order` | Immutable request/accepted-order intent: product, quantity, agreed unit price, and creation time | Job Order / production request, approximating a production-order aggregate, extended with a commercial price | Partial | Alias | First-class and immutable, but still one-to-one with a `Job` and not a generalized production-order model |
-| `Job` | Mutable execution/work-item analogue: status, current step (of `routing.stepCount() x quantity` repeated routing passes), current machine, completion time, and a reference to its `Order` | Work item / job execution state | Partial | Alias | Request, execution, and result concerns are separated from `Order`, but `Job` still holds the whole `Order` rather than an ID-only reference, and quantity is represented as repeated routing passes within one job rather than distinct work-item records |
+| Runtime `RoutingStep` | Step ID, name, eligible `MachineId` set, and duration | Simplified work step / Process Segment analogue | Partial | Alias | Explicit eligible instances support deterministic equivalent-resource dispatch, but there is no generalized capability requirement/pool model |
+| `Order` | Immutable request/accepted-order intent: product, quantity, agreed unit price, and creation time | Job Order / production request, approximating a production-order aggregate, extended with a commercial price | Partial | Alias | Current implementation still creates one `Job`; ADR-0010 establishes `OrderId` as the aggregate correlation identity for multiple child work items under W1 |
+| `Job` | Mutable execution/work-item analogue identified by `JobId`; current implementation still repeats `routing.stepCount() x quantity` within one job | Work item / job execution state | Partial | Alias | ADR-0010 establishes the W1 target: one unit-quantity `Job` per requested quantity unit, independently dispatchable under the parent `Order`; implementation is pending |
 | `JobStatus` | Queued, in progress, or completed | Work/job execution status | Good narrow mapping | Alias | Does not represent the complete requested/accepted/started/completed lifecycle |
-| `OrderCreation` event | Acceptance/release fact that creates the `Order` and its associated `Job` | Job-order release / acceptance fact | Approximate | Alias | The event still creates exactly one order and one job together |
-| `TaskStart` / `TaskEnd` | Actual operation execution facts | Work execution / performance facts | Good narrow mapping | Alias | No first-class operation-performance record exists beyond state and event history |
-| `OrderCompleted` | Operational fact that one job completed its routing | Job response / production performance fact | Partial | Alias | Correlation is still by `jobId`; `Job` remains one-to-one with an `Order`, so this is only an approximate completion/performance fact |
+| Order-level execution aggregate | Accepted W1 responsibility for released/completed quantity and aggregate completion, correlated by the same `OrderId` | Production-request execution/performance aggregation | Partial | Alias | Architecture accepted by ADR-0010; runtime representation/observation remains to be implemented |
+| `OrderCreation` event | Acceptance/release fact that currently creates one `Order` and one associated `Job` | Job-order release / acceptance fact | Approximate | Alias | W1 will atomically create the order execution aggregate and `N` unit-quantity child jobs for quantity `N` |
+| `TaskStart` / `TaskEnd` | Actual operation execution facts correlated by `JobId` | Work execution / performance facts | Good narrow mapping | Alias | ADR-0010 retains `JobId` as work-item correlation; no first-class operation-performance record exists beyond state and event history |
+| `OrderCompleted` | Current operational completion fact correlated by `jobId` | Job response / production performance fact | Partial | Alias | ADR-0010 requires W1 to emit exactly once per order with explicit `OrderId` plus the completing child `JobId`; implementation is pending |
 | `Scheduler` | Deterministic ordering of simulation events | No direct ISA-95 object equivalent | Arcogine-specific | Extend | Simulation infrastructure, not an Operations Schedule by itself |
 | `EventLog` | Append-only sequence of processed simulation facts | Performance/history source | Partial | Extend | Event history is not yet a structured ISA-95 performance model |
 | `FactoryHandler` | Owner of machines, jobs, queues, routings, and production aggregates | Narrow production-execution function in a Level-3-like scope | Approximate | Alias | A class is not an ISA-95 level; Arcogine covers only a subset of MOM activities |
-| Throughput, lead-time, backlog, utilization and related observations | Operational measures derived from simulation state and history | Operations Performance / manufacturing KPI information | Partial | Adopt or alias per KPI | Each KPI needs an explicit formula and semantic mapping before standards claims |
-| Finance ledger and observations | Financial interpretation of completed operational work | Enterprise/business-side financial information | Adjacent, not one-to-one | Diverge | Deliberately separate from operational production truth |
+| Throughput, lead-time, backlog, utilization and related observations | Operational measures derived from simulation state and history | Operations Performance / manufacturing KPI information | Partial | Adopt or alias per KPI | ADR-0010 requires existing backlog/completed-sales/order-lead-time meanings to remain order-level under child-job decomposition |
+| Finance ledger and observations | Financial interpretation of completed operational work | Enterprise/business-side financial information | Adjacent, not one-to-one | Diverge | Deliberately separate from operational production truth; W1 must not multiply full order value by child-job count |
 | Economy/demand model | Offer price and demand-generation behavior | Business/planning input adjacent to Level 4 | Arcogine-specific | Extend | Not an ISA-95 enterprise-planning implementation |
 | Proposed factory-floor position and footprint | Physical placement with transfer consequences | No one-to-one equipment-hierarchy mapping | Orthogonal | Extend | Must remain distinct from organizational/resource containment |
 | Proposed resource pool / work center | Group of eligible resources and aggregate capacity | Work Center / resource scope | Potentially strong | Adopt or alias when implemented | Introduce only when it owns real dispatch, capacity, or reporting semantics |
@@ -153,7 +154,7 @@ Resource capability and requirements
 Arcogine currently represents part of this through `MaterialConfig`, `OperationsDefinitionConfig`, `Routing`, and `RoutingStep`. The main limitations are:
 
 - no first-class runtime `Product` or generalized material definition;
-- `RoutingStep` selects one concrete machine rather than expressing a resource requirement;
+- `RoutingStep` expresses explicit eligible resource instances rather than a generalized resource-capability requirement;
 - no explicit definition version carried by in-flight work;
 - machine definition and machine instance properties are combined.
 
@@ -171,9 +172,9 @@ Priority
 Scheduling scope
 ```
 
-Arcogine currently receives work through `OrderCreation` events generated by the demand model. An immutable `Order` records the requested work (product, quantity, agreed price, creation time), and a `Job` is created alongside it to hold mutable execution state, referencing the `Order` it was created for.
+Arcogine receives work both through economy-driven `OrderCreation` events and the explicit `FactoryRuntime.submitWorkload` boundary. An immutable `Order` records accepted work intent (product, quantity, agreed price, creation time). The current implementation creates one `Job` alongside it; ADR-0010 keeps the `Order` as one accepted production requirement but establishes that W1 will create multiple independently dispatchable child jobs while aggregate progress remains correlated by `OrderId`.
 
-For explicit production contracts and external consumers, Arcogine should further separate order intent from execution state along these lines:
+For explicit production contracts and external consumers, further request/schedule concerns may later include:
 
 ```text
 ProductionOrder
@@ -201,7 +202,7 @@ WorkItem
     transfer state
 ```
 
-This is the mutable shop-floor concern currently held mostly by `Job`, `Machine`, and machine queues.
+This is the mutable shop-floor concern held mostly by `Job`, `Machine`, machine queues, and cross-machine pending work. ADR-0010 makes the mapping more precise for W1: `JobId` identifies one independently dispatchable work item; quantity `N` becomes `N` unit-quantity sibling jobs under the accepted `Order`; each child progresses through one routing independently. No separate `ExecutionUnitId`, `LotId`, or `BatchId` is introduced by W1.
 
 ### 6.4 Performance
 
@@ -218,11 +219,11 @@ Failures or rejections
 Order completion outcome
 ```
 
-Arcogine currently derives performance from jobs, machine state, aggregate counters, and the event log. This is sufficient for current simulation reports, but it is not yet a first-class performance model or ISA-95 interchange representation.
+Arcogine currently derives performance from jobs, machine state, aggregate counters, and the event log. ADR-0010 further requires an explicit order-level execution observation with requested/released/completed quantity and aggregate completion so consumers do not infer order performance by counting child jobs. This is still not a complete ISA-95 performance model or interchange representation.
 
-### 6.5 Current compression
+### 6.5 Current implementation and accepted W1 direction
 
-The present model can be summarized as:
+The currently implemented pre-W1 model can be summarized as:
 
 ```text
 Routing
@@ -235,13 +236,33 @@ Order
 Job
     reference to its Order
     + mutable execution state
-    + completion result
+    + quantity-scaled repeated routing
 
 EventLog
     historical execution facts
 ```
 
-Order intent is now separated from execution state as an immutable `Order`, but `Job` still holds the whole `Order` object (not an ID-only reference), and the relationship remains strictly one `Job` per `Order`. Order quantity now consumes proportional production work -- `Job.totalSteps = routing.stepCount() * order.quantity()`, with the routing repeating once per unit -- but this was deliberately achieved by scaling one job's step count rather than by introducing multiple `Job`/work-item objects per order, since Arcogine does not yet need per-unit-scoped state (a distinct machine/timing record per unit) and an N-times-larger `Job.totalSteps` counter avoids allocating unbounded objects for a large quantity. The strict one-`Job`-per-`Order` relationship remains a further refactoring target for when a concrete feature needs genuinely separate work-item records (e.g. per-unit-scoped state, or partial per-unit dispatch to parallel equivalent resources), plan versions, or structured performance records that aggregate across jobs -- the trigger Gate 2's capability-based parallel dispatch is expected to supply.
+Order intent is separated from execution state as an immutable `Order`, but the implementation still has one `Job` per `Order`. Quantity consumes proportional production work by repeating the routing within that single job. That remains an accurate statement of current code and test evidence.
+
+The concrete feature that previously justified a future refactor now exists: the fixed 20-unit factory-design challenge must let two equivalent cutters process different portions of one accepted order concurrently. ADR-0010 therefore establishes the accepted target architecture:
+
+```text
+Order
+    immutable accepted production requirement
+    OrderId
+        |
+        v
+order-level execution aggregate
+    same OrderId
+    requested / released / completed quantity
+        |
+        +---- Job 0 (JobId, executionQuantity 1)
+        +---- Job 1 (JobId, executionQuantity 1)
+        +---- ...
+        +---- Job N-1 (JobId, executionQuantity 1)
+```
+
+This direction strengthens rather than weakens the ISA-95-informed separation of request, execution, and performance: the request remains one immutable order, individual `Job`s become concrete work-item execution state, and aggregate production progress/completion remains an order-level fact. It does **not** imply ISA-95 conformance, generalized production-lot semantics, or a requirement to adopt ISA-95 type names internally.
 
 ## 7. Resource definitions, instances, capabilities, and pools
 
@@ -270,9 +291,9 @@ ResourcePool / WorkCenter
 
 ### 7.1 Why the distinction matters
 
-The current `RoutingStep -> MachineId` relationship means a routing selects one exact machine. This prevents a newly added equivalent machine from contributing capacity without changing the routing itself.
+Arcogine's runtime routing now supports an explicit set of eligible machine instances for an operation. That allows a second equivalent eligible machine to contribute capacity without rewriting the product operation for a different concrete machine. This is sufficient for the current deterministic dispatch contract, while generalized capability pools remain deferred.
 
-A capability-oriented operation should instead express something like:
+A future capability-oriented operation may instead express something like:
 
 ```text
 Operation requirement
@@ -281,7 +302,7 @@ Operation requirement
     eligible pool: cutting resources
 ```
 
-The execution layer then selects an eligible instance using a documented deterministic policy.
+The execution layer would then select an eligible instance using a documented deterministic policy.
 
 This supports:
 
@@ -294,7 +315,7 @@ This supports:
 
 ### 7.2 Determinism requirement
 
-Resource selection must remain deterministic. Any ranking policy must define a final stable tie-breaker, such as machine instance ID. The ISA-95 mapping does not prescribe Arcogine's dispatch algorithm; Arcogine owns that simulation semantic.
+Resource selection must remain deterministic. Arcogine's current Gate 2 contract uses a stable ranking ending in `MachineId` as final tie-breaker. The ISA-95 mapping does not prescribe Arcogine's dispatch algorithm; Arcogine owns that simulation semantic.
 
 ## 8. Equipment hierarchy versus spatial layout
 
@@ -350,13 +371,13 @@ Arcogine currently models a narrow production-execution slice, not the complete 
 
 | Area | Current Arcogine coverage | Status |
 |---|---|---|
-| Production definition | Materials linked to routings and concrete-machine steps | Partial |
-| Production requests | Demand-generated order-creation events | Minimal and implicit |
-| Production scheduling | Deterministic event scheduler and per-machine FIFO queues | Simplified, simulation-specific |
-| Production execution | Machines, jobs, task transitions, queues, completion | Core current coverage |
+| Production definition | Materials linked to routings and explicit eligible-resource steps | Partial |
+| Production requests | Immutable `Order` intent accepted through explicit workload submission or economy-driven order creation | Partial |
+| Production scheduling | Deterministic event scheduler, explicit eligible-resource dispatch, per-machine FIFO queues, and cross-machine pending work | Simplified, simulation-specific |
+| Production execution | Machines, jobs, task transitions, queues, completion; W1 child-job decomposition accepted but not yet implemented | Core current coverage plus accepted extension |
 | Production performance | Events, completion aggregates, jobs, and selected KPIs/observations | Partial |
 | Equipment management | Machine identity, state, concurrency, queue, capacity/setup properties | Partial |
-| Equipment capability | Concrete machine binding only | Not first-class |
+| Equipment capability | Explicit eligible-instance sets; no generalized capability taxonomy/pool model | Partial |
 | Equipment hierarchy | None | Deferred |
 | Material management | Product-like material configuration and `ProductId` | Minimal |
 | Inventory operations | None | Deferred |
@@ -393,6 +414,8 @@ Machine
 ```
 
 is preferable to renaming the class `WorkUnit` without adding actual hierarchy or work-unit semantics.
+
+Likewise, ADR-0010 keeps the established Arcogine term `Job` for an independently dispatchable work item instead of adding a standards-sounding type whose semantics would not be clearer.
 
 ### 10.3 Do not use a standard term when
 
@@ -434,9 +457,9 @@ Revisit this document whenever a change introduces or materially alters:
 - ISA-95/B2MML import, export, transactions, or exchange profiles;
 - public claims of ISA-95 compatibility or conformance.
 
-This mapping document records current relationships and open design constraints. Create an ADR when a decision becomes accepted and hard to reverse, for example:
+This mapping document records current relationships and accepted design constraints. Create an ADR when a decision becomes accepted and hard to reverse, for example:
 
-- aggregate boundaries between product, order, work item, and performance;
+- aggregate boundaries between product, order, work item, and performance — ADR-0010 now records the W1 `Order`/aggregate/`Job` boundary;
 - capability-pool and deterministic dispatch semantics;
 - hierarchy and spatial-model separation;
 - the canonical public model contract;
@@ -485,15 +508,17 @@ This semantic mapping does not commit Arcogine to:
 - ERP, MES, or MOM product scope;
 - personnel, maintenance, quality, or inventory modules without concrete requirements;
 - standards certification or conformance testing;
-- treating spatial factory layout as equipment hierarchy.
+- treating spatial factory layout as equipment hierarchy;
+- treating ADR-0010's unit work-item decomposition as material-lot genealogy or generalized batch semantics.
 
 ## 15. Maintenance rule
 
-Keep this document current rather than chronological:
+Keep this document current rather than chronological, while clearly distinguishing implemented behavior from accepted-but-not-yet-implemented architecture:
 
 - update the mapping register when the implementation changes;
 - state implemented semantics as present fact;
-- remove resolved gaps from current-gap descriptions;
+- identify accepted target semantics explicitly when an ADR precedes implementation;
+- remove resolved gaps from current-gap descriptions once implementation lands;
 - use Git history and ADRs to preserve decision chronology;
 - track implementation work in issues or plans, not in this reference;
 - re-check official standard publication metadata before making version-specific claims.

--- a/docs/planning/factory-design-game-consumer.md
+++ b/docs/planning/factory-design-game-consumer.md
@@ -3,8 +3,8 @@
 > **Status:** Proposed  
 > **Scope:** A separate, single-player factory-design game consuming Arcogine as its production engine  
 > **Authority:** Planning only; this document does not describe current capability or accepted architecture  
-> **Dependency:** Headless [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md) may progress independently; playable/runtime-integrated game implementation begins only after the model-seam entry gate (§1.1 of [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)), Engine Gates 1-5, and the reference-challenge work-decomposition prerequisite recorded by [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md) are satisfied  
-> **Related:** [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md), [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md), [Factory Design Architecture](../architecture/factory-design.md), [Factory Design Capability](factory-design-capability.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md)
+> **Dependency:** Headless [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md) may progress independently; playable/runtime-integrated game implementation begins only after the model-seam entry gate (§1.1 of [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)), Engine Gates 1-5, and the accepted W1 decomposition contract in [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) are implemented and proven  
+> **Related:** [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md), [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md), [Factory Design Architecture](../architecture/factory-design.md), [Factory Design Capability](factory-design-capability.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md)
 
 ## 1. Initiative summary
 
@@ -49,12 +49,14 @@ The game may own an editor-specific draft, but that draft is not the authoritati
 [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) owns runtime concerns:
 
 - production orders, quantity semantics, and work execution;
-- work decomposition when one accepted production requirement must expose multiple independently dispatchable execution units;
+- deterministic decomposition of one accepted quantity-`N` order into independently dispatchable work items under the accepted W1 contract;
 - capability/eligibility-based deterministic dispatch;
 - consumer-neutral session and bounded advancement;
 - supported observations and externally visible runtime events;
 - deterministic transfer/runtime consequences of semantic layout;
 - later recovery, checkpoint, compatibility, and sidecar hardening.
+
+ADR-0009 records why decomposition is separate from Gate 2 dispatch. ADR-0010 resolves the W1 architecture: `Order` remains immutable production intent and the aggregate correlation identity; `JobId` identifies independently dispatchable work items; W1 creates one unit-quantity `Job` per requested quantity unit; aggregate progress/completion remains order-level; and exactly one `OrderCompleted` event is produced for the order. This design is accepted but is not runtime evidence until implemented and proven by the Engine track.
 
 A CLI command, JUnit harness, or thin reference consumer used to prove either upstream plan is not game implementation.
 
@@ -82,8 +84,8 @@ Before playable or runtime-integrated game implementation starts, Arcogine must 
 2. Gate 1: explicit production workload and separate execution semantics.
 3. Gate 2: capability/eligibility-based deterministic resource dispatch for independently dispatchable work.
 4. Gate 3: consumer-neutral simulation session with bounded advancement.
-5. The reference-challenge work-decomposition prerequisite from ADR-0009: one fixed accepted production requirement can expose multiple independently dispatchable execution units so equivalent bottleneck capacity can affect that same contract.
-6. Gate 4: stable observations and ordered external runtime events, including the execution identities/correlation introduced by work decomposition.
+5. W1 as defined by ADR-0010: one fixed accepted quantity-`N` production requirement deterministically creates `N` unit-quantity sibling `Job`s under one `Order`, so equivalent bottleneck capacity can affect that same contract while aggregate progress/completion remains order-level.
+6. Gate 4: stable observations and ordered external runtime events, including the `OrderId`/`JobId` execution correlation established by W1.
 7. Gate 5: deterministic spatial runtime consequences.
 
 The headless dispatch-capacity, fixed-contract work-decomposition, and layout benchmarks must pass before a game UI is used as evidence for those capabilities. Gate 2 remains complete independently of work decomposition; the extra prerequisite exists because the current reference challenge specifically requires both semantics together.
@@ -190,7 +192,7 @@ Live placement/movement/removal during active work is not required for the verti
 | Shared executability validation | Arcogine design/model boundary |
 | Published model identity/version/provenance | Arcogine design/model boundary |
 | Products, operations, resource definitions/instances, semantic layout | Arcogine canonical model |
-| Orders, work decomposition/execution units, queues, dispatch, processing, transfers in progress | Arcogine runtime |
+| Orders, order-level execution progress, child Jobs/work items, queues, dispatch, processing, transfers in progress | Arcogine runtime |
 | Simulation clock, event ordering, deterministic random behavior | Arcogine runtime |
 | Runtime observations and KPIs | Arcogine runtime |
 | Model/command/event/observation compatibility contracts | Arcogine |
@@ -230,7 +232,7 @@ These are game rules. They do not extend Arcogine Finance unless a separate prod
 
 Challenge identity/version, admissibility, evaluation-policy identity/version, score/success semantics, and attempt provenance/history are specified in [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md). Challenge evaluation may interpret authoritative Arcogine outcome facts but must not recreate production semantics to derive facts Arcogine did not report.
 
-The fixed challenge workload remains one game-owned production requirement. The game does not split it into multiple Arcogine Orders merely to obtain parallel capacity. Arcogine's work-decomposition capability is responsible for exposing independently dispatchable execution units while preserving the authoritative parent production requirement.
+The fixed challenge workload remains one game-owned production requirement. The game does not split it into multiple Arcogine Orders merely to obtain parallel capacity. ADR-0010 assigns decomposition to Arcogine: quantity `N` becomes `N` deterministic unit-quantity sibling `Job`s under the accepted `Order`; the game may visualize those work items and aggregate progress, but it does not choose their count, identity, release order, or dispatch.
 
 ### 6.6 Persistence and local runtime
 
@@ -268,7 +270,7 @@ The vertical slice does not require:
 | Scoring formula | Playtests showing meaningful factory trade-offs |
 | Tutorial sequence | First-time-user observation |
 
-Canonical model, order/work semantics, work decomposition, dispatch, session behavior, event envelopes, and transfer rules are upstream decisions and do not belong here.
+Canonical model, order/work semantics, W1 decomposition/work-item identity, dispatch, session behavior, event envelopes, and transfer rules are upstream decisions and do not belong here.
 
 ## 9. Playable/runtime-integrated game implementation entry criteria
 
@@ -276,10 +278,10 @@ Headless Challenge Readiness C1-C5 is explicitly outside this entry gate and may
 
 1. The model-seam entry gate (§1.1 of [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)) is satisfied.
 2. Gates 1-3 in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) are satisfied, including Gate 2 at its deterministic-dispatch boundary.
-3. The ADR-0009 work-decomposition prerequisite is implemented and a single fixed accepted production requirement can exercise parallel equivalent bottleneck capacity without the game manufacturing independent Orders.
-4. Gates 4-5 in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) are satisfied after accounting for the execution identities/correlation introduced by work decomposition.
+3. ADR-0010 is implemented: a single quantity-20 accepted `Order` creates exactly 20 independently dispatchable unit-quantity sibling `Job`s with deterministic identities/order, explicit aggregate progress, and exactly one aggregate order completion.
+4. Gates 4-5 in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) are satisfied after accounting for the `OrderId`/`JobId` execution correlation introduced by W1.
 5. A game-like draft can project into the canonical model and publish a `FactoryModelVersion` without using mutable runtime classes.
-6. The headless capacity benchmark proves equivalent-resource dispatch, and a fixed-contract decomposition benchmark proves the current reference workload can actually use that capacity.
+6. The headless capacity benchmark proves equivalent-resource dispatch, and the fixed-contract decomposition benchmark proves the current reference workload can actually use that capacity without game-authored order splitting.
 7. The headless layout benchmark proves deterministic transfer consequences across distinct published model versions.
 8. A reference consumer can instantiate, submit workload, advance, observe, and reset without Arcogine internals.
 9. Model and runtime observation contracts are stable enough for a prototype consumer.

--- a/docs/planning/factory-design-game-vertical-slice.md
+++ b/docs/planning/factory-design-game-vertical-slice.md
@@ -3,7 +3,7 @@
 > **Status:** Proposed  
 > **Scope:** Product hypothesis for the first playable factory-design game slice  
 > **Authority:** Planning only; this document does not describe current Arcogine capability or accepted architecture  
-> **Related:** [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [Factory Design Capability](factory-design-capability.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [Product Charter](../product/charter.md)
+> **Related:** [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [Factory Design Capability](factory-design-capability.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md), [Product Charter](../product/charter.md)
 
 ## 1. Product thesis
 
@@ -62,7 +62,7 @@ The player decides where additional compatible resources are worth their capital
 
 Adding capacity at a true bottleneck should be capable of reducing queueing or completion time. Adding capacity away from the bottleneck may produce little or no benefit. Solving one bottleneck may expose another.
 
-For the fixed-contract reference challenge below, this requirement applies to one accepted production requirement, not to a game-authored collection of artificial independent orders. Arcogine therefore needs the pre-playable work-decomposition capability recorded by ADR-0009 before the second-cutter strategy can be used as runtime evidence.
+For the fixed-contract reference challenge below, this requirement applies to one accepted production requirement, not to a game-authored collection of artificial independent orders. Arcogine's accepted W1 architecture is now recorded by ADR-0010: one accepted quantity-`N` `Order` decomposes into `N` independently dispatchable unit-quantity `Job`s, while aggregate progress and completion remain order-level. That architecture must be implemented and proven headlessly before the second-cutter strategy can be used as runtime evidence.
 
 ### 3.2 Resource eligibility and dispatch
 
@@ -125,7 +125,7 @@ Strategy B
 
 Neither approach should dominate under every constraint. The useful product question is whether the player can understand why one design performs better in a particular run.
 
-The 20-unit contract remains one fixed game-owned production requirement. The game must not obtain Strategy A's parallelism by silently translating that requirement into several independent Arcogine `Order`s. Arcogine owns how accepted production intent is decomposed into independently dispatchable execution units; that capability is an explicit pre-playable dependency under ADR-0009 and the consumer plan.
+The 20-unit contract remains one fixed game-owned production requirement. The game must not obtain Strategy A's parallelism by silently translating that requirement into several independent Arcogine `Order`s. Under ADR-0010, Arcogine owns the deterministic decomposition of the accepted order into 20 sibling unit-quantity `Job`s, `JobId` is the independently dispatchable work-item identity, and order progress/completion remain aggregate facts correlated by `OrderId`. The game consumes those semantics; it does not choose the decomposition.
 
 ## 5. Player evidence and attempt comparison
 
@@ -163,6 +163,6 @@ The consumer-readiness gates, ownership rules, integration acceptance criteria, 
 
 This document owns only the concrete product hypothesis: player fantasy, loop, decisions, reference challenge, player-facing evidence, and product success criteria.
 
-[Factory-Design Game Consumer Initiative](factory-design-game-consumer.md) owns the Arcogine/game responsibility boundary, upstream readiness dependencies, implementation entry criteria, integration acceptance criteria, and non-goals. [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) owns the runtime gates themselves.
+[Factory-Design Game Consumer Initiative](factory-design-game-consumer.md) owns the Arcogine/game responsibility boundary, upstream readiness dependencies, implementation entry criteria, integration acceptance criteria, and non-goals. [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) owns the runtime gates themselves. [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) owns the accepted W1 decomposition and work-item identity contract.
 
 Detailed art direction, content expansion, campaign design, and distribution planning should remain outside Arcogine until the vertical slice provides evidence that those investments are justified.

--- a/docs/planning/factory-simulation-engine-readiness.md
+++ b/docs/planning/factory-simulation-engine-readiness.md
@@ -4,7 +4,7 @@
 > **Scope:** Prepare Arcogine's factory runtime for external consumers after the canonical factory-model boundary is established  
 > **Authority:** Planning only; this document defines runtime-readiness gates, not current capability or accepted architecture  
 > **Prerequisite:** the model-seam entry gate (§1.1) — narrower than full D1-D4 in [Factory Design Capability](factory-design-capability.md)  
-> **Related:** [Factory Design Architecture](../architecture/factory-design.md), [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md), [Architecture Overview](../architecture/overview.md)
+> **Related:** [Factory Design Architecture](../architecture/factory-design.md), [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md), [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md), [Architecture Overview](../architecture/overview.md)
 
 ## 1. Purpose
 
@@ -131,7 +131,7 @@ Gate 2        Capability-based deterministic dispatch
         ↓
 Gate 3        Consumer-neutral simulation session
         ↓
-W1            Intra-order work decomposition / lot-and-batch execution
+W1            Intra-order execution decomposition
         ↓
 Gate 4        Stable observations and event envelopes
         ↓
@@ -140,7 +140,7 @@ Gate 5        Spatial runtime consequences
 Game consumer may begin
 ```
 
-The current fixed-quantity factory-design reference challenge already activates **W1 — intra-order work decomposition / lot-and-batch execution**. W1 is therefore a required Engine capability in the critical path between Gate 3 and Gate 4. It is not a hidden completion condition for Gate 2; Gate 2 remains complete for dispatch of independently dispatchable work. See [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md) and §14.1.
+The current fixed-quantity factory-design reference challenge activates **W1 — intra-order execution decomposition**. ADR-0009 records why W1 is separate from Gate 2 dispatch; [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) now records the accepted W1 architecture. W1 remains an implementation/evidence prerequisite in the critical path between Gate 3 and Gate 4: one accepted quantity-`N` `Order` decomposes deterministically into `N` independently dispatchable unit-quantity `Job`s, `JobId` is the work-item identity, aggregate progress/completion remains order-level, and exactly one order completion is emitted. Gate 2 remains complete for dispatch of independently dispatchable work.
 
 Distribution hardening follows the core gates. A first UI experiment may begin after these gates; a distributable client additionally requires the contract, recovery, persistence, and packaging work in Section 11.
 
@@ -195,13 +195,27 @@ Job (mutable execution)
 
 The second Gate 1 slice added an explicit, consumer-neutral workload-submission entry point: `FactoryRuntime.submitWorkload(productId, quantity, unitPrice)`. `FactoryRuntime` wraps a `FactoryHandler` together with a `Scheduler` it owns internally, so a caller supplies only product/quantity/commercial intent -- never a mutable `Scheduler` or an authoritative simulation time, which stayed internal event-engine plumbing rather than becoming part of the workload boundary. Both `FactoryRuntime.submitWorkload` and the economy-driven `OrderCreation` event resolve to the same package-private `FactoryHandler.submitOrder(productId, quantity, unitPrice, currentTime, scheduler)` acceptance operation -- `FactoryHandler.handleEvent` delegates to it for that event rather than duplicating the logic, and it is not exposed outside the `factory.process` package. `FactoryHandler` already had no compile-time dependency on economy/pricing/demand/agents; this slice makes explicit submission a supported, named entry point instead of something only reachable by hand-constructing an internal event payload and owning a `Scheduler`. `FactoryRuntime` is only constructed from a published model, via `FactoryRuntime.forModel(FactoryModelVersion)` (internally using `FactoryRuntimeAssembler`) -- never wrapped around an already-live `FactoryHandler` some other scheduler might also be driving, so it always owns the exclusive factory/scheduler pair it advances and event ordering stays globally authoritative. It also does not expose the mutable `FactoryHandler` directly; callers observe state through `FactoryRuntime`'s own read-only projections (`ordersView`, `jobsView`, `job`, `machinesView`, `backlog`, `avgLeadTime`, `throughput`, `completedSalesValue`, `completedSales`). A headless test (`ExplicitWorkloadSubmissionTest`) builds a runtime this way and submits workload directly, with no `DemandModel`, `PricingState`, or agent in the loop, and proves repeated identical submissions are deterministic. `FactoryRuntime.advance()` pumps exactly one pending event at a time so a headless caller can drive submitted workload to completion without reaching into scheduler internals; this is deliberately not a general session/advancement API -- that remains Gate 3 work. Economy-driven scenarios continue to work unchanged: `DemandModel.generateOrders` still schedules `OrderCreation` events, which route through the same `submitOrder` logic.
 
-The third Gate 1 slice made order quantity consume proportional production work. `FactoryHandler.submitOrder` now sizes a job's routing to `routing.stepCount() * quantity` instead of `routing.stepCount()`: the job repeats its routing once per unit of quantity, and dispatch/completion resolve each job-global step back to its underlying `RoutingStep` by `stepIndex % routing.stepCount()`. This was chosen over multiplying each step's fixed `duration` by quantity, and over creating one `Job`/`JobId` per unit, because it gives countable progress (`Job.currentStep()` is a job-global counter that advances once per routing step executed, i.e. `routing.stepCount()` times per unit) without multiplying `Order`/`Job` object volume per unit of quantity -- a 100,000-unit order still creates exactly one `Order` and one `Job`, just with a larger `totalSteps` counter. This deliberately does not bound *event* volume the same way: `TaskStart`/`TaskEnd` events are still scheduled once per routing step per unit (quantity-proportional), because that is the mechanism that makes quantity actually consume proportional machine-occupied time; only object allocation (`Order`/`Job`/`JobId`) stays flat. The externally visible `TaskStart`/`TaskEnd.stepIndex` continues to carry the routing-local index (`stepIndex % routing.stepCount()`), not the job-global counter, so that event field's existing meaning is unchanged. `Job` remains strictly one-to-one with `Order` under this model, so `OrderCompleted`'s existing `jobId` correlation field stays unambiguous and did not need to change; `OrderCompleted` still fires exactly once per order, only after the job's full (quantity-scaled) routing completes. `completedSales`/`backlog`/`avgLeadTime` keep their existing per-order (per-job) counting semantics -- quantity now changes *how long* a job occupies a machine and stays in backlog, not what those counts measure. Both the economy-driven `OrderCreation` path and `FactoryRuntime.submitWorkload` resolve to this same `submitOrder` operation, so they share identical proportional-quantity semantics. See `ProportionalQuantityWorkTest` for the headless proof, including a multi-step, multi-quantity execution that exercises the `stepIndex` modulo wrap-around directly (quantity 10 taking ten times the machine-occupied ticks of quantity 1, determinism, single completion, and economy/explicit-path equivalence).
+The third Gate 1 slice made order quantity consume proportional production work. `FactoryHandler.submitOrder` now sizes a job's routing to `routing.stepCount() * quantity` instead of `routing.stepCount()`: the job repeats its routing once per unit of quantity, and dispatch/completion resolve each job-global step back to its underlying `RoutingStep` by `stepIndex % routing.stepCount()`. This was chosen over multiplying each step's fixed `duration` by quantity, and over creating one `Job`/`JobId` per unit, because it gives countable progress (`Job.currentStep()` is a job-global counter that advances once per routing step executed, i.e. `routing.stepCount()` times per unit) without multiplying `Order`/`Job` object volume per unit of quantity -- a 100,000-unit order still creates exactly one `Order` and one `Job`, just with a larger `totalSteps` counter. This deliberately does not bound *event* volume the same way: `TaskStart`/`TaskEnd` events are still scheduled once per routing step per unit (quantity-proportional), because that is the mechanism that makes quantity actually consume proportional machine-occupied time; only object allocation (`Order`/`Job`/`JobId`) stays flat. The externally visible `TaskStart`/`TaskEnd.stepIndex` continues to carry the routing-local index (`stepIndex % routing.stepCount()`), not the job-global counter, so that event field's existing meaning is unchanged. `Job` remains strictly one-to-one with `Order` under this implemented model, so `OrderCompleted`'s existing `jobId` correlation field stays unambiguous today and `OrderCompleted` still fires exactly once per order, only after the job's full quantity-scaled routing completes. `completedSales`/`backlog`/`avgLeadTime` keep their existing per-order (per-job) counting semantics. Both the economy-driven `OrderCreation` path and `FactoryRuntime.submitWorkload` resolve to this same `submitOrder` operation, so they share identical proportional-quantity semantics. See `ProportionalQuantityWorkTest` for the headless proof.
 
-One accepted order currently corresponds to exactly one execution job (the routing repeats within that job rather than spawning multiple jobs). This remains the implemented model today, but the current fixed-quantity reference challenge now requires a subsequent W1 work-decomposition capability that can expose independently dispatchable execution units within one accepted order. W1 is active planning under §14.1 and [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md); it is separate from Gate 2.
+That one-`Order`/one-`Job` shape remains the **implemented pre-W1 runtime**, but it is no longer the intended architecture for quantity decomposition. ADR-0010 accepts the W1 target shape:
 
-The existing `OrderCompleted` event retains `jobId`, not an explicit `orderId`, as its correlation field. Under the 1 Order <-> 1 Job invariant this model keeps, that correlation is unambiguous and fully supported: a consumer resolves `OrderCompleted.jobId` through `FactoryRuntime.job(jobId)` to a `JobView`, whose `orderId()` identifies the accepted `Order` the completion belongs to. `Gate1EngineReadinessAcceptanceTest` proves this path end to end through `FactoryRuntime` alone. Adding an explicit `orderId` field to the event payload is a stable-event-contract concern -- it belongs to the later Gate 4 (`§8`) work on event envelopes, not Gate 1: Gate 1 only requires that completion be derivable and observable through a supported observation, which it is.
+```text
+Order (immutable intent, OrderId)
+        |
+        v
+order-level execution aggregate (same OrderId)
+        |
+        +---- Job ordinal 0, executionQuantity 1
+        +---- Job ordinal 1, executionQuantity 1
+        +---- ...
+        +---- Job ordinal N-1, executionQuantity 1
+```
 
-The canonical-model seam is already complete enough for this runtime work, so definition-model changes do not need to be mixed into the remaining Gate 1 refactor.
+Under that contract, `JobId` is the independently dispatchable work-item identity; each child traverses the routing exactly once; child creation/ID allocation/initial dispatch are deterministic in ordinal order; aggregate `releasedQuantity` and `completedQuantity` are order-level; backlog/completed-sales/lead-time remain order-level measures; and the final child completion emits exactly one `OrderCompleted` carrying explicit `OrderId` plus the completing child `JobId`.
+
+The current `OrderCompleted` payload still retains `jobId`, not explicit `orderId`, because W1 has not yet been implemented. ADR-0010 intentionally moves that correlation change into W1 rather than postponing it to Gate 4: once several `JobId`s belong to one `Order`, order completion must identify the aggregate explicitly. Gate 4 remains responsible for the later stable event-envelope contract, not for deciding W1's basic execution identities.
+
+The canonical-model seam is already complete enough for this runtime work, so definition-model changes do not need to be mixed into W1.
 
 ### 5.3 Required behavior
 
@@ -224,16 +238,16 @@ Gate 1 is satisfied when:
 7. The same model version, seed, and workload produce the same ordered result.
 8. Existing economy-driven scenario behavior remains covered or is migrated deliberately.
 
-**Gate 1 is complete.** All eight criteria have identified executable evidence:
+**Gate 1 is complete.** All eight criteria have identified executable evidence for the Gate 1 baseline. That evidence records the implemented pre-W1 representation and should not be read as overriding ADR-0010's later accepted architecture:
 
 1. **Runtime instantiates from a published model.** `FactoryRuntime.forModel(FactoryModelVersion)` is the only constructor; there is no path to a `FactoryRuntime` that was not built from a published model. Proven by every test in `Gate1EngineReadinessAcceptanceTest`, `ExplicitWorkloadSubmissionTest`, and `ProportionalQuantityWorkTest`.
 2. **Explicit submission without economy/demand/agents.** `FactoryRuntime.submitWorkload(productId, quantity, unitPrice)` requires no `DemandModel`, `PricingState`, or agent. Proven by `ExplicitWorkloadSubmissionTest` and `Gate1EngineReadinessAcceptanceTest.modelAndRuntimeBoundary`.
-3. **Quantity consumes proportional production work.** `FactoryHandler.submitOrder` sizes a job's routing to `routing.stepCount() * quantity`. Proven by `ProportionalQuantityWorkTest` (including the routing-local `stepIndex` modulo wrap-around) and, at the `FactoryRuntime` boundary, by `Gate1EngineReadinessAcceptanceTest.quantityDrivesRepeatedProductionStepCompletionBeforeTheJobIsDone`.
-4. **Immutable order intent vs. mutable execution state.** The `Order`/`Job` split: `Order` is an immutable record; `Job` is mutable execution state referencing it. Proven by `OrderIntentSeparationTest` and `Gate1EngineReadinessAcceptanceTest.modelAndRuntimeBoundary`.
-5. **One job per order, with job-global progress standing in for "work items."** `Job.currentStep()` is a job-global counter advancing once per routing step executed (`routing.stepCount()` times per unit), from which per-unit progress is derivable (`currentStep / routing.stepCount()`). This is the deliberate current shape of the quantity model (see §5.2), not multiple `Job` objects per `Order`.
-6. **Completion derived from executed work, observable via `FactoryRuntime.advance()`.** `OrderCompleted` fires only once `Job.isComplete()` (i.e., every quantity-scaled step has executed), and is observed as the return value of `FactoryRuntime.advance()`. Proven end to end by `Gate1EngineReadinessAcceptanceTest.completionIsObservableThroughFactoryRuntimeAdvance`, which also proves the `OrderCompleted.jobId` -> `FactoryRuntime.job(jobId)` -> `JobView.orderId()` correlation path described above.
-7. **Determinism.** The strongest ordered-stream proof reaches the full `FactoryRuntime` contract, not just the `FactoryHandler`/`Scheduler` seam: `Gate1EngineReadinessAcceptanceTest.identicalWorkloadFromTwoFreshRuntimesProducesIdenticalOrderedEventStreamsAndTerminalState` drains the entire ordered event stream from two independently constructed, fresh `FactoryRuntime`s given the same published model and workload and asserts the streams are identical, plus identical terminal state (job completion, lead time, backlog, completed sales count/value, average lead time). `ExplicitWorkloadSubmissionTest.repeatedIdenticalSubmissionsAreDeterministic` and `ProportionalQuantityWorkTest.identicalWorkloadProducesIdenticalOrderedResults` remain as lower-level determinism evidence at the `FactoryHandler`/`Scheduler` seam.
-8. **Economy-driven workload shares the same accepted-order/proportional-work path.** Both the economy-driven `OrderCreation` event and `FactoryRuntime.submitWorkload` resolve to the same package-private `FactoryHandler.submitOrder`. Existing regression evidence: `ProportionalQuantityWorkTest.economyDrivenOrderCreationFollowsTheSameProportionalWorkSemanticsAsQuantityOne` and `.explicitAndEconomyPathsProduceIdenticalProportionalWorkForTheSameQuantity` prove the two paths share identical proportional-work semantics; `OrderLifecycleIntegrationTest` (`interfaces/api`) proves the full economy-driven `OrderCreation -> Factory -> OrderCompleted -> Finance` chain end to end through the real wired `IntegratedHandler`; `DemandModelTest` proves the economy demand loop schedules `OrderCreation` events, which route through the identical acceptance path. This evidence was judged sufficient as-is -- no additional economy scenario test was needed to close this criterion.
+3. **Quantity consumes proportional production work.** The current implementation sizes a job's routing to `routing.stepCount() * quantity`. Proven by `ProportionalQuantityWorkTest` and `Gate1EngineReadinessAcceptanceTest.quantityDrivesRepeatedProductionStepCompletionBeforeTheJobIsDone`. W1 will preserve proportional work while changing representation to unit-quantity sibling jobs.
+4. **Immutable order intent vs. mutable execution state.** The `Order`/`Job` split is established: `Order` is immutable; `Job` is mutable execution state referencing it. ADR-0010 extends that split to several sibling jobs under one order rather than replacing it.
+5. **Work-item progress is represented.** Today one job-global progress counter stands in for the quantity work. ADR-0010 resolves the later concrete multi-work-item representation required by the reference challenge.
+6. **Completion derived from executed work, observable via `FactoryRuntime.advance()`.** Current completion remains proven by Gate 1 acceptance tests; W1 must preserve exactly-once order completion after aggregate child progress reaches requested quantity.
+7. **Determinism.** Existing two-fresh-runtime tests prove the current representation. W1 adds stronger determinism requirements covering child ordinals, `JobId` allocation, initial dispatch, assignments, ordered events, and aggregate terminal state.
+8. **Economy-driven workload shares the same accepted-order/proportional-work path.** Both economy-driven `OrderCreation` and explicit submission resolve to the same acceptance path. W1 must preserve that convergence while changing the internal decomposition.
 
 ## 6. Gate 2 — Capability-based deterministic dispatch
 
@@ -272,7 +286,7 @@ Gate 2 removed that restriction: `RoutingStep` now carries `Set<MachineId> eligi
 
 ### 6.3 Deterministic dispatch
 
-The dispatch policy established by ADR-0005, applied in `FactoryHandler.selectMachine`:
+The dispatch policy established by ADR-0005 and retained by ADR-0009, applied in `FactoryHandler.selectMachine`:
 
 1. eligible;
 2. online (an eligible machine that is `Offline` is excluded from selection while any eligible machine is online);
@@ -282,7 +296,7 @@ The dispatch policy established by ADR-0005, applied in `FactoryHandler.selectMa
 
 Projected-completion-time ranking, resource pools, and capability taxonomies were considered and deliberately deferred -- none are required by the acceptance criteria below. A future slice that changes ranking must record that decision rather than silently reinterpreting the current policy.
 
-Gate 2 is about **dispatch**, not work decomposition: the runtime selects an eligible resource for an independently dispatchable unit of work that already exists. Splitting one accepted production order into several concurrently executable lots/batches/execution units is the separate W1 production-semantic capability now activated by the current reference challenge (§14.1; [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md)).
+Gate 2 is about **dispatch**, not work decomposition: the runtime selects an eligible resource for an independently dispatchable unit of work that already exists. ADR-0010 now defines how W1 creates those units within one accepted quantity-scaled order: deterministic unit-quantity sibling `Job`s identified by `JobId`. That decision does not change Gate 2's selector or `pendingMultiEligible` semantics.
 
 ### 6.4 Acceptance criteria
 
@@ -290,13 +304,13 @@ Gate 2 is satisfied when:
 
 1. Runtime consumes model-side resource definitions and installed instances rather than redefining them. **Satisfied** (unchanged by this slice -- `FactoryRuntimeAssembler` builds `Machine`s directly from `ResourceDefinition`).
 2. Two equivalent eligible resource instances can both execute the same operation. **Satisfied** -- proved at both the `FactoryHandler` seam (`MultiResourceDispatchTest`) and end to end through the published-model boundary (`Gate2MultiResourceDispatchAcceptanceTest`, driven entirely through `FactoryRuntime`).
-3. Both resources are used when workload justifies parallel capacity. **Satisfied** for sufficient independently dispatchable work: `Gate2MultiResourceDispatchAcceptanceTest.publishedMultiEligibleModelSurvivesAssemblyAndDispatchesBothOrdersConcurrently` proves two independent orders occupy both eligible machines at once, through `FactoryRuntime` alone. Gate 2 does not require one quantity-scaled order to be decomposed into several concurrent execution units; that is W1.
+3. Both resources are used when workload justifies parallel capacity. **Satisfied** for sufficient independently dispatchable work: `Gate2MultiResourceDispatchAcceptanceTest.publishedMultiEligibleModelSurvivesAssemblyAndDispatchesBothOrdersConcurrently` proves two independent orders occupy both eligible machines at once, through `FactoryRuntime` alone. Gate 2 does not require one quantity-scaled order to be decomposed; ADR-0010/W1 provides that separate capability.
 4. Equal candidates resolve reproducibly through a stable tie-break rule. **Satisfied** -- `MultiResourceDispatchTest.equalCandidatesResolveDeterministicallyToTheLowestMachineId` and `Gate2MultiResourceDispatchAcceptanceTest.identicalWorkloadFromTwoFreshRuntimesResolvesToTheSameMachineAssignments`.
-5. Adding a second compatible resource changes queueing, utilization, throughput, or completion time in an appropriate workload. **Satisfied**: under concurrent independent orders, both machines' queues stay empty where a single-machine model would queue the second order. The criterion requires an appropriate workload with sufficient independently dispatchable work; it does not require intra-order work decomposition.
-6. Removing/disabling one instance does not require changing the product definition. **Satisfied**, including the machine-recovery lifecycle: `MultiResourceDispatchTest.machineComingBackOnlineDispatchesWorkThatWasStrandedWaitingOnAnotherMachine` and `Gate2MultiResourceDispatchAcceptanceTest.bringingAnEligibleMachineOnlineDispatchesWorkStrandedWaitingForTheOtherMachine` prove that work waiting because one eligible machine was offline is not pinned to whichever other machine happened to be checked when it started waiting -- `FactoryHandler` reconsiders it against its whole eligible set whenever any eligible machine frees up or comes online (see `pendingMultiEligible`/`tryDispatchPendingMultiEligible`), so a machine that was offline when a job first waited can still pick it up once it recovers. `Gate2MultiResourceDispatchAcceptanceTest.offlineEligibleMachineIsExcludedAndRemovingItDoesNotRequireChangingTheProductDefinition` proves the product/operation definition is untouched, only runtime machine availability changes. `Gate2MultiResourceDispatchAcceptanceTest.disjointPendingPoolDispatchesEvenWhileAnEarlierUnrelatedPoolIsStillFull` proves the pending backlog does not head-of-line block: an undispatchable entry waiting on one still-fully-busy eligible pool does not stop a later entry with a disjoint eligible pool from dispatching the moment its own pool frees up.
-7. Resource capability, operational status, and queue state remain distinct concepts. **Satisfied** -- `OperationStepDefinition.eligibleResources` (model eligibility), `MachineState` (operational status), and `Machine`'s per-machine queue plus `FactoryHandler`'s cross-machine pending backlog (runtime queue state) remain separate types; this slice does not merge them.
+5. Adding a second compatible resource changes queueing, utilization, throughput, or completion time in an appropriate workload. **Satisfied** under concurrent independent orders. W1 must separately prove the same capacity can affect sibling jobs from one order.
+6. Removing/disabling one instance does not require changing the product definition. **Satisfied**, including machine recovery and cross-machine pending-work reconsideration.
+7. Resource capability, operational status, and queue state remain distinct concepts. **Satisfied** -- `OperationStepDefinition.eligibleResources`, `MachineState`, per-machine queue state, and `pendingMultiEligible` remain separate concepts.
 
-**Gate 2 is complete.** All seven criteria have executable evidence for deterministic resource selection and parallel-capacity use across independently dispatchable work. Intra-order parallelism is not an unfinished Gate 2 condition; it is the separately activated W1 work-decomposition / lot-and-batch execution capability (§14.1, ADR-0009). Also deferred unless a concrete need arises: load-aware ranking beyond queue depth and resource pools/capability taxonomies.
+**Gate 2 is complete.** Intra-order parallelism is not an unfinished Gate 2 condition; it is the separately accepted W1 execution-decomposition contract in ADR-0010. Also deferred unless a concrete need arises: load-aware ranking beyond queue depth and resource pools/capability taxonomies.
 
 ## 7. Gate 3 — Consumer-neutral simulation session
 
@@ -332,6 +346,8 @@ Every externally initiated runtime change returns a definite result containing a
 
 A rejected runtime command must not leave partial mutation.
 
+W1 preserves this contract. In particular, rejected workload submission must leave no partial `Order`, order-level execution aggregate, child `Job`, machine assignment/queue mutation, `pendingMultiEligible` entry, or command-produced event.
+
 ### 7.3 Bounded advancement
 
 Interactive consumers control presentation speed by requesting bounded simulated progress. Wall-clock sleeping and rendering cadence remain outside the simulation core.
@@ -357,20 +373,9 @@ Gate 3 is satisfied when a non-graphical reference consumer can:
 7. identify the source model version throughout the session;
 8. operate without Spring controllers, frontend DTOs, or mutable domain internals.
 
-**Gate 3 is complete.** All eight criteria have identified executable evidence, all through `FactoryRuntime` alone -- see [ADR-0007](../architecture/decisions/0007-gate-3-session-control-primitives.md) for the full decision record behind the additive shapes below.
+**Gate 3 is complete.** All eight criteria have identified executable evidence through `FactoryRuntime`; see [ADR-0007](../architecture/decisions/0007-gate-3-session-control-primitives.md). W1 is required to preserve those session semantics while changing the work-item representation.
 
-1. **Instantiate a published model version.** Unchanged from Gate 1/2: `FactoryRuntime.forModel(FactoryModelVersion)` remains the only constructor.
-2. **Structured submit-workload results.** `FactoryRuntime.submitWorkload` and `FactoryRuntime.setMachineAvailability` -- the two externally initiated runtime changes this type exposes -- always return a definite `CommandResult<T>` (accepted/rejected/faulted status via the sealed `Accepted`/`Rejected`/`Faulted` variants; a stable code and diagnostic; `modelVersion()` provenance; every `Event` scheduled as a direct effect of the command) rather than ever throwing on rejection or returning `void`. `Rejected` wraps the original, already-structured, sealed `SimError` (`SimError.OutOfRange` for an invalid quantity, `SimError.UnknownId` for a product/machine with no match, `SimError.InvalidStateTransition` for taking a busy machine offline -- all concretely reachable today, and all verified pre-mutation) rather than re-deriving a parallel shape; `Faulted` covers the one case neither command can fully preflight -- a genuine engine fault deep in `setMachineAvailability`'s online-machine dispatch cascade, after mutation may already have started -- so the command still always returns rather than throwing past its boundary, while being honest that `Faulted`, unlike `Rejected`, does not promise zero mutation. Acceptance and execution outcome are independent facts: `Faulted` carries the same accepted value (`EventPayload.MachineAvailabilityChange`) `Accepted` would have, alongside the fault, since the request genuinely was applied before the later failure -- a caller never loses which entity was affected just because execution subsequently failed. See ADR-0007 for the full design and the four successive review rounds that shaped it: why an earlier revision over-claimed this criterion by relying on the exception-based contract alone, why a further revision fixed a real partial-mutation bug in the first `CommandResult` implementation (a `SimTime` overflow discoverable only after `Order`/`Job`/`Machine` mutation had already started), why a third revision added `Faulted` after review found the interim fix could still let a post-mutation fault escape as a bare exception, and why a fourth revision gave `Faulted` an accepted value after review found it had collapsed acceptance and execution outcome onto one axis. Proven by `Gate3SessionControlAcceptanceTest.acceptedSubmissionReturnsAStructuredResultWithProvenanceAndScheduledEvents`, `.rejectedSubmissionReturnsAStructuredResultAndLeavesNoPartialMutation`, `.rejectedSubmissionFromAPostValidationSchedulingFailureStillLeavesNoPartialMutation`, `.machineAvailabilityCommandReturnsAStructuredResultForAcceptanceAndRejection`, `.takingABusyMachineOfflineIsRejectedBeforeAnyMutation`, and `.setMachineAvailabilityReportsFaultedRatherThanThrowingWhenTheDispatchCascadeFailsAfterMutation` -- asserting the actual result fields and post-command state rather than only exception-subtype/no-partial-mutation behavior in the easy cases.
-3. **Advance exactly one event.** Unchanged: `FactoryRuntime.advance()`.
-4. **Advance to a selected simulated time with a maximum event bound.** New: `FactoryRuntime.advanceUntil(SimTime targetTime, long maxEvents)`, implemented directly in terms of `advance()` so it cannot diverge from single-event dispatch semantics. Proven equivalent to looping `advance()` one event at a time -- both bounded to one event per call and unbounded in a single call -- by `Gate3SessionControlAcceptanceTest.advanceUntilBoundedToOneEventPerCallConvergesWithLoopingAdvance` and `.advanceUntilDrainingInOneUnboundedCallConvergesWithLoopingAdvance`; the time bound is proven independently by `.advanceUntilStopsAtTheTargetSimulatedTimeWithoutProcessingLaterEvents`.
-5. **Inspect order, work-item, queue, and resource state.** The existing `ordersView`, `jobsView`, `job`, `machinesView`, `backlog`, `avgLeadTime`, `throughput`, `completedSalesValue`, `completedSales` projections (proven across the Gate 1/Gate 2 acceptance tests) do not, by themselves, expose all authoritative queue state under the current Gate 2 dispatch model: `FactoryHandler.pendingMultiEligible` (ADR-0005) is a second, cross-machine waiting-work structure not reflected in any `MachineView.queueDepth()`. New: `FactoryRuntime.pendingWorkView()` exposes it as read-only `PendingWorkView(JobId, Set<MachineId>)` entries. Proven by `Gate3SessionControlAcceptanceTest.pendingWorkViewExposesAMultiEligibleJobWaitingWhileBothEligibleMachinesAreOccupied`, which occupies both eligible machines, submits a third order, shows every machine's `queueDepth()` at zero while `pendingWorkView()` reports the waiting job and its eligible set, then shows the job dispatched and cleared from `pendingWorkView()` once a machine frees up.
-6. **Reset and reproduce the same result.** New: `FactoryRuntime.reset()` returns a fresh `FactoryRuntime.forModel(modelVersion())`, leaving the original session untouched -- fresh construction rather than in-place mutation, since `FactoryHandler`'s stores have no partial-reset subsystem to mutate safely (see ADR-0007). Proven by `Gate3SessionControlAcceptanceTest.resetSessionReproducesIdenticalResultToTheOriginalSessionWithoutMutatingIt`, mirroring `Gate1EngineReadinessAcceptanceTest`'s two-fresh-runtimes determinism pattern: a reset session replaying the identical workload reproduces an identical ordered event stream and terminal state, and the original session's own state is unaffected by the `reset()` call.
-7. **Identify the source model version throughout the session.** New: `FactoryRuntime` retains the exact `FactoryModelVersion` passed to `forModel` and exposes it via `modelVersion()`, unchanged for the session's lifetime. Proven by `Gate3SessionControlAcceptanceTest.runtimeRetainsAndExposesItsSourceModelVersionThroughoutTheSession`.
-8. **Operate without Spring controllers, frontend DTOs, or mutable domain internals.** Unchanged: `FactoryRuntime` has no dependency on `interfaces/api` or `interfaces/web`, and every new method/type (`modelVersion()`, `advanceUntil`, `reset()`, `CommandResult`, `pendingWorkView()`/`PendingWorkView`) is a plain domain type or read-only projection, following the same shape as the rest of the class.
-
-This slice deliberately does not migrate `interfaces/api`'s `SimThread` or `interfaces/cli`'s `SimRunner`/`HeadlessHandler` onto `FactoryRuntime`/`advanceUntil` -- both still duplicate their own bespoke max-time loop, which ADR-0007 records as accepted, separately tracked follow-up rather than silently left unrecorded. Neither called `submitWorkload`/`setMachineAvailability` either, so this slice's `CommandResult<T>` signature change touches no production code outside the `factory` module's own tests. It also does not add event envelopes/cursors (Gate 4), a new session-identity type, or a general command-result framework beyond the two commands that need one today -- no acceptance criterion above requires more.
-
-With Gate 3 closed, **W1 — intra-order work decomposition / lot-and-batch execution (§14.1) is the next active Engine semantic slice.** Gate 4 follows W1 so its stable observation/event contract can include the execution identities and correlation semantics W1 establishes.
+With Gate 3 closed, **W1 — intra-order execution decomposition (§14.1) is the next active Engine implementation slice.** Its architecture is no longer open: [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) defines the target. Gate 4 follows W1 so its stable observation/event contract can expose the resulting `OrderId`/`JobId` identities and aggregate progress semantics.
 
 ## 8. Gate 4 — Stable observations and event envelopes
 
@@ -407,7 +412,10 @@ Orders
     status
 
 Work items
-    parent order
+    JobId
+    parent OrderId
+    ordinal within order
+    execution quantity
     current operation
     assignment
     execution state
@@ -419,6 +427,8 @@ Performance
     work in process/backlog
     utilization
 ```
+
+The minimum order/work-item split above follows ADR-0010. Gate 4 may choose purpose-specific projection types and envelope structure, but it must not collapse aggregate order progress back into one child job or reinterpret `JobId` as an order identity.
 
 Not every consumer must receive one universal state dump. Purpose-specific observations remain preferable where they preserve capability boundaries.
 
@@ -439,13 +449,15 @@ payload
 
 The sequence is monotonic within one session and makes order explicit independently of event timestamps.
 
+ADR-0010 already requires W1's aggregate completion payload to include explicit `OrderId` while retaining the completing child `JobId`. Gate 4 must preserve that correlation inside whatever stable envelope it chooses.
+
 These are **simulation-runtime** events and observations. A future Operational Execution adapter may translate relevant production semantics into its own command/result and external-observation contracts, but Gate 4 does not define production telemetry envelopes, external source authenticity, or digital-twin reconciliation.
 
 ### 8.4 Acceptance criteria
 
 Gate 4 is satisfied when:
 
-1. Every externally visible runtime entity has a stable identifier.
+1. Every externally visible runtime entity has a stable identifier within the session semantics that own it.
 2. Observation state and emitted events agree about the same authoritative transition history.
 3. Event ordering is explicit and reproducible.
 4. A consumer can identify the active bottleneck using supported observations rather than internal stores.
@@ -566,7 +578,7 @@ Product
     CUT -> ASSEMBLE -> INSPECT
 
 Production requirement
-    one accepted order for 20 units
+    one accepted Order for 20 units
 
 Published model A
     one cutter
@@ -579,17 +591,24 @@ Published model B
     one inspector
 ```
 
-Expected evidence:
+Expected evidence under ADR-0010:
 
-- the workload remains one accepted production requirement / one parent Order rather than being rewritten by the consumer into several independent Orders;
-- the runtime exposes more than one independently dispatchable execution unit under that Order;
-- model B can execute different portions of the same Order concurrently on both eligible cutters;
-- parent-order quantity, progress, completion, and correlation remain deterministic and unambiguous;
-- adding the second cutter changes queueing, throughput, utilization, or completion time for this fixed-contract workload;
-- repeated fresh runs with the same model, workload, and commands reproduce the same decomposition, assignments, ordered events, and terminal result;
+- exactly one accepted parent `Order` exists for the 20-unit requirement;
+- exactly 20 sibling unit-quantity `Job`s exist under that order;
+- child ordinals, `JobId` allocation, and initial dispatch order are deterministic;
+- each child independently traverses `CUT -> ASSEMBLE -> INSPECT` exactly once and preserves its own operation precedence;
+- model B can execute different sibling jobs from the same order concurrently on both eligible cutters;
+- aggregate `releasedQuantity` is 20 after successful acceptance and aggregate `completedQuantity` advances exactly once per completed child from 0 through 20;
+- exactly one `OrderCompleted` is emitted, carrying explicit parent `OrderId` and the child `JobId` whose completion caused the aggregate transition;
+- backlog, completed-sales count/value, and order lead-time semantics remain order-level rather than multiplying by child count;
+- adding the second cutter changes queueing, utilization, throughput, or completion time for this fixed-contract workload;
+- repeated fresh runs reproduce child identities/order, assignments, ordered events, progress transitions, and terminal state;
+- quantity 1 remains the degenerate one-order/one-child case;
 - the proof uses Arcogine-owned execution semantics rather than game-owned splitting logic.
 
-This benchmark is the minimum headless evidence for W1. The concrete representation of execution units/lots/batches is not prescribed by the benchmark and must follow the accepted W1 design.
+The W1 acceptance suite must also preserve existing Gate 2 independent-order behavior, offline/recovery behavior, Gate 3 reset/replay and bounded advancement, and rejected-submission atomicity.
+
+A non-functional large-order benchmark (for example quantity 100,000) must record the memory/execution impact of unit decomposition. W1 accepts quantity-proportional resident work-item count because arbitrary chunking would invent batch semantics; measured evidence should determine whether a later representation-efficiency design is required.
 
 ### 10.3 Layout benchmark
 
@@ -647,6 +666,8 @@ Engine readiness does not require:
 - external telemetry ingestion or digital-twin reconciliation;
 - fail-safe physical actuation or production adapter recovery;
 - dynamic mutation of published factory structure while work is in flight;
+- generalized material-lot identity/genealogy, configurable production batch sizes, transfer batches, or split/merge semantics as part of W1;
+- setup-family optimization, priority/due-date scheduling, or generalized scheduler semantics merely to implement W1;
 - a generic plugin framework;
 - multiplayer/distributed simulation/remote hosting;
 - game rendering, scoring, progression, narrative, tutorials, or player economy.
@@ -671,11 +692,11 @@ Scenario factory semantics
 
 1. Separate accepted immutable order intent from mutable job execution. **Implemented as the first behavior-preserving Gate 1 slice.**
 2. Add explicit workload submission independent of the economy/pricing loop. **Implemented as the second Gate 1 slice** (`FactoryRuntime.submitWorkload`, backed by package-private `FactoryHandler.submitOrder`).
-3. Make quantity consume proportional production work and allow multiple work items/jobs per order where required. **Implemented as the third Gate 1 slice**: a job's routing repeats once per unit of quantity (`totalSteps = routing.stepCount() * quantity`) rather than spawning multiple `Job`/`JobId` aggregates, giving a job-global executed-step counter (`Job.currentStep()`) from which per-unit progress can be derived, while keeping `Job` one-to-one with `Order`.
-4. Capability/eligibility-driven deterministic dispatch. **Implemented as Gate 2**: published multi-resource eligibility survives into runtime routing, independently dispatchable work is selected deterministically across equivalent resources, and queue/recovery semantics are covered by `MultiResourceDispatchTest` and `Gate2MultiResourceDispatchAcceptanceTest` (see ADR-0005 and ADR-0009).
-5. Consumer-neutral session and bounded advancement. **Implemented as the Gate 3 slice** (`FactoryRuntime.modelVersion()`, `advanceUntil(SimTime, long)`, `reset()`, `submitWorkload`/`setMachineAvailability` returning `CommandResult<T>`, `pendingWorkView()`; see [ADR-0007](../architecture/decisions/0007-gate-3-session-control-primitives.md)).
-6. **W1 — intra-order work decomposition / lot-and-batch execution. Active next slice.** Required by the current fixed 20-unit reference challenge; define independently dispatchable execution units under one accepted Order and prove §10.2. See [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md).
-7. Stable runtime observations and event envelopes.
+3. Make quantity consume proportional production work. **Implemented as the third Gate 1 slice** using repeated routing inside one `Job`; this is retained as historical/current pre-W1 behavior, not the accepted final decomposition shape.
+4. Capability/eligibility-driven deterministic dispatch. **Implemented as Gate 2**; see ADR-0009 for the dispatch/decomposition boundary.
+5. Consumer-neutral session and bounded advancement. **Implemented as Gate 3**; see ADR-0007.
+6. **W1 — intra-order execution decomposition. Active next implementation slice.** Architecture resolved by [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md): quantity `N` -> `N` unit-quantity sibling `Job`s; `JobId` is work-item identity; order-level execution progress uses the parent `OrderId`; Gate 2 dispatch is reused unchanged; exactly one order completion; deterministic ordering/replay; large-order benchmark required.
+7. Stable runtime observations and event envelopes, built on W1's execution identities.
 8. Spatial transfer consequences from published layout.
 9. Public-contract, recovery, persistence, and packaging hardening.
 
@@ -702,58 +723,62 @@ This milestone deliberately excludes changing the canonical-model boundary, layo
 
 | Decision | Trigger for resolution |
 |---|---|
-| Final aggregate/type boundaries for order and work execution | Gate 1 implementation |
-| Intra-order work decomposition / lot-and-batch execution | **Activated** by the current fixed 20-unit factory-design reference challenge; see ADR-0009 and §14.1 |
+| Final aggregate/type boundaries for order and work execution | Gate 1 baseline implemented; W1 parent/child shape further resolved by ADR-0010 |
+| Intra-order execution decomposition and work-item identity | **Resolved by ADR-0010; implementation/evidence active next slice** |
+| Future lot/batch sizing or material-lot identity | A concrete domain requirement supplies real lot/batch semantics beyond W1 unit decomposition |
 | Capability pools versus explicit eligible-instance sets | A concrete scheduling/control use case cannot be expressed cleanly by explicit eligibility |
-| Deterministic dispatch policy | Resolved by Gate 2 / ADR-0005 and ADR-0009; revisit only if a concrete workload requires a different ranking policy |
+| Deterministic dispatch policy | Resolved by Gate 2 / ADR-0009; revisit only if a concrete workload requires a different ranking policy |
 | Session interface/module ownership | Resolved by Gate 3 / ADR-0007; revisit only if a concrete consumer proves `FactoryRuntime` is no longer the right boundary |
 | Tick/event-count advancement semantics | Interactive/headless responsiveness tests |
-| Observation decomposition | First reference consumer and capability-boundary review |
+| Observation decomposition | First reference consumer and capability-boundary review after W1 |
 | Spatial metric/transfer policy | Layout benchmark prototype |
 | Public compatibility policy | Before external consumer contract publication |
 
-### 14.1 W1 — active execution capability: work decomposition / lot-and-batch execution
+### 14.1 W1 — active execution capability: intra-order execution decomposition
 
-Intra-order parallelism is a **separate active Engine execution capability**, not unfinished Gate 2 work. [ADR-0009](../architecture/decisions/0009-gate-2-closure-and-work-decomposition-boundary.md) records the dispatch-vs-decomposition boundary and activation of this capability.
+Intra-order parallelism is a **separate active Engine execution capability**, not unfinished Gate 2 work. ADR-0009 records the dispatch-vs-decomposition boundary and activation of W1. [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) resolves the production semantics that ADR-0009 deliberately left open.
 
-The generic activation trigger is:
-
-> A supported consumer requires one accepted production order of quantity N to expose multiple independently dispatchable execution units so equivalent resources can process different portions of that order concurrently.
-
-That trigger is already met by the current factory-design reference challenge: one fixed production requirement for 20 units must be able to benefit from installing a second eligible cutter without the game manufacturing several independent Arcogine Orders. Therefore W1 is the next active Engine semantic slice and must complete before Gate 4.
-
-W1 must define production semantics before implementation, including at minimum:
+The accepted W1 model is:
 
 ```text
-Production Order
-    ↓
-execution decomposition policy
-    ↓
-Lot / batch / execution unit(s)
-    ↓
-operation instances
-    ↓
-deterministic Gate 2 dispatch across eligible resources
+Order
+    immutable production intent
+    OrderId
+    requested quantity N
+        |
+        v
+order-level execution aggregate
+    identity: same OrderId
+    requested/released/completed quantity
+        |
+        +---- Job ordinal 0, executionQuantity 1, JobId
+        +---- Job ordinal 1, executionQuantity 1, JobId
+        +---- ...
+        +---- Job ordinal N-1, executionQuantity 1, JobId
 ```
 
-Questions to resolve include:
+W1 therefore does **not** need another design round to choose whether one unit becomes one execution object: for this first capability, it does. This is a deliberately minimal unit-decomposition policy, not a generalized lot/batch framework.
 
-- whether order quantity is divisible at every operation or only at declared decomposition points;
-- the identity and lifecycle of independently dispatchable execution units;
-- lot/batch sizing and whether transfer batches differ from production batches;
-- precedence when different units of one order are at different operations concurrently;
-- partial and aggregate progress semantics;
-- aggregate order completion and failure semantics;
-- event/observation correlation across Order, Job, and any new execution-unit identity;
-- deterministic interaction with setup/changeover, material, transfer, or other constraints if those capabilities exist when this work is activated.
+Required implementation semantics are fixed by ADR-0010:
 
-Do not assume "one quantity unit = one execution object." The first implementation should be driven by the concrete fixed-contract reference workload that activated the capability.
+- accepting quantity `N` creates exactly `N` unit-quantity sibling `Job`s under one `Order`;
+- `JobId` is the independently dispatchable work-item identity already used by machine queues, active work, pending work, and task events;
+- no new `ExecutionUnitId`, `LotId`, or `BatchId` is introduced;
+- child ordinal is immutable deterministic ordering metadata, not identity;
+- all W1 children are released atomically at acceptance, so `releasedQuantity == requestedQuantity` after successful submission;
+- each child traverses the routing exactly once and has no sibling precedence beyond its own routing order;
+- Gate 2's selector and `pendingMultiEligible` semantics are reused unchanged;
+- aggregate `completedQuantity` increments exactly once per child final completion;
+- the `N-1 -> N` aggregate transition emits exactly one `OrderCompleted`, carrying explicit `OrderId` and the completing child `JobId`;
+- backlog, completed-sales count/value, lead time, and existing order-throughput measures remain order-level;
+- `FactoryRuntime.submitWorkload` continues to return one `OrderId` and rejected submission remains zero-partial-mutation across the entire parent/child creation operation;
+- runtime observation must expose aggregate order progress rather than forcing consumers to infer it by counting child jobs;
+- child creation, `JobId` allocation, initial dispatch, queueing, pending-work reconsideration, machine tie-breaking, and same-time event ordering remain deterministic;
+- implementation must include the fixed-contract acceptance benchmark in §10.2 and a large-order performance/memory benchmark.
 
-This capability does **not** automatically include material-lot tracking, inventory allocation, setup optimization, transfer batching, or generalized production scheduling. Those remain separate unless the activating use case proves they are inseparable.
+This decision intentionally leaves material-lot genealogy, configurable batch sizes, transfer batches, split/merge, setup optimization, inventory allocation, generalized scheduling, and durable cross-session work-item identity out of W1. Those require separate accepted semantics when a concrete use case justifies them.
 
-W1 is placed **before Gate 4** deliberately. W1 establishes the execution identities, parent/child correlation, progress, and completion semantics that Gate 4 must then expose as stable observations and event envelopes. Gate 4 must not freeze a public contract around the current one-Job-per-Order shape and force W1 to retrofit identity later.
-
-Minimum W1 completion evidence is the fixed-contract benchmark in §10.2. Until that benchmark passes, Gate 4 is not the next active Engine gate and playable/runtime-integrated game work remains blocked.
+W1 remains placed **before Gate 4** deliberately. Gate 4 must stabilize observations and event envelopes around the execution identities and aggregate progress model W1 establishes rather than around the obsolete one-Job-per-Order runtime shape.
 
 The canonical model/run/runtime boundary is tracked by [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md). Operational execution-context/trust/command/deployment/reconciliation decisions belong to the sibling operational track and should receive their own ADRs when hard-to-reverse contracts are selected. Record additional accepted Engine decisions as ADRs rather than expanding this plan into a decision log.
 
@@ -765,7 +790,7 @@ As gates become implemented:
 
 - update [`../architecture/overview.md`](../architecture/overview.md) with established runtime architecture;
 - update [Factory Design Architecture](../architecture/factory-design.md) only as the model boundary becomes accepted/implemented;
-- update the [ISA-95 semantic mapping](../architecture/isa-95-semantic-mapping.md) when manufacturing concepts change;
+- update the [ISA-95 semantic mapping](../architecture/isa-95-semantic-mapping.md) when manufacturing concepts change, while distinguishing accepted target architecture from implementation status;
 - update [`../reference/api.md`](../reference/api.md) only for implemented public behavior;
 - add ADRs for durable execution, scheduling, session, persistence, and compatibility decisions;
 - keep headless acceptance scenarios executable and version-controlled;


### PR DESCRIPTION
## Summary

- add accepted ADR-0010 defining the W1 `Order -> order execution aggregate -> Job*` model
- establish `JobId` as the independently dispatchable work-item identity
- define quantity `N` as deterministic decomposition into `N` unit-quantity sibling `Job`s for W1
- preserve the existing Gate 2 dispatch policy and `pendingMultiEligible` semantics
- keep aggregate progress, backlog, lead time, completed-sales count/value, and exactly-once completion at the `Order` level
- require explicit `OrderId` plus completing child `JobId` on W1 order completion
- align Engine readiness, game consumer/vertical-slice planning, and the ISA-95 semantic mapping with the accepted architecture

## Key decisions

- one accepted `Order` remains one production requirement
- the order-level execution aggregate uses the same `OrderId`; no second aggregate identity is introduced
- no new `ExecutionUnitId`, `LotId`, or `BatchId` is introduced for W1
- child `ordinalWithinOrder` is deterministic ordering metadata, not identity
- all child jobs are released atomically at acceptance and each traverses the routing exactly once
- child creation, `JobId` allocation, initial dispatch, queueing, resource tie-breaking, and replay ordering are deterministic
- exactly one `OrderCompleted` is emitted when aggregate completed quantity reaches requested quantity
- Gate 4 remains after W1 so it can stabilize observations/events around the correct `OrderId`/`JobId` correlation model
- a large-order benchmark (for example quantity 100,000) is required before declaring W1 complete

## Documentation status

The docs deliberately distinguish **accepted target architecture** from **current implementation**. The runtime is still pre-W1 and currently uses one quantity-scaled `Job` per `Order`; this PR does not claim otherwise.

## Scope

Documentation and architecture only. No runtime implementation is included in this PR.