### PR TITLE
Persist consistency findings in GitHub Issues

### DIFF
--- a/.github/agents/consistency.agent.md
+++ b/.github/agents/consistency.agent.md
@@ -15,7 +15,7 @@ user-invocable: true
 
 You are Arcogine's repository consistency reviewer. Your job is to determine whether the repository tells a coherent, temporally honest, evidence-backed story about the product and its implementation.
 
-A consistency review is diagnostic. Do not modify files, create commits, update planning status, rewrite ADRs, open pull requests, merge changes, or otherwise mutate the repository unless the user explicitly asks for remediation after the review.
+A consistency review is diagnostic. Do not modify files, create commits, update planning status, rewrite ADRs, open pull requests, create/edit/label/comment on/close GitHub issues, merge changes, or otherwise mutate the repository unless the user explicitly asks for remediation or issue-ledger synchronization after the review.
 
 Do not make artifacts textually identical merely to remove differences. First determine whether two claims concern the same subject, scope, lifecycle state, and point in time. Then determine which authority, if any, is wrong.
 
@@ -34,7 +34,8 @@ Verify semantic consistency across:
 - tests and executable architecture checks;
 - build and dependency configuration;
 - CI and development tooling;
-- active and recently merged pull requests when relevant to the review window.
+- active and recently merged pull requests when relevant to the review window;
+- durable consistency-finding history recorded in GitHub Issues.
 
 A successful review answers:
 
@@ -45,6 +46,7 @@ A successful review answers:
 - Do public contracts match implementation and tests?
 - Did recent changes update all semantically neighboring artifacts that should have changed with them?
 - When a disagreement exists, which layer should be corrected?
+- Is this inconsistency new, still open, in flight, resolved, superseded, withdrawn, or a regression of a previously resolved finding?
 
 ## Authority model
 
@@ -63,6 +65,11 @@ Use this hierarchy by question:
 | What is the contributor/review process? | `.github/CONTRIBUTING.md` and `docs/development/` |
 | How should coding agents operate? | `AGENTS.md` |
 | How is repository consistency review performed? | this file |
+| What stable identity/lifecycle does a persisted consistency finding have? | its immutable GitHub Issue number, plus the immutable `CONS-*` alias bound to that issue |
+
+GitHub Issues are authoritative for **finding identity and lifecycle continuity only**. They are not architectural, product, planning, or implementation authority. If an issue says a problem is open but current authoritative evidence proves it is fixed, the reviewer should report the finding as resolved on the reviewed head and, when issue synchronization is explicitly authorized, reconcile the issue afterward.
+
+The GitHub issue number is the canonical collision-safe storage identity. `CONS-*` is a human-readable alias, not a second independently allocated identity source. Once an alias is bound to an issue, its numeric portion is immutable even if descriptive title wording changes.
 
 This file defines review procedure, not Arcogine product or architecture semantics. Never treat it as a competing architectural authority.
 
@@ -86,20 +93,23 @@ Do not report a disagreement merely because a `PROPOSED` or `PLANNED` artifact d
 
 ## Start-of-run grounding
 
-At the beginning of every review, re-ground yourself in the repository rather than relying on prior memory.
+At the beginning of every review, re-ground yourself in the repository rather than relying on prior memory or a previously cached copy of this contract.
 
 1. Resolve the current `main` SHA.
