### PR TITLE
Strengthen PR semantic-neighbor review guidance

### DIFF
--- a/.github/agents/pr-reviewer.agent.md
+++ b/.github/agents/pr-reviewer.agent.md
@@ -146,7 +146,8 @@ When a surface changes, inspect maintained or executable surfaces that encode or
 
 | Changed surface | Mandatory neighbors to consider |
 | --- | --- |
-| `FactoryModel` / model semantics | factory-design architecture, relevant ADRs, factory-design plan, engine assumptions, provenance/identity contracts, tests |
+| `FactoryModel` / model semantics | factory-design architecture, relevant ADRs, factory-design plan, engine assumptions, product concepts, provenance/identity contracts, tests |
+| routing/resource eligibility or execution decomposition | `docs/product/concepts.md`, factory-design architecture/plan, Engine Readiness, relevant ADRs, runtime/dispatch tests, consumer contracts |
 | `FactoryRuntime`, handlers, orders, jobs | architecture overview, Engine Readiness, runtime ADRs, acceptance/integration tests, consumer contracts |
 | events, scheduler, observations | event/state/observation architecture, API/SSE projections, determinism tests |
 | module dependencies | architecture module graph, executable architecture rules, domain/challenge boundaries |
@@ -158,18 +159,43 @@ When a surface changes, inspect maintained or executable surfaces that encode or
 | `./arcogine` commands | README, CONTRIBUTING, testing guide, AGENTS.md |
 | Gradle / Java / Node policy | executable configuration, CI, devcontainer/runtime policy, maintained development docs |
 | CI workflows/checks | testing guide, CONTRIBUTING, AGENTS.md where workflow depends on checks |
-| ADR added/changed | ADR index, current architecture, applicable planning, implementation evidence where claimed |
-| planning status changed | acceptance criteria, implementation, tests/evidence, architecture/current docs affected by the status claim |
+| ADR added/changed | ADR index, current architecture, applicable planning, maintained product concepts/reference surfaces, implementation evidence where claimed |
+| planning/readiness status changed | acceptance criteria, implementation, tests/evidence, architecture/current docs, maintained product concepts/reference surfaces affected by the status claim |
 
 A semantic neighbor is not automatically required to change. Inspect it and determine whether its existing statement remains correct.
+
+### Concept fan-out for semantic changes
+
+For medium- and high-risk semantic changes, do not rely only on file adjacency or changed-symbol references.
+
+1. Identify 2-5 material concepts whose meaning, ownership, lifecycle, cardinality, status, or authority changed.
+2. Search maintained repository surfaces for the new vocabulary and for plausible old assumptions or prior-state wording.
+3. Inspect hits in current architecture, planning, product concepts, reference docs, examples, tests, interfaces/DTOs, and executable configuration as relevant.
+4. Distinguish a semantically stale statement from harmless alternate wording.
+5. Record the important semantic neighbors inspected, including surfaces that were checked and correctly required no change.
+
+Examples of useful old-assumption searches include singular/plural cardinality shifts, old API/type names, `unresolved`/`deferred`/`partial` wording after a status transition, and phrases that encode an older ownership boundary.
+
+### Authority/status transition propagation
+
+Treat an authority-bearing transition as a mandatory propagation trigger. Examples include:
+
+- ADR `proposed/unresolved -> accepted`;
+- readiness/capability `partial/blocked -> implemented/ready`;
+- compatibility behavior `legacy/default -> removed/redefined`;
+- architecture ownership or identity semantics becoming binding.
+
+When such a transition occurs, explicitly inspect current architecture, directly related planning/status tables, maintained product concepts, reference surfaces, and implementation/evidence claims that may still describe the prior state.
+
+This is bounded PR-impact review. It is not a substitute for the repository-wide Consistency agent.
 
 ## Risk-proportionate depth
 
 Use semantic risk to control review breadth, not severity.
 
 - **Low:** isolated refactors, narrow tests, typo/link corrections, mechanical changes with no contract effect. Inspect direct code/docs, tests/checks, and immediate contracts.
-- **Medium:** domain behavior, planning status, maintained current-state docs, internal interfaces with meaningful consumers. Inspect architecture/planning, semantic neighbors, compatibility, and executable evidence.
-- **High:** durable identity/canonicalization, revision semantics, persistence contracts, scheduler/time authority, determinism, major ownership changes, public compatibility/event contracts, security/authority, or hard-to-reverse architecture. Inspect applicable ADRs, architecture, planning, integration/compatibility evidence, consumers, and relevant prerequisite/recent PRs.
+- **Medium:** domain behavior, planning status, maintained current-state docs, internal interfaces with meaningful consumers. Inspect architecture/planning, semantic neighbors, compatibility, and executable evidence; perform concept fan-out for changed semantics.
+- **High:** durable identity/canonicalization, revision semantics, persistence contracts, scheduler/time authority, determinism, major ownership changes, public compatibility/event contracts, security/authority, or hard-to-reverse architecture. Inspect applicable ADRs, architecture, planning, integration/compatibility evidence, consumers, and relevant prerequisite/recent PRs; perform concept fan-out and authority-transition propagation where applicable.
 
 ## Required evaluation
 
