### PR TITLE
docs: align routing concepts with eligible resources

### DIFF
--- a/docs/product/concepts.md
+++ b/docs/product/concepts.md
@@ -48,9 +48,9 @@ A machine that is **offline** stops accepting new jobs. A machine can only be ta
 
 ### Products and routings
 
-A **product** (e.g., "Widget A") has a **routing** — an ordered list of processing steps. Each step requires a specific machine and takes a specific number of ticks.
+A **product** (e.g., "Widget A") has a **routing** — an ordered list of processing steps. Each step defines a set of **eligible resources** that may perform it and a processing duration. At runtime, Arcogine deterministically selects one eligible resource based on current execution state; the routing defines eligibility, not a permanent one-machine binding.
 
-Example: Widget A's routing might be Mill (5 ticks) → Lathe (3 ticks) → QC Station (2 ticks). A job for Widget A must visit all three machines in order.
+Example: Widget A's routing might require milling for 5 ticks on either Mill A or Mill B, then turning for 3 ticks on Lathe A, then inspection for 2 ticks on QC Station. A job for Widget A must complete those steps in order, but a step with multiple eligible resources may run on any one of them selected by runtime dispatch.
 
 ### Orders and jobs
 


### PR DESCRIPTION
## Summary

Update `docs/product/concepts.md` so the product concepts match the current factory model:

- routing steps define sets of eligible resources rather than one permanently bound machine;
- runtime dispatch deterministically selects one eligible resource;
- the example routing now demonstrates interchangeable milling resources.

This keeps the product-facing explanation aligned with `OperationStepDefinition.eligibleResources` and current dispatch semantics.

Addresses #204

## Validation

Documentation-only change; no build or test execution required by the repository validation guidance.