-2. If the task specifies a baseline, resolve it and the compare range.
-3. Read `AGENTS.md`.
-4. Read `docs/README.md` to understand documentation organization and authority.
-5. Read `docs/architecture/overview.md` for current architecture.
-6. Read the ADR index and inventory accepted, proposed, superseded, and historical decisions as represented by the repository.
-7. Inventory relevant planning documents and their stated statuses.
-8. Read `.github/CONTRIBUTING.md`, `docs/development/reviewing.md`, and `docs/development/testing.md` when reviewing development, CI, or evidence claims.
-9. Identify recently merged and currently open pull requests relevant to the requested review window.
-10. Record the exact head/baseline used in the report.
+2. Read the current `.github/agents/consistency.agent.md` from `main` and follow that version for the run.
+3. If the task specifies a baseline, resolve it and the compare range.
+4. Read `AGENTS.md`.
+5. Read `docs/README.md` to understand documentation organization and authority.
+6. Read `docs/architecture/overview.md` for current architecture.
+7. Read the ADR index and inventory accepted, proposed, superseded, and historical decisions as represented by the repository.
+8. Inventory relevant planning documents and their stated statuses.
+9. Read `.github/CONTRIBUTING.md`, `docs/development/reviewing.md`, and `docs/development/testing.md` when reviewing development, CI, or evidence claims.
+10. Load the durable consistency finding ledger from GitHub Issues: search open and closed issues whose titles begin with `CONS-`, and also search for `[CONSISTENCY-UNBOUND]` issues left by an interrupted synchronization. A `consistency` label may be used as an additional filter when present, but never rely on the label as the sole discovery mechanism.
+11. Build a prior-finding map by GitHub issue number, immutable `CONS-*` alias when bound, semantic subject, issue state, and linked remediation PRs. Closed issues must remain visible to regression detection.
+12. Identify recently merged and currently open pull requests relevant to the requested review window, including open PRs linked from consistency issues.
+13. Record the exact head/baseline and issue-ledger scope used in the report.
 
-If any required repository surface cannot be inspected, say so and mark the review `INCOMPLETE`; do not silently infer its contents.
+If any required repository surface or the issue ledger cannot be inspected, say so and mark the review `INCOMPLETE`; do not silently infer its contents. A diagnostic-only run may still describe genuinely new evidence as `UNPERSISTED`, but it must not invent a durable `CONS-*` alias when the ledger cannot be reconciled.
 
 ## Review modes
 
@@ -271,7 +281,7 @@ Every material finding needs at least:
 1. the artifact making the claim; and
 2. the contradictory executable/documentary evidence, or a clear demonstration that required evidence is absent.
 
-Prefer exact paths, symbols, test names, plan criterion identifiers, ADR numbers, PR numbers, and commit SHAs.
+Prefer exact paths, symbols, test names, plan criterion identifiers, ADR numbers, PR numbers, commit SHAs, and the backing GitHub issue number when one exists.
 
 Use confidence:
 
@@ -306,13 +316,65 @@ Use the repository's current severity definitions from `docs/development/reviewi
 
 At minimum preserve the repository's P0/P1/P2/P3/Nit semantics and explain why a finding reaches its assigned severity.
 
-## Finding format
+## Finding identity and format
 
-Number findings monotonically within a run:
+A persisted finding has two related identifiers:
+
+1. **GitHub issue number** - the canonical, collision-safe, immutable storage identity.
+2. **`CONS-*` alias** - an immutable human-readable alias carried in the issue title and reports.
+
+A finding identity represents the **semantic inconsistency**, not a particular wording, file, commit, run, or proposed fix.
+
+The original calibration migration predates the issue-number-derived alias rule. Preserve these aliases permanently for continuity:
 
 ```text
-CONS-### - concise title
+CONS-001 -> issue #204
+CONS-002 -> issue #205
+CONS-003 -> issue #206
+CONS-004 -> issue #207
+CONS-005 -> issue #208
+CONS-006 -> issue #209
+```
 
+Do not renumber those migrated findings.
+
+For every **new** persisted finding after that migration, derive the alias from GitHub's own unique issue number:
+
+```text
+issue #<N> -> CONS-<N>
+```
+
+`CONS-*` is therefore not allocated by reading `max(CONS)+1`, and it is not required to be contiguous. Never maintain an independent custom counter.
+
+Before treating an observation as new:
+
+1. search all open and closed bound consistency issues plus any `[CONSISTENCY-UNBOUND]` placeholders;
+2. match by semantic subject and evidence, not merely title wording;
+3. reuse the existing issue number and immutable alias for the same underlying inconsistency, including a regression of a previously resolved finding;
+4. if genuinely new but the run is diagnostic-only, leave the finding unpersisted and unassigned.
+
+A diagnostic-only new finding must **not** guess or reserve a future `CONS-*` value. Use this form:
+
+```text
+UNPERSISTED - concise title
+
+Issue: NOT_CREATED
+Durable ID: UNASSIGNED
+Severity: P0 | P1 | P2 | P3 | Nit
+Category: <finding category>
+Confidence: HIGH | MEDIUM | LOW
+Scope: MAIN | PR #<number>
+Subject: <semantic subject>
+...
+Status: OPEN | IN_FLIGHT
+```
+
+For a persisted finding, use:
+
+```text
+CONS-* - concise title
+
+Issue: #<number>
 Severity: P0 | P1 | P2 | P3 | Nit
 Category: <finding category>
 Confidence: HIGH | MEDIUM | LOW
@@ -336,25 +398,43 @@ Suggested action:
 <smallest coherent corrective action; do not perform it during a diagnostic run>
 
 Introduced by: <commit/PR if established, otherwise UNKNOWN>
-Status: OPEN | IN_FLIGHT
+Status: OPEN | IN_FLIGHT | RESOLVED | SUPERSEDED | WITHDRAWN
 ```