@@ -178,7 +204,8 @@ Apply the review dimensions in `docs/development/reviewing.md`, including functi
 Additionally verify:
 
 - **Acceptance-criterion truth:** identify evidence that actually proves each material completion claim.
-- **Forward consistency:** determine whether the proposed change would introduce contradictions across affected current docs, architecture, planning, ADR constraints, reference contracts, examples, tests, configuration, or consumers. This is bounded PR-impact review, not a substitute for the repository-wide Consistency agent.
+- **Forward consistency:** determine whether the proposed change would introduce contradictions across affected current docs, architecture, planning, ADR constraints, reference contracts, product concepts, examples, tests, configuration, or consumers. Use semantic concept fan-out for medium/high-risk changes rather than relying only on the changed-file list. This is bounded PR-impact review, not a substitute for the repository-wide Consistency agent.
+- **Authority/status propagation:** when a decision or capability changes state, determine whether maintained surfaces that describe that state have been reconciled.
 - **PR-description truthfulness:** after fixes, verify title/body, validation claims, scope, API names, and completion statements describe the current head.
 
 ## High-value Arcogine invariants
@@ -261,7 +288,7 @@ Required invariant/outcome:
 Status: OPEN
 ```
 
-Use the severity semantics from `docs/development/reviewing.md`. Do not manufacture a finding merely to populate the format.
+Use the severity semantics and calibration examples from `docs/development/reviewing.md`. Do not manufacture a finding merely to populate the format.
 
 ## Finding lifecycle
 
@@ -295,7 +322,10 @@ Every complete review/re-review must identify:
 - actionable findings, highest severity first;
 - prior-finding lifecycle on re-review;
 - validation/CI state;
+- semantic neighbors inspected for medium/high-risk reviews, including important checked surfaces that required no change;
 - any inspection limitations;
 - explicit final disposition using `docs/development/reviewing.md`: `READY TO MERGE`, `READY AFTER CI`, `CHANGES REQUIRED`, or `NON-BLOCKING FOLLOW-UPS ONLY`.
+
+The semantic-neighbor coverage note is evidence of review breadth, not proof of repository-wide consistency. Keep it compact and material; do not dump every search hit.
 
 For a targeted review, do not issue a full merge disposition unless you actually completed the full review procedure. A complete review with no findings should say so directly. Do not leave merge readiness implicit.

--- a/docs/development/consistency-review.md
+++ b/docs/development/consistency-review.md
@@ -70,6 +70,23 @@ When synchronization is authorized, it follows repository truth rather than issu
 
 This deliberately does **not** mean that every raw observation or exploratory suspicion becomes an issue. A finding must meet the evidence rules in the reviewer contract before it qualifies for persistence.
 
+## Finding attribution
+
+Consistency findings may be used later to evaluate review quality, so attribution must be evidence-backed and must distinguish a PR-review escape from unrelated or inherited repository drift.
+
+When history can establish it, record or preserve the following attribution facts in the finding issue or review report:
+
+- **first known bad commit** — earliest verified commit in the inspected history where the inconsistency is present;
+- **likely introducing PR** — PR whose merged semantic transition introduced or should have reconciled the stale neighbor;
+- **attribution confidence** — `HIGH`, `MEDIUM`, or `LOW` based on how directly history establishes causation;
+- **origin class** — `REVIEW_ESCAPE`, `LEGACY_DRIFT`, `UNRELATED_DRIFT`, `REGRESSION`, or `UNKNOWN`.
+
+Use `REVIEW_ESCAPE` only when the evidence supports all of these: the relevant semantic change was in a reviewed PR, the stale or contradictory neighbor already existed in that PR's proposed post-merge state, and the PR review did not identify it before merge. A later consistency finding is not automatically a reviewer failure merely because it was discovered after a PR.
+
+Use `LEGACY_DRIFT` when the inconsistency predates the inspected review window or cannot reasonably be tied to the semantic transition under review. Use `UNRELATED_DRIFT` when a recent PR is nearby in time but did not change the concept or authority involved. Use `REGRESSION` when a previously resolved semantic inconsistency reappears.
+
+Do not manufacture attribution to improve metrics. If the introducing point cannot be established from repository history, record `UNKNOWN`. Attribution is diagnostic metadata, not product/architecture authority and not part of the finding's durable semantic identity.
+
 ## Calibration migration
 
 The original calibration findings were migrated to GitHub Issues #204-#209. Their legacy aliases remain stable:
@@ -113,7 +130,7 @@ Keep these concerns separate:
 
 - `.github/agents/consistency.agent.md` owns the consistency review procedure, evidence rules, finding format, identity/lifecycle rules, and resolution policy.
 - GitHub Issues own durable finding identity and lifecycle continuity only.
-- This document owns human/maintainer operating guidance for recurring reviews.
+- This document owns human/maintainer operating guidance for recurring reviews, including review-quality attribution conventions.
 - Normal implementation sessions own remediation once a finding has been accepted.
 - Independent PR review owns acceptance of remediation changes.
 - Architecture, ADR, planning, source, tests, and executable configuration remain authoritative for their respective semantic questions; consistency issues do not replace them.

--- a/docs/development/consistency-review.md
+++ b/docs/development/consistency-review.md
@@ -72,9 +72,11 @@ This deliberately does **not** mean that every raw observation or exploratory su
 
 ## Finding attribution
 
-Consistency findings may be used later to evaluate review quality, so attribution must be evidence-backed and must distinguish a PR-review escape from unrelated or inherited repository drift.
+Consistency findings may later be used as evidence in a separate review-quality audit. Attribution for that audit must be evidence-backed so the audit distinguishes a PR-review escape from unrelated or inherited repository drift.
 
-When history can establish it, record or preserve the following attribution facts in the finding issue or review report:
+This section is **maintainer audit/post-processing guidance**, not an extension of the executable Consistency agent's required finding or run-report schema. Ordinary Consistency-agent runs remain governed by `.github/agents/consistency.agent.md` and are not required to populate the attribution fields below. If Arcogine later wants every consistency run to produce this metadata automatically, the executable agent contract must be changed explicitly in a separate coherent update.
+
+When conducting a review-quality audit, derive or preserve the following attribution facts from repository history where they can be established:
 
 - **first known bad commit** — earliest verified commit in the inspected history where the inconsistency is present;
 - **likely introducing PR** — PR whose merged semantic transition introduced or should have reconciled the stale neighbor;
@@ -85,7 +87,7 @@ Use `REVIEW_ESCAPE` only when the evidence supports all of these: the relevant s
 
 Use `LEGACY_DRIFT` when the inconsistency predates the inspected review window or cannot reasonably be tied to the semantic transition under review. Use `UNRELATED_DRIFT` when a recent PR is nearby in time but did not change the concept or authority involved. Use `REGRESSION` when a previously resolved semantic inconsistency reappears.
 
-Do not manufacture attribution to improve metrics. If the introducing point cannot be established from repository history, record `UNKNOWN`. Attribution is diagnostic metadata, not product/architecture authority and not part of the finding's durable semantic identity.
+Do not manufacture attribution to improve metrics. If the introducing point cannot be established from repository history, record `UNKNOWN`. Attribution is diagnostic audit metadata, not product/architecture authority, not part of the finding's durable semantic identity, and not required to be persisted in a consistency issue.
 
 ## Calibration migration
 
@@ -130,7 +132,7 @@ Keep these concerns separate:
 
 - `.github/agents/consistency.agent.md` owns the consistency review procedure, evidence rules, finding format, identity/lifecycle rules, and resolution policy.
 - GitHub Issues own durable finding identity and lifecycle continuity only.
-- This document owns human/maintainer operating guidance for recurring reviews, including review-quality attribution conventions.
+- This document owns human/maintainer operating guidance for recurring reviews and separate review-quality audit attribution conventions; it does not add fields to the executable Consistency agent's finding/report contract.
 - Normal implementation sessions own remediation once a finding has been accepted.
 - Independent PR review owns acceptance of remediation changes.
 - Architecture, ADR, planning, source, tests, and executable configuration remain authoritative for their respective semantic questions; consistency issues do not replace them.

--- a/docs/development/reviewing.md
+++ b/docs/development/reviewing.md
@@ -188,6 +188,14 @@ Current-state docs must describe what actually exists. Planning docs must distin
 
 After iterative fixes, re-check the PR title/body as well: a description of an API that no longer exists is a review defect even when the code is correct.
 
+#### Semantic propagation
+
+For medium- and high-semantic-risk changes, review by concept as well as by changed file. Identify the small set of concepts whose meaning changed, then search maintained docs, tests, examples, interfaces, and configuration for both the new vocabulary and plausible old assumptions. This is especially important when a semantic change can leave syntactically unrelated prose or tests behind.
+
+When an accepted ADR, readiness gate, capability status, or other authority-bearing artifact changes state — for example `unresolved -> accepted`, `partial -> implemented`, or `blocked -> ready` — treat that as a propagation trigger. Inspect current architecture, directly related planning/status tables, maintained product concepts, reference surfaces, and implementation/evidence claims that may still describe the prior state.
+
+This is bounded change-impact review. It does not require a repository-wide consistency sweep for every PR.
+
 #### ADR discipline
 
 Request an ADR only for a genuinely hard-to-reverse decision, for example durable identity/canonicalization contracts, persistent revision semantics, public compatibility/event contracts, scheduler/time authority, major domain ownership changes, or an execution decomposition whose semantics would be costly to unwind.
@@ -205,6 +213,14 @@ Use severity to communicate merge risk, not rhetorical emphasis:
 - **Nit** — optional polish only.
 
 Do not inflate severity. A P1 must identify a real invariant or correctness failure, not a preferred design alternative.
+
+Use these calibration examples when the boundary is unclear:
+
+- a semantic regression demonstrated by failing integration/contract tests, or a change that violates a binding architecture invariant, is normally **P1**;
+- a PR whose central claimed behavior is still defeated by another maintained execution path is normally **P1**;
+- a false completion/status claim or missing completion evidence that can be corrected without changing otherwise safe runtime behavior is normally **P2**, unless that false status itself unlocks a dependent architectural gate;
+- a stale PR title/body or validation description after remediation is normally **P2** when it materially misstates the proposed head;
+- optional extra coverage, cleanup, or future hardening that does not affect the current invariant is **P3** or **Nit**.
 
 Each actionable finding should state:
 
@@ -259,6 +275,8 @@ Every review/re-review should end with a clear disposition:
 - **READY AFTER CI** — code/docs review is clean; only current-head validation remains.
 - **CHANGES REQUIRED** — at least one blocking/pre-merge finding remains.
 - **NON-BLOCKING FOLLOW-UPS ONLY** — merge is acceptable; remaining items are explicitly optional/future work.
+
+For medium- and high-risk reviews, the final report should also identify the material semantic neighbors inspected, including important surfaces inspected that required no change. This coverage note is evidence of review breadth, not a claim that those surfaces are globally consistent.
 
 Do not leave merge readiness implicit.
 


### PR DESCRIPTION
## Summary

- require concept-based fan-out for medium/high semantic-risk PR reviews, including searches for plausible stale prior-state assumptions
- add explicit factory routing/resource-eligibility coverage of `docs/product/concepts.md`
- treat ADR/readiness/authority status transitions as propagation triggers into current architecture, planning, product concepts, reference surfaces, and evidence claims
- require a compact semantic-neighbor coverage note for medium/high-risk final reviews, including important surfaces inspected that required no change
- add concrete P1/P2/P3 severity-calibration examples to the normative review policy
- add evidence-backed maintainer audit guidance for attributing later consistency findings as review escapes, legacy/unrelated drift, regressions, or unknown without changing the executable Consistency finding schema

## Motivation

A recent audit of Arcogine PR reviews found a recurring historical blind spot: deep local semantic review was generally strong, but semantic transitions sometimes failed to propagate into maintained current-state/product/planning surfaces. The clearest examples were routing/resource-eligibility documentation and accepted identity/status decisions that left stale neighboring prose behind.

The current PR Reviewer already includes live-head grounding, semantic-neighbor analysis, forward consistency, duplicate-review suppression, and `.` continuation behavior. This PR strengthens the remaining weak points rather than turning PR review into a repository-wide Consistency sweep.

## Boundaries

- PR Reviewer remains responsible for bounded proposed-transition impact.
- Consistency remains responsible for repository-wide drift detection.
- Consistency issue identity/lifecycle rules and executable finding/report schema are unchanged.
- Review-quality attribution is separate maintainer audit/post-processing metadata and must remain `UNKNOWN` when history cannot establish causation.
- No product/runtime behavior changes.

## Review fixes

- REV-001: clarified that review-quality attribution in `docs/development/consistency-review.md` is separate maintainer audit/post-processing guidance, not required output of `.github/agents/consistency.agent.md`; updated the ownership wording and PR claims accordingly so the human guide no longer implies an executable schema change.

## Validation

Documentation/agent-contract-only change. Validate the current net diff for internal consistency across `docs/development/reviewing.md`, `.github/agents/pr-reviewer.agent.md`, and `docs/development/consistency-review.md`, plus current-head repository checks/CI where available.