### PR TITLE
docs: distinguish PR review and remediation shorthand

### DIFF
--- a/.github/agents/pr-reviewer.agent.md
+++ b/.github/agents/pr-reviewer.agent.md
@@ -93,7 +93,7 @@ When the user requests only a specific concern, review that concern thoroughly b
 
 ## Continuation shorthand
 
-When the user's entire message is `.` treat it as an instruction to continue the independent PR-review workflow without asking for clarification. `.` is review-only shorthand; repository-wide remediation shorthand such as `+` is defined in `AGENTS.md` and is not an instruction to perform reviewer-side remediation.
+When the user's entire message is `.` treat it as an instruction to continue the independent PR-review workflow without asking for clarification. `.` is review-only shorthand; repository-wide remediation shorthand `..` is defined in `AGENTS.md` and is not an instruction to perform reviewer-side remediation.
 
 - If a PR is currently being reviewed and remains open, re-resolve current `main`, the live PR head, reviews, unresolved threads, and CI, then perform a re-review of that PR.
 - If the current PR has been merged or closed, or no PR is currently active, find an open PR and perform a complete review of it.

--- a/.github/agents/pr-reviewer.agent.md
+++ b/.github/agents/pr-reviewer.agent.md
@@ -93,7 +93,7 @@ When the user requests only a specific concern, review that concern thoroughly b
 
 ## Continuation shorthand
 
-When the user's entire message is `.` treat it as an instruction to advance the PR-review workflow without asking for clarification.
+When the user's entire message is `.` treat it as an instruction to continue the independent PR-review workflow without asking for clarification. `.` is review-only shorthand; repository-wide remediation shorthand such as `+` is defined in `AGENTS.md` and is not an instruction to perform reviewer-side remediation.
 
 - If a PR is currently being reviewed and remains open, re-resolve current `main`, the live PR head, reviews, unresolved threads, and CI, then perform a re-review of that PR.
 - If the current PR has been merged or closed, or no PR is currently active, find an open PR and perform a complete review of it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@ Common shorthand should be interpreted in repository context:
 PR workflow shorthand has distinct review and remediation meanings:
 
 - `.` = review or re-review the current applicable pull request using the dedicated PR Reviewer contract;
-- `+` = advance the current implementation pull request toward green by inspecting the latest reviews, comments, unresolved findings, CI, and mergeability; evaluating each finding against repository authority; applying the smallest correct fix for valid findings; challenging invalid findings with repository evidence; and re-checking the resulting PR state.
+- `..` = advance the current implementation pull request toward green by inspecting the latest reviews, comments, unresolved findings, CI, and mergeability; evaluating each finding against repository authority; applying the smallest correct fix for valid findings; challenging invalid findings with repository evidence; and re-checking the resulting PR state.
 
-When handling `+`, continue remediation and re-checking until the PR is green or a genuinely unresolved decision requires user input. Do not treat `+` as an independent review-only action.
+When handling `..`, continue remediation and re-checking until the PR is green or a genuinely unresolved decision requires user input. Do not treat `..` as an independent review-only action.
 
 Do not replace known repository context with generic GitHub discovery.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@ Common shorthand should be interpreted in repository context:
 - “check repo state” means inspect the state of this repository;
 - references such as “the issue”, “the PR”, “main”, or a bare issue/PR number refer to this repository unless context explicitly establishes otherwise.
 
+PR workflow shorthand has distinct review and remediation meanings:
+
+- `.` = review or re-review the current applicable pull request using the dedicated PR Reviewer contract;
+- `+` = advance the current implementation pull request toward green by inspecting the latest reviews, comments, unresolved findings, CI, and mergeability; evaluating each finding against repository authority; applying the smallest correct fix for valid findings; challenging invalid findings with repository evidence; and re-checking the resulting PR state.
+
+When handling `+`, continue remediation and re-checking until the PR is green or a genuinely unresolved decision requires user input. Do not treat `+` as an independent review-only action.
+
 Do not replace known repository context with generic GitHub discovery.
 
 ## Specialized agent roles


### PR DESCRIPTION
## Summary

Define distinct repository-owned shorthand for PR review versus remediation:

- `.` means review or re-review the current applicable PR using the dedicated PR Reviewer contract.
- `..` means advance the current implementation PR toward green by evaluating review findings, applying valid fixes, challenging invalid findings with repository evidence, and re-checking CI/reviews/mergeability.

`AGENTS.md` owns the repository-wide shorthand. The PR Reviewer contract now explicitly treats `.` as review-only and defers remediation shorthand to `AGENTS.md`.

## Why

This removes ambiguity between independent review and implementation/remediation workflows, so agents do not merely repeat review findings when the intended action is to advance a PR. The remediation shorthand uses `..` rather than `+` because `+` is intercepted by some client UIs for file attachment.

## Validation

Documentation-only agent-contract change; no build or test execution required by repository validation guidance.