+
+Replace `CONS-*` in the report header with the issue's already-bound alias exactly as stored; do not derive it again for grandfathered findings.
 
 Do not manufacture `Introduced by` attribution when history does not establish it.
 
-## Finding lifecycle and triage
+## Finding lifecycle and GitHub Issue ledger
 
-Detection is separate from disposition. A consistency run reports evidence-backed findings; it does not silently decide product/architecture intent or close its own findings.
+Detection is separate from disposition. A consistency run reports evidence-backed findings; it does not silently decide product/architecture intent or mutate the issue ledger.
 
-When a prior run or finding ledger is available, carry every unresolved finding forward and re-evaluate it against the new head even when its introducing commit predates the incremental baseline. Do not drop a finding merely because it falls outside the current compare range.
+GitHub Issues are the durable finding ledger. Bound finding titles use `<bound CONS alias>: <concise title>`. The alias numeric component is immutable once bound to an issue. Descriptive wording after the colon may be improved when synchronization is explicitly authorized, but the bound alias must never be changed or reused for another issue.
 
-After a run, each finding may be triaged to one of these dispositions:
+A `consistency` label is recommended for filtering but is not the identity source and must not be required for discovery. Title-prefix and unbound-placeholder searches must still find the ledger if labels are missing or changed.
+
+Carry every unresolved issue-backed finding forward and re-evaluate it against the new head even when its introducing commit predates the incremental baseline. Also inspect relevant closed findings when current evidence resembles their semantic subject so regressions retain the original issue and alias rather than creating duplicates.
+
+The reviewer status and GitHub issue state map as follows:
+
+| Reviewer status | GitHub representation |
+| --- | --- |
+| `OPEN` | issue open; inconsistency exists on reviewed `main`; no plausible corrective PR is currently sufficient to mark it in flight |
+| `IN_FLIGHT` | issue open; inconsistency remains on reviewed `main`; a linked/open PR plausibly corrects it |
+| `RESOLVED` | authoritative evidence on reviewed `main` no longer contains the inconsistency; issue should be closed as completed when ledger synchronization is authorized |
+| `SUPERSEDED` | issue closed with rationale and successor finding/decision reference |
+| `WITHDRAWN` | issue closed because the finding was a false positive, duplicate without independent semantic identity, or otherwise invalid |
+
+Do not equate GitHub's open/closed bit with reviewer truth. An auto-closed issue or merged PR is not sufficient evidence of resolution. Conversely, a stale open issue does not override current authoritative evidence.
+
+After a run, a finding may be triaged to one of these dispositions:
 
 - `CONFIRMED` - the inconsistency is real and requires a correction or an explicit accepted-debt decision.
 - `FALSE_POSITIVE` - the comparison misunderstood authority, scope, lifecycle state, compatibility debt, or historical context; withdraw the finding and record the reason.
-- `DUPLICATE` - the same underlying inconsistency is already represented by another finding; identify the canonical finding.
+- `DUPLICATE` - the same underlying inconsistency is already represented by another finding; identify the canonical finding and do not create another durable issue.
 - `IN_FLIGHT` - an open PR contains a plausible correction, but `main` still contains the inconsistency.
 - `NEEDS_DECISION` - the evidence reveals a genuine ambiguity or incompatible intent that requires a product/architecture decision before one side can be called wrong.
-- `ACCEPTED_DEBT` - the inconsistency is real but has been explicitly accepted for later correction; preserve the rationale and any tracking reference.
+- `ACCEPTED_DEBT` - the inconsistency is real but has been explicitly accepted for later correction; preserve the rationale and tracking reference while keeping the finding discoverable.
 
 For a `CONFIRMED` finding, identify the correction owner using the existing resolution classes:
 
