### PR TITLE
chore(deps-dev): bump @types/react-dom to ^19.2.5

### DIFF
--- a/product/interfaces/web/package-lock.json
+++ b/product/interfaces/web/package-lock.json
@@ -22,7 +22,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
-        "@types/react-dom": "^19.2.4",
+        "@types/react-dom": "^19.2.5",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
         "@typescript-eslint/parser": "^8.61.0",
         "@vitejs/plugin-react": "^6.1.0",
@@ -1630,9 +1630,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/product/interfaces/web/package.json
+++ b/product/interfaces/web/package.json
@@ -31,7 +31,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.4",
+    "@types/react-dom": "^19.2.5",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.61.0",
     "@vitejs/plugin-react": "^6.1.0",


### PR DESCRIPTION
### Motivation

- Bring the frontend dev dependency `@types/react-dom` forward one patch to `^19.2.5` to match the upstream Dependabot update trajectory and pick up type fixes.
- Ensure the repository lockfile accurately reflects the dependency change so installs are reproducible and CI uses the updated artifact.

### Description

- Updated `product/interfaces/web/package.json` devDependency `@types/react-dom` from `^19.2.4` to `^19.2.5` and updated `product/interfaces/web/package-lock.json` to reflect the resolved `19.2.5` package, URL, and integrity hash. 
- No other tracked files were changed and no unrelated edits were introduced.

### Testing

- Used the repository-supported Node version via `nvm use 22.22.2` and ran `npm ci` which completed successfully with no vulnerabilities reported. 
- Ran frontend validation commands `npm run lint`, `npm run build`, and `npm test`, with the frontend test run reporting 9 test files and 82 tests passed. 
- Ran the project-wide validation `./arcogine check` which completed successfully (Java compile/checks, unit tests, frontend lint/typecheck/tests and build all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a93ee6d5a44832281265d1d7f6dc2b2)