### PR TITLE
Resolve remaining consistency P3 drift and clarify ledger triage

### DIFF
--- a/.github/agents/consistency.agent.md
+++ b/.github/agents/consistency.agent.md
@@ -369,6 +369,10 @@ Subject: <semantic subject>
 Status: OPEN | IN_FLIGHT
 ```
 
+Persistence is for continuity, not ceremony. If the user explicitly requests immediate remediation after a review, a genuinely new `P3` or `Nit` finding may remain `UNPERSISTED` when all of the following hold: the inconsistency is localized and unambiguous, no product/architecture/planning decision is required, the corrective change is included in the immediate remediation PR, and no durable tracking value would remain after that PR lands. Do not create a GitHub Issue solely so it can be closed immediately afterward.
+
+Persist or recommend persistence instead when a finding is `P0`/`P1`/`P2`, is deferred or accepted as debt, is disputed or decision-dependent, spans multiple semantic surfaces or likely multiple PRs/runs, represents a regression whose identity must remain stable, or otherwise needs lifecycle continuity beyond the immediate remediation. Existing issue-backed findings always retain their durable identity regardless of severity. Immediate remediation does not make an unpersisted finding `RESOLVED` until authoritative evidence reaches the reviewed `main` head.
+
 For a persisted finding, use:
 
 ```text

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -27,10 +27,10 @@ and resolved Gradle dependencies together. It does not provision toolchains.
 | `./arcogine check --full` | Everything above, plus Playwright, canonical `dist/` build, Docker image build/smoke, and security scans (dependency audit, frontend audit, Trivy image scans, Gitleaks) |
 
 `./arcogine check --full` is a complete local certification command, so it
-fails up front with a scoped diagnostic when Docker, Docker Compose, Trivy, or
-Gitleaks is unavailable. This is intentional rather than a silent skip. Use
-`./arcogine check` or the native commands below when the task does not require
-container/security certification.
+fails up front with a scoped diagnostic when Docker, Docker Compose, Trivy,
+Gitleaks, or `curl` is unavailable. This is intentional rather than a silent
+skip. Use `./arcogine check` or the native commands below when the task does not
+require container/security certification.
 
 ### Command model
 

--- a/docs/product/concepts.md
+++ b/docs/product/concepts.md
@@ -42,7 +42,7 @@ Your goal is to keep this loop healthy: enough demand to generate revenue, enoug
 
 ### Machines
 
-Machines (also called equipment in ISA-95 terminology) are the physical resources that do work. Each machine can process one job at a time. You can toggle machines online/offline during a run.
+Machines (also called equipment in ISA-95 terminology) are the physical resources that do work. Each machine can process up to its configured concurrency of active jobs at a time; a machine with concurrency `1` processes one job at a time. You can toggle machines online/offline during a run.
 
 A machine that is **offline** stops accepting new jobs. A machine can only be taken offline while it is **idle**: if it has active jobs, the request is rejected and the machine keeps running until its current work completes. Wait for the machine to become idle, then take it offline. Once offline, the machine can be brought back online at any time.
 


### PR DESCRIPTION
## Summary

- align public machine-capacity documentation with configurable machine concurrency
- document `curl` as an explicit `./arcogine check --full` prerequisite
- clarify consistency finding persistence triage so low-risk P3/Nit findings fixed immediately do not require issue churn, while continuity-sensitive findings still use the durable issue ledger

## Consistency findings addressed

- unpersisted PUBLIC_DOC_DRIFT: `docs/product/concepts.md` said every machine processes one job at a time despite configurable runtime concurrency
- unpersisted TOOLCHAIN_CI_DRIFT: `docs/development/testing.md` omitted `curl` from the explicit `check --full` fail-fast prerequisite list

These are intentionally not assigned durable `CONS-*` identities: both are localized P3 findings being remediated immediately in this PR. The agent-contract change makes that distinction explicit without weakening read-only diagnosis or the issue-ledger mutation policy.

## Validation

Documentation/agent-contract-only changes. Verify the net diff for semantic consistency against `Machine.concurrency` / `Machine.canAcceptJob()` and `./arcogine`'s `require_commands` call for `check --full`. CI remains the merge validation surface.