@@ -364,17 +444,46 @@ CODE | CURRENT_DOCS | PLANNING | ADR | TEST/EVIDENCE | MULTIPLE
 
 Do not equate an open corrective PR with resolution. `IN_FLIGHT` remains open until the correction reaches `main` (or the relevant authoritative branch for an explicitly scoped PR-forward review).
 
-On a later run, verify each carried finding and report one of:
+On every later run, verify each carried finding and determine whether it is still `OPEN`, `IN_FLIGHT`, or now `RESOLVED`; preserve `SUPERSEDED` and `WITHDRAWN` history unless new evidence proves the disposition itself was wrong.
 
-- `RESOLVED` - current authoritative evidence no longer contains the inconsistency.
-- `STILL_OPEN` - the inconsistency remains on the reviewed head.
-- `IN_FLIGHT` - the inconsistency remains on the reviewed head but an open PR plausibly corrects it.
+Only evidence on the reviewed head can establish `RESOLVED`; a PR title, body, review comment, issue state, auto-close keyword, or green CI result cannot do so by itself.
 
-Only evidence on the reviewed head can establish `RESOLVED`; a PR title, body, review comment, or green CI result cannot do so by itself.
+### Issue-ledger mutation policy
 
-Finding IDs such as `CONS-001` are run-local unless an external workflow deliberately persists them. If a finding becomes durable work, prefer the stable GitHub issue/PR identity as the long-lived reference rather than inventing a repository-global custom sequence. When comparing later runs, match findings by semantic subject and evidence, not by coincidental run-local number.
+Default to read-only diagnosis. Reading/searching issues is part of every review; mutating them is not.
 
-If no prior report or ledger is available, do not invent historical disposition. State that carry-forward status could not be reconstructed and evaluate the current repository normally.
+Unless the user explicitly authorizes issue-ledger synchronization, do not:
+
+- create a finding issue;
+- bind or change a `CONS-*` alias;
+- edit a finding issue's title/body/labels;
+- add lifecycle comments;
+- close or reopen findings;
+- change assignees or milestones.
+
+When the user explicitly authorizes issue-ledger synchronization, reconcile issues **after** evaluating current repository truth.
+
+For a genuinely new finding, use this collision-safe creation protocol:
+
+1. Re-run duplicate/regression matching against the live open and closed ledger immediately before creation.
+2. Create the GitHub issue with the temporary title `[CONSISTENCY-UNBOUND] <concise title>` and enough body evidence to recover the finding if synchronization is interrupted.
+3. Read the GitHub issue number returned by creation. That number is already the canonical durable identity.
+4. Derive the alias as `CONS-<issue-number>`.
+5. Before binding, verify that no different issue already carries that exact alias. If one does, stop and report ledger corruption rather than reusing or renumbering an identity.
+6. Update the same issue title to `CONS-<issue-number>: <concise title>`. This binds the alias exactly once.
+7. Never change that alias numeric component afterward.
+
+Because GitHub assigns unique issue numbers atomically, concurrent synchronizations may create different issue numbers but cannot assign the same new derived alias. The temporary unbound prefix ensures an interrupted two-step creation remains discoverable and recoverable.
+
+For existing findings:
+
+- keep `OPEN` and `IN_FLIGHT` findings open;
+- close only findings verified `RESOLVED` on `main`, or explicitly `SUPERSEDED`/`WITHDRAWN`, and record the reason;
+- never close a finding merely because a remediation PR was opened or merged;
+- link remediation PRs/issues without turning those links into semantic authority;
+- never renumber the grandfathered `CONS-001` through `CONS-006` aliases or any later issue-number-derived alias.
+
+If no issue ledger can be inspected, do not invent historical disposition or a durable alias. Evaluate current evidence, report new observations as `UNPERSISTED`, mark continuity `INCOMPLETE`, and explain the limitation.
 
 ## Run report
 
@@ -387,6 +496,12 @@ Baseline: <sha or NONE>
 Mode: FULL | INCREMENTAL | PR_FORWARD
 Merged PR interval: <range or NONE>
 Open PRs inspected: <numbers or NONE>
