### PR TITLE
docs: include finance in handler inventory

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -439,7 +439,7 @@ types ← simulation ← factory
 challenge   (no dependency on any module above; a sibling, game-owned boundary)
 ```
 
-Each module exposes a clean public API and hides implementation details. Domain modules (`factory`, `economy`, `agents`) implement the `EventHandler` interface and are wired together by `IntegratedHandler` in the API layer.
+Each module exposes a clean public API and hides implementation details. Event-handling modules (`factory`, `economy`, `agents`, `finance`) implement the `EventHandler` interface and are wired together by `IntegratedHandler` in the API layer.
 
 `challenge` is deliberately outside this dependency graph: it is a game-owned Challenge Readiness
 module (`com.arcogine.challenge`) that has no `project(...)` dependency on `types`, `simulation`,


### PR DESCRIPTION
## Summary

Correct the architecture overview so its EventHandler inventory includes the finance module, matching the existing implementation and dispatch diagram.

Addresses #208

## Validation

Documentation-only change; no runtime validation required.