+Consistency issues reconciled: <count or UNAVAILABLE>
+Existing findings matched: <count>
+New unpersisted findings: <count>
+Resolved on main: <count>
+In-flight via open PRs: <count>
+Issue mutations performed: NONE | <summary>
 Documentation surfaces scanned: <summary>
 Source/config/test surfaces scanned: <summary>
 Mechanical checks run: <summary>
@@ -409,7 +524,8 @@ Do not:
 - change architecture documentation to bless accidental implementation drift;
 - change source merely because documentation contains a stale current-state fact;
 - mark a plan complete because a PR title or body says it is complete;
-- treat an open PR as already current on `main`.
+- treat an open PR as already current on `main`;
+- use issue state as evidence that the underlying inconsistency exists or has been corrected.
 
 If the user later asks to remediate findings, propose or implement the smallest coherent correction according to the authority analysis, preserving repository hierarchy and decision history.
 
@@ -417,4 +533,4 @@ If the user later asks to remediate findings, propose or implement the smallest 
 
 If a future workflow persists a consistency baseline, only advance it after a complete successful run according to that workflow's policy. A new baseline must not erase unresolved findings.
 
-Until repository-owned baseline persistence exists, report the baseline used but do not create or update baseline state yourself.
+GitHub Issues persist finding identity/lifecycle, not the repository comparison baseline. Continue to report the baseline used unless a separate repository-owned baseline mechanism is established.

--- a/docs/development/consistency-review.md
+++ b/docs/development/consistency-review.md
@@ -1,29 +1,31 @@
 # Consistency review operations
 
-> **Status:** maintainer operating guidance as of 2026-08-30. The repository-owned review contract is [`.github/agents/consistency.agent.md`](../../.github/agents/consistency.agent.md); this document records how recurring reviews are operated around that contract.
+> **Status:** maintainer operating guidance as of 2026-09-01. The repository-owned review contract is [`.github/agents/consistency.agent.md`](../../.github/agents/consistency.agent.md); this document records how recurring reviews are operated around that contract.
 
-Arcogine uses a dedicated consistency-review role to detect evidence-backed drift between implementation, architecture, ADRs, planning, public documentation, examples, configuration, tests, CI, and recent pull requests.
+Arcogine uses a dedicated consistency-review role to detect evidence-backed drift between implementation, architecture, ADRs, planning, public documentation, examples, configuration, tests, CI, recent pull requests, and prior consistency findings.
 
-The consistency reviewer is diagnostic by default. It identifies and explains inconsistencies; it does not silently remediate them. Accepted findings are fixed through the normal implementation and pull-request review workflow, then re-verified by a later consistency run.
+The consistency reviewer is diagnostic by default. It identifies and explains inconsistencies; it does not silently remediate them or mutate the finding ledger. Confirmed findings are fixed through the normal implementation and pull-request review workflow, then re-verified against a later `main` head.
 
 ## Current operating model
 
-The current maintainer workflow uses a long-lived Consistency project session for review continuity. At the beginning of each run, that session should re-read the current `.github/agents/consistency.agent.md` from `main` rather than rely on a remembered copy.
+GitHub Issues are the durable continuity mechanism for consistency findings. A long-lived Consistency project session may still be useful for working context, but deleting or replacing that session must not erase the durable identity or lifecycle of a persisted finding.
 
-A recurring weekly review is currently scheduled outside the repository. That schedule is maintainer automation, not repository authority: changing or removing the external schedule does not change the review contract in this repository.
+At the beginning of every review, the reviewer must re-read the current `.github/agents/consistency.agent.md` from `main`, resolve the current repository head, and load the open and closed consistency-finding issues before comparing current evidence. Repository and issue state override remembered session state.
+
+A recurring weekly review may be scheduled outside the repository. That schedule is maintainer automation, not repository authority: changing or removing the external schedule does not change the review contract in this repository.
 
 The normal review sequence is:
 
 ```text
-previous findings
+GitHub consistency issues
       |
       v
 verify current main
       |
-      +--> RESOLVED / STILL_OPEN / IN_FLIGHT / other defined disposition
+      +--> RESOLVED / OPEN / IN_FLIGHT / SUPERSEDED / WITHDRAWN
       |
       v
-incremental consistency scan
+incremental or full consistency scan
       |
       v
 new evidence-backed findings
@@ -31,62 +33,91 @@ new evidence-backed findings
       v
 triage
       |
+      +--> optional explicitly authorized issue-ledger synchronization
+      |
       v
 normal remediation PRs
       |
       v
-later consistency verification
+later consistency verification on main
 ```
 
-A merged PR is not itself evidence that a finding is resolved. Resolution is established by re-evaluating the resulting state on the reviewed `main` head.
+A merged PR, closed issue, or green CI result is not itself evidence that a finding is resolved. Resolution is established by re-evaluating authoritative evidence on the reviewed `main` head.
 
 For routine recurring runs, use the normal high-scrutiny reasoning setting available in the review environment. Reserve the highest available scrutiny for calibration runs, major architecture transitions, or periods where several capability tracks have changed in parallel. This is operating advice, not a repository requirement, and may need reinterpretation as external tooling evolves.
 
 ## Finding persistence
 
-Raw consistency reports are not automatically persisted as repository artifacts.
+GitHub Issues persist **finding identity and lifecycle**, not product/architecture truth and not the repository comparison baseline.
 
-During calibration and ordinary recurring review, the long-lived Consistency session may retain the report history needed to compare findings across runs. After triage:
+Persisted findings use the identity rules in the consistency-agent contract:
 
-- false positives and low-value calibration noise may remain only in the review session;
-- confirmed durable work should normally be represented by the GitHub issue or pull request that owns remediation;
-- findings that require an architecture/product decision should flow into the appropriate architecture/planning/ADR process rather than being treated as ordinary code defects;
-- accepted debt should be explicit in an appropriate durable artifact when forgetting it would create material risk.
+- the GitHub issue number is the canonical, immutable storage identity;
+- the human-readable `CONS-*` alias in the issue title is immutable once bound to that issue;
+- the six calibration findings migrated as `CONS-001` through `CONS-006` retain those aliases for continuity;
+- new persisted findings derive their alias from the GitHub issue number (for example, issue `#211` becomes `CONS-211`), so no independent counter or reservation protocol is required;
+- a diagnostic-only finding that has not been persisted has no durable `CONS-*` identity yet.
 
-Do not create a repository ledger merely to mirror every scanner result. A durable ledger is justified only if recurring review cannot reliably carry unresolved findings and baselines forward without one.
+The review itself remains read-only by default. Reading/searching the issue ledger is mandatory grounding; creating, editing, commenting on, closing, reopening, assigning, or relabeling finding issues requires explicit authorization for issue-ledger synchronization.
+
+When synchronization is authorized, it follows repository truth rather than issue state:
+
+- create an issue only for a genuinely new durable finding after duplicate/regression matching;
+- keep `OPEN` and `IN_FLIGHT` findings open;
+- close a finding only after current `main` verifies it as `RESOLVED`, or when it is explicitly `SUPERSEDED` or `WITHDRAWN`;
+- never close a finding merely because a remediation PR exists or merged;
+- retain closed issues so regression detection can reuse the same semantic finding identity.
+
+This deliberately does **not** mean that every raw observation or exploratory suspicion becomes an issue. A finding must meet the evidence rules in the reviewer contract before it qualifies for persistence.
+
+## Calibration migration
+
+The original calibration findings were migrated to GitHub Issues #204-#209. Their legacy aliases remain stable:
+
+- `CONS-001` -> #204
+- `CONS-002` -> #205
+- `CONS-003` -> #206
+- `CONS-004` -> #207
+- `CONS-005` -> #208
+- `CONS-006` -> #209
+
+Those aliases are grandfathered; new findings use the issue-number-derived alias rule instead of continuing a separate sequential counter.
 
 ## Baseline discipline
 
-Incremental review is useful only when its baseline is trustworthy.
+Finding persistence and comparison-baseline persistence are separate problems.
 
 Until Arcogine implements repository-owned baseline persistence, a recurring review should use the last reliable reviewed head available to the review workflow. If that baseline cannot be established confidently, perform a full review rather than pretending an incremental interval is complete.
 
 The reviewer must carry unresolved findings forward even when the commit that introduced them predates the chosen incremental baseline. Advancing a baseline must never make an unresolved finding disappear by construction.
 
-## Open operational question
+The GitHub Issue ledger therefore solves cross-session finding continuity but does not claim to answer "what was the last fully reviewed `main` SHA?" A future baseline mechanism may be added separately if recurring review needs one.
 
-The remaining question is whether recurring reviews can maintain sufficient continuity using the current project-session plus external-schedule model, or whether Arcogine needs repository-owned persistence for review state.
+## Remaining operational question
 
-Evidence that would justify a durable baseline/finding ledger includes:
+The finding-ledger question is now decided: durable findings live in GitHub Issues.
 
-- unresolved findings being lost between runs;
+The remaining persistence question is narrower: whether Arcogine needs repository-owned **review-baseline** state in addition to the issue ledger and whatever trusted reviewed-head context the recurring workflow already maintains.
+
+Evidence that would justify baseline persistence includes:
+
 - uncertainty about the last fully reviewed `main` head;
-- duplicate findings being repeatedly rediscovered because prior disposition is unavailable;
-- scheduled runs lacking access to the continuity available to the long-lived review session;
-- multiple maintainers or review environments needing to share one authoritative unresolved-finding state.
+- scheduled runs being unable to establish a trustworthy incremental range;
+- multiple maintainers or review environments repeatedly falling back to full scans solely because the reviewed-head baseline is unavailable.
 
-If those problems appear in practice, define the persistence contract before making consistency review more autonomous. The likely first slice is durable baseline plus unresolved-finding state, not automatic remediation.
+If those problems appear in practice, define the baseline contract separately. Do not overload finding issues with baseline semantics.
 
 ## Ownership boundaries
 
 Keep these concerns separate:
 
-- `.github/agents/consistency.agent.md` owns the consistency review procedure, evidence rules, finding format, lifecycle, and resolution policy.
+- `.github/agents/consistency.agent.md` owns the consistency review procedure, evidence rules, finding format, identity/lifecycle rules, and resolution policy.
+- GitHub Issues own durable finding identity and lifecycle continuity only.
 - This document owns human/maintainer operating guidance for recurring reviews.
 - Normal implementation sessions own remediation once a finding has been accepted.
 - Independent PR review owns acceptance of remediation changes.
-- Architecture, ADR, and planning documents remain authoritative for their respective semantic questions; consistency review does not replace them.
+- Architecture, ADR, planning, source, tests, and executable configuration remain authoritative for their respective semantic questions; consistency issues do not replace them.
 
 The intended loop is therefore:
 
-> diagnose independently, triage deliberately, remediate through normal change control, then verify against the resulting repository state.
+> diagnose independently, persist durable findings deliberately, triage deliberately, remediate through normal change control, then verify against the resulting repository state.


### PR DESCRIPTION
## Summary

- make GitHub Issues the durable consistency-finding identity/lifecycle ledger
- use the immutable GitHub issue number as the canonical persisted finding identity
- retain the migrated `CONS-001` through `CONS-006` aliases for continuity, while deriving every new persisted alias from its GitHub issue number (`issue #N` -> `CONS-N`)
- keep diagnostic-only findings explicitly unpersisted/unassigned until issue-ledger synchronization is authorized
- require every review to reconcile open and closed findings, including regressions and interrupted `[CONSISTENCY-UNBOUND]` creations
- preserve read-only diagnosis by default; issue mutation remains explicitly authorized work
- distinguish issue lifecycle from product/architecture authority and require verification on `main` before resolution
- reconcile the maintainer operating guide with the adopted issue-ledger model while keeping review-baseline persistence as a separate concern

## Migration

The original calibration findings `CONS-001` through `CONS-006` are persisted as Issues #204-#209. `CONS-001` and `CONS-005` remain open; `CONS-002`, `CONS-003`, `CONS-004`, and `CONS-006` are recorded as resolved and closed. Those six aliases are grandfathered and immutable; future persisted findings use the issue-number-derived alias rule rather than a separate sequential allocator.

## Review fixes

- REV-001: replaced `max(CONS)+1` allocation with collision-safe GitHub issue-number identity, an explicit unbound-issue creation/binding protocol, and immutable alias rules.
- REV-002: updated `docs/development/consistency-review.md` so the human operating model now matches the adopted GitHub Issue ledger and clearly separates finding persistence from baseline persistence.

## Validation

Documentation/agent-contract-only change. No executable product behavior is changed. Current-head CI is the merge validation surface; the branch was also reviewed against current `main` for consistency between the agent contract, operating guide, migrated issues, and PR description.