### PR TITLE
feat(challenge): add deterministic challenge evaluation

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -418,7 +418,8 @@ product/
 ├── agents/               Agent framework: SalesAgent, AgentObservation
 ├── consumer/
 │   └── challenge/        Challenge Readiness: game-owned challenge definition/validation,
-│                         catalogue/economics, and candidate admissibility (see
+│                         catalogue/economics, candidate admissibility, and deterministic
+│                         challenge evaluation (see
 │                         docs/planning/factory-design-game-challenge-readiness.md).
 │                         Headless — no dependency on any module below.
 └── interfaces/
@@ -450,9 +451,10 @@ Each module exposes a clean public API and hides implementation details. Event-h
 `challenge` is deliberately outside this dependency graph: it is a game-owned Challenge Readiness
 module (`com.arcogine.challenge`) that has no `project(...)` dependency on `types`, `simulation`,
 any domain module, `api`, or `cli`, and no Spring dependency. It defines immutable challenge
-definitions and validation, game-owned catalogue/economics, and deterministic candidate
-admissibility. These are distinct validation domains from `FactoryModelValidator` — see the
-Challenge Readiness planning doc for the ownership boundary.
+definitions and validation, game-owned catalogue/economics, deterministic candidate admissibility,
+and deterministic challenge evaluation over supplied authoritative outcome facts. These are
+distinct validation domains from `FactoryModelValidator` and do not inspect factory/runtime state —
+see the Challenge Readiness planning doc for the ownership boundary.
 
 ## Event Dispatch Architecture
 

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -405,8 +405,9 @@ succeeds only when the supplied authoritative facts report fixed-contract comple
 the challenge deadline and committed construction cost is within the starting budget. It produces
 ordered game-owned reason codes for incomplete contract, missed deadline, and exceeded budget;
 records deadline margin and unused budget; and returns zero score on failure. Its deliberately
-small first score formula is `1 + deadline margin + unused budget` on success, where the one-point
-completion bonus distinguishes exact-deadline/exact-budget completion from failure. This is a
+small first score formula is exact-integer `1 + deadline margin + unused budget` on success, where
+the one-point completion bonus distinguishes exact-deadline/exact-budget completion from failure.
+This is a
 vertical-slice policy, not a permanent balancing decision; any observable semantic change requires
 a new `EvaluationPolicyIdentity` version.
 

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -340,7 +340,8 @@ Implemented in C2b:
 C2 completion does not make the game playable and satisfies no Engine Readiness gate. An admitted
 candidate is not canonically executable: a later game-owned projection still requires Arcogine
 canonical validation before publication/run. Conversely, a canonically executable factory may
-remain inadmissible under a particular challenge. C3-C5 remain deferred.
+remain inadmissible under a particular challenge. C3 is implemented independently of that
+projection; C4-C5 remain deferred.
 
 ## 7. C3 — Deterministic challenge evaluation
 
@@ -390,6 +391,31 @@ C3 is ready when:
 5. Every result-affecting evaluator change creates a new evaluation-policy version.
 6. An old attempt retains the exact challenge and evaluation-policy identities/versions that produced its result.
 7. Reference fixtures can reproduce historical evaluation results under their recorded policy versions.
+
+### Implementation status (C3 — complete)
+
+C3 is **complete** as a headless, deterministic evaluation capability in
+`com.arcogine.challenge.evaluation`. `ChallengeEvaluationInput` carries the exact immutable
+`ChallengeDefinition`, opaque published-model and run references, narrow supplied
+`AuthoritativeOutcomeFacts`, and game-owned committed construction cost. It does not inspect or
+instantiate a factory model, `FactoryRuntime`, scheduler, queue, or API/runtime DTO.
+
+`ReferenceChallengeEvaluationPolicy` implements `policy.contract-completion` version `1`. It
+succeeds only when the supplied authoritative facts report fixed-contract completion on or before
+the challenge deadline and committed construction cost is within the starting budget. It produces
+ordered game-owned reason codes for incomplete contract, missed deadline, and exceeded budget;
+records deadline margin and unused budget; and returns zero score on failure. Its deliberately
+small first score formula is `1 + deadline margin + unused budget` on success, where the one-point
+completion bonus distinguishes exact-deadline/exact-budget completion from failure. This is a
+vertical-slice policy, not a permanent balancing decision; any observable semantic change requires
+a new `EvaluationPolicyIdentity` version.
+
+`ChallengeEvaluationResult` retains the exact challenge identity/version, policy identity/version,
+opaque model/run provenance, decision, immutable ordered reasons, deadline margin, unused budget,
+and score. Synthetic outcome fixtures demonstrate deterministic historical reproduction without an
+active Arcogine runtime. C3 does not create attempt history or comparison (C4), content loading or
+reference-content serialization (C5), a runtime adapter, a generic evaluation framework, or any
+Engine Readiness evidence. No playable game or Engine Readiness gate is claimed complete.
 
 ## 8. C4 — Attempt provenance and design-to-design comparison
 

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/AuthoritativeOutcomeFacts.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/AuthoritativeOutcomeFacts.java
@@ -1,0 +1,23 @@
+package com.arcogine.challenge.evaluation;
+
+/**
+ * Narrow, consumer-neutral production facts supplied by an authoritative producer.
+ *
+ * <p>This value deliberately does not describe queues, dispatch, transfers, or runtime state. A
+ * later adapter may obtain these facts from an Arcogine-supported result, while tests may provide
+ * synthetic facts directly.
+ */
+public record AuthoritativeOutcomeFacts(boolean contractCompleted, Long completionTick) {
+
+    public AuthoritativeOutcomeFacts {
+        if (contractCompleted && completionTick == null) {
+            throw new IllegalArgumentException("completed contract requires completionTick");
+        }
+        if (!contractCompleted && completionTick != null) {
+            throw new IllegalArgumentException("incomplete contract must not have completionTick");
+        }
+        if (completionTick != null && completionTick < 0) {
+            throw new IllegalArgumentException("completionTick must be non-negative");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ChallengeEvaluationInput.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ChallengeEvaluationInput.java
@@ -1,0 +1,26 @@
+package com.arcogine.challenge.evaluation;
+
+import com.arcogine.challenge.ChallengeDefinition;
+
+/** Explicit, immutable inputs to a deterministic challenge evaluation. */
+public record ChallengeEvaluationInput(
+        ChallengeDefinition challenge,
+        EvaluationProvenance provenance,
+        AuthoritativeOutcomeFacts outcomeFacts,
+        long committedConstructionCostCredits) {
+
+    public ChallengeEvaluationInput {
+        if (challenge == null) {
+            throw new NullPointerException("challenge");
+        }
+        if (provenance == null) {
+            throw new NullPointerException("provenance");
+        }
+        if (outcomeFacts == null) {
+            throw new NullPointerException("outcomeFacts");
+        }
+        if (committedConstructionCostCredits < 0) {
+            throw new IllegalArgumentException("committedConstructionCostCredits must be non-negative");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ChallengeEvaluationIssue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ChallengeEvaluationIssue.java
@@ -1,0 +1,17 @@
+package com.arcogine.challenge.evaluation;
+
+/** A stable, game-rule diagnostic explaining why an evaluation did not succeed. */
+public record ChallengeEvaluationIssue(String code, String path, String message) {
+
+    public ChallengeEvaluationIssue {
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
+        if (path == null) {
+            throw new NullPointerException("path");
+        }
+        if (message == null) {
+            throw new NullPointerException("message");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ChallengeEvaluationResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ChallengeEvaluationResult.java
@@ -2,6 +2,7 @@ package com.arcogine.challenge.evaluation;
 
 import com.arcogine.challenge.ChallengeIdentity;
 import com.arcogine.challenge.EvaluationPolicyIdentity;
+import java.math.BigInteger;
 import java.util.List;
 
 /** The immutable, explainable result of evaluating one exact challenge input. */
@@ -13,7 +14,7 @@ public record ChallengeEvaluationResult(
         List<ChallengeEvaluationIssue> issues,
         Long deadlineMarginTicks,
         long unusedBudgetCredits,
-        long score) {
+        BigInteger score) {
 
     public ChallengeEvaluationResult {
         if (challengeIdentity == null) {
@@ -28,6 +29,9 @@ public record ChallengeEvaluationResult(
         if (issues == null) {
             throw new NullPointerException("issues");
         }
+        if (score == null) {
+            throw new NullPointerException("score");
+        }
         issues = List.copyOf(issues);
         if (successful != issues.isEmpty()) {
             throw new IllegalArgumentException("successful evaluations must have no issues");
@@ -35,7 +39,7 @@ public record ChallengeEvaluationResult(
         if (successful && deadlineMarginTicks == null) {
             throw new IllegalArgumentException("successful evaluations require deadlineMarginTicks");
         }
-        if (!successful && score != 0L) {
+        if (!successful && !score.equals(BigInteger.ZERO)) {
             throw new IllegalArgumentException("unsuccessful evaluations must have zero score");
         }
     }

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ChallengeEvaluationResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ChallengeEvaluationResult.java
@@ -1,0 +1,42 @@
+package com.arcogine.challenge.evaluation;
+
+import com.arcogine.challenge.ChallengeIdentity;
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import java.util.List;
+
+/** The immutable, explainable result of evaluating one exact challenge input. */
+public record ChallengeEvaluationResult(
+        ChallengeIdentity challengeIdentity,
+        EvaluationPolicyIdentity evaluationPolicy,
+        EvaluationProvenance provenance,
+        boolean successful,
+        List<ChallengeEvaluationIssue> issues,
+        Long deadlineMarginTicks,
+        long unusedBudgetCredits,
+        long score) {
+
+    public ChallengeEvaluationResult {
+        if (challengeIdentity == null) {
+            throw new NullPointerException("challengeIdentity");
+        }
+        if (evaluationPolicy == null) {
+            throw new NullPointerException("evaluationPolicy");
+        }
+        if (provenance == null) {
+            throw new NullPointerException("provenance");
+        }
+        if (issues == null) {
+            throw new NullPointerException("issues");
+        }
+        issues = List.copyOf(issues);
+        if (successful != issues.isEmpty()) {
+            throw new IllegalArgumentException("successful evaluations must have no issues");
+        }
+        if (successful && deadlineMarginTicks == null) {
+            throw new IllegalArgumentException("successful evaluations require deadlineMarginTicks");
+        }
+        if (!successful && score != 0L) {
+            throw new IllegalArgumentException("unsuccessful evaluations must have zero score");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/EvaluationProvenance.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/EvaluationProvenance.java
@@ -1,0 +1,24 @@
+package com.arcogine.challenge.evaluation;
+
+/**
+ * Opaque, immutable references to the published design and run whose supplied facts are evaluated.
+ *
+ * <p>These are attribution values only. They do not grant the challenge module access to a model,
+ * runtime, or execution internals.
+ */
+public record EvaluationProvenance(String publishedModelReference, String runReference) {
+
+    public EvaluationProvenance {
+        requireNonBlank(publishedModelReference, "publishedModelReference");
+        requireNonBlank(runReference, "runReference");
+    }
+
+    private static void requireNonBlank(String value, String name) {
+        if (value == null) {
+            throw new NullPointerException(name);
+        }
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(name + " must be non-blank");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicy.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicy.java
@@ -1,0 +1,89 @@
+package com.arcogine.challenge.evaluation;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The first, versioned policy for the reference vertical slice.
+ *
+ * <p>Policy {@value #POLICY_ID} v{@value #POLICY_VERSION} succeeds only when the supplied
+ * authoritative facts say the fixed contract completed on or before the challenge deadline and
+ * the supplied game-owned construction cost is within budget. A successful score is {@code 1 +
+ * deadlineMarginTicks + unusedBudgetCredits}; an unsuccessful result scores zero. The one-point
+ * completion bonus makes exact-deadline, exact-budget completion distinguishable from failure.
+ * Changing any of these observable rules requires a new policy version.
+ */
+public final class ReferenceChallengeEvaluationPolicy {
+
+    public static final String POLICY_ID = "policy.contract-completion";
+    public static final String POLICY_VERSION = "1";
+    private static final EvaluationPolicyIdentity IDENTITY =
+            new EvaluationPolicyIdentity(POLICY_ID, POLICY_VERSION);
+
+    private ReferenceChallengeEvaluationPolicy() {}
+
+    /** Evaluates explicit facts without accessing Arcogine runtime or factory-model types. */
+    public static ChallengeEvaluationResult evaluate(ChallengeEvaluationInput input) {
+        if (input == null) {
+            throw new NullPointerException("input");
+        }
+        ChallengeDefinition challenge = input.challenge();
+        validateChallenge(challenge);
+        if (!IDENTITY.equals(challenge.evaluationPolicy())) {
+            throw new IllegalArgumentException("challenge evaluation policy is not supported: "
+                    + challenge.evaluationPolicy());
+        }
+
+        long unusedBudget = Math.subtractExact(
+                challenge.startingBudget(), input.committedConstructionCostCredits());
+        Long deadlineMargin = input.outcomeFacts().contractCompleted()
+                ? Math.subtractExact(challenge.deadline(), input.outcomeFacts().completionTick())
+                : null;
+        List<ChallengeEvaluationIssue> issues = new ArrayList<>();
+        addContractIssue(input.outcomeFacts(), issues);
+        addDeadlineIssue(deadlineMargin, issues);
+        addBudgetIssue(unusedBudget, issues);
+
+        boolean successful = issues.isEmpty();
+        long score = successful ? Math.addExact(1L, Math.addExact(deadlineMargin, unusedBudget)) : 0L;
+        return new ChallengeEvaluationResult(challenge.identity(), challenge.evaluationPolicy(),
+                input.provenance(), successful, issues, deadlineMargin, unusedBudget, score);
+    }
+
+    private static void validateChallenge(ChallengeDefinition challenge) {
+        if (challenge.startingBudget() < 0) {
+            throw new IllegalArgumentException("challenge startingBudget must be non-negative");
+        }
+        if (challenge.deadline() <= 0) {
+            throw new IllegalArgumentException("challenge deadline must be positive");
+        }
+    }
+
+    private static void addContractIssue(AuthoritativeOutcomeFacts outcome,
+            List<ChallengeEvaluationIssue> issues) {
+        if (!outcome.contractCompleted()) {
+            issues.add(issue("challenge.contract.incomplete", "outcomeFacts.contractCompleted",
+                    "authoritative outcome does not report fixed contract completion"));
+        }
+    }
+
+    private static void addDeadlineIssue(Long deadlineMargin, List<ChallengeEvaluationIssue> issues) {
+        if (deadlineMargin != null && deadlineMargin < 0) {
+            issues.add(issue("challenge.deadline.missed", "outcomeFacts.completionTick",
+                    "authoritative completion tick exceeds challenge deadline"));
+        }
+    }
+
+    private static void addBudgetIssue(long unusedBudget, List<ChallengeEvaluationIssue> issues) {
+        if (unusedBudget < 0) {
+            issues.add(issue("challenge.budget.exceeded", "committedConstructionCostCredits",
+                    "committed construction cost exceeds challenge starting budget"));
+        }
+    }
+
+    private static ChallengeEvaluationIssue issue(String code, String path, String message) {
+        return new ChallengeEvaluationIssue(code, path, message);
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicy.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicy.java
@@ -2,6 +2,7 @@ package com.arcogine.challenge.evaluation;
 
 import com.arcogine.challenge.ChallengeDefinition;
 import com.arcogine.challenge.EvaluationPolicyIdentity;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,8 +12,9 @@ import java.util.List;
  * <p>Policy {@value #POLICY_ID} v{@value #POLICY_VERSION} succeeds only when the supplied
  * authoritative facts say the fixed contract completed on or before the challenge deadline and
  * the supplied game-owned construction cost is within budget. A successful score is {@code 1 +
- * deadlineMarginTicks + unusedBudgetCredits}; an unsuccessful result scores zero. The one-point
- * completion bonus makes exact-deadline, exact-budget completion distinguishable from failure.
+ * deadlineMarginTicks + unusedBudgetCredits}; an unsuccessful result scores zero. The score uses
+ * an exact {@link BigInteger}, so this formula is total for every accepted {@code long} input. The
+ * one-point completion bonus makes exact-deadline, exact-budget completion distinguishable from failure.
  * Changing any of these observable rules requires a new policy version.
  */
 public final class ReferenceChallengeEvaluationPolicy {
@@ -47,7 +49,9 @@ public final class ReferenceChallengeEvaluationPolicy {
         addBudgetIssue(unusedBudget, issues);
 
         boolean successful = issues.isEmpty();
-        long score = successful ? Math.addExact(1L, Math.addExact(deadlineMargin, unusedBudget)) : 0L;
+        BigInteger score = successful
+                ? BigInteger.ONE.add(BigInteger.valueOf(deadlineMargin)).add(BigInteger.valueOf(unusedBudget))
+                : BigInteger.ZERO;
         return new ChallengeEvaluationResult(challenge.identity(), challenge.evaluationPolicy(),
                 input.provenance(), successful, issues, deadlineMargin, unusedBudget, score);
     }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicyTest.java
@@ -1,0 +1,143 @@
+package com.arcogine.challenge.evaluation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.ChallengeFixtures;
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ReferenceChallengeEvaluationPolicyTest {
+
+    @Test
+    void completedOnTimeAndWithinBudgetIsSuccessfulAndDeterministic() {
+        ChallengeEvaluationInput input = input(true, 350L, 10_000L);
+
+        ChallengeEvaluationResult first = evaluate(input);
+        ChallengeEvaluationResult second = evaluate(input);
+
+        assertTrue(first.successful());
+        assertEquals(first, second);
+        assertEquals(50L, first.deadlineMarginTicks());
+        assertEquals(30_000L, first.unusedBudgetCredits());
+        assertEquals(30_051L, first.score());
+        assertEquals(ChallengeFixtures.referenceChallenge().identity(), first.challengeIdentity());
+        assertEquals(ChallengeFixtures.referenceChallenge().evaluationPolicy(), first.evaluationPolicy());
+        assertEquals("model.factory-basics:v1", first.provenance().publishedModelReference());
+    }
+
+    @Test
+    void consumesSyntheticAuthoritativeFactsWithoutFactoryRuntime() throws ClassNotFoundException {
+        ChallengeEvaluationResult result = evaluate(input(true, 400L, 40_000L));
+
+        assertTrue(result.successful());
+        assertEquals(0L, result.deadlineMarginTicks());
+        assertEquals(0L, result.unusedBudgetCredits());
+        assertEquals(1L, result.score());
+        assertThrows(ClassNotFoundException.class,
+                () -> Class.forName("com.arcogine.factory.process.FactoryRuntime"));
+    }
+
+    @Test
+    void incompleteContractCannotBecomeSuccessfulThroughGoodOtherFacts() {
+        ChallengeEvaluationResult result = evaluate(input(false, null, 0L));
+
+        assertFalse(result.successful());
+        assertEquals(List.of("challenge.contract.incomplete"), codes(result));
+        assertEquals(null, result.deadlineMarginTicks());
+        assertEquals(40_000L, result.unusedBudgetCredits());
+        assertEquals(0L, result.score());
+    }
+
+    @Test
+    void deadlineAndBudgetFailuresAreExplainedInStableRuleOrder() {
+        ChallengeEvaluationResult result = evaluate(input(true, 401L, 40_001L));
+
+        assertFalse(result.successful());
+        assertEquals(-1L, result.deadlineMarginTicks());
+        assertEquals(-1L, result.unusedBudgetCredits());
+        assertEquals(List.of("challenge.deadline.missed", "challenge.budget.exceeded"), codes(result));
+    }
+
+    @Test
+    void deadlineMarginUsesSuppliedCompletionFactRatherThanProductionReconstruction() {
+        assertEquals(1L, evaluate(input(true, 399L, 0L)).deadlineMarginTicks());
+        assertEquals(-1L, evaluate(input(true, 401L, 0L)).deadlineMarginTicks());
+    }
+
+    @Test
+    void historicalFixtureReproducesRecordedOutput() {
+        ChallengeEvaluationResult result = evaluate(input(true, 375L, 12_000L));
+
+        assertEquals(25L, result.deadlineMarginTicks());
+        assertEquals(28_000L, result.unusedBudgetCredits());
+        assertEquals(28_026L, result.score());
+        assertTrue(result.successful());
+    }
+
+    @Test
+    void resultIssuesAreImmutableAndOrdered() {
+        ChallengeEvaluationResult result = evaluate(input(true, 401L, 40_001L));
+
+        assertThrows(UnsupportedOperationException.class, () -> result.issues().clear());
+        assertEquals(List.of("challenge.deadline.missed", "challenge.budget.exceeded"), codes(result));
+    }
+
+    @Test
+    void inputAndOutcomeInvariantsRejectMalformedFacts() {
+        assertThrows(IllegalArgumentException.class, () -> new AuthoritativeOutcomeFacts(true, null));
+        assertThrows(IllegalArgumentException.class, () -> new AuthoritativeOutcomeFacts(false, 1L));
+        assertThrows(IllegalArgumentException.class, () -> new AuthoritativeOutcomeFacts(true, -1L));
+        assertThrows(IllegalArgumentException.class, () -> new ChallengeEvaluationInput(
+                ChallengeFixtures.referenceChallenge(), provenance(), new AuthoritativeOutcomeFacts(true, 1L), -1L));
+        assertThrows(IllegalArgumentException.class, () -> new EvaluationProvenance(" ", "run-1"));
+    }
+
+    @Test
+    void unsupportedPolicyAndMalformedChallengeAreRejected() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        ChallengeDefinition unsupported = new ChallengeDefinition(challenge.identity(), challenge.floor(),
+                challenge.startingBudget(), challenge.workload(), challenge.availableEquipment(),
+                challenge.deadline(), new EvaluationPolicyIdentity("policy.other", "1"),
+                challenge.catalogueIdentity(), challenge.catalogueSemanticFingerprint());
+        ChallengeDefinition invalidDeadline = new ChallengeDefinition(challenge.identity(), challenge.floor(),
+                challenge.startingBudget(), challenge.workload(), challenge.availableEquipment(), 0L,
+                challenge.evaluationPolicy(), challenge.catalogueIdentity(), challenge.catalogueSemanticFingerprint());
+
+        assertThrows(IllegalArgumentException.class, () -> evaluate(new ChallengeEvaluationInput(
+                unsupported, provenance(), new AuthoritativeOutcomeFacts(true, 1L), 0L)));
+        assertThrows(IllegalArgumentException.class, () -> evaluate(new ChallengeEvaluationInput(
+                invalidDeadline, provenance(), new AuthoritativeOutcomeFacts(true, 1L), 0L)));
+    }
+
+    @Test
+    void resultInvariantRejectsMutableInconsistentShape() {
+        List<ChallengeEvaluationIssue> issues = new ArrayList<>();
+        assertThrows(IllegalArgumentException.class, () -> new ChallengeEvaluationResult(
+                ChallengeFixtures.referenceChallenge().identity(),
+                ChallengeFixtures.referenceChallenge().evaluationPolicy(), provenance(), false, issues,
+                null, 0L, 0L));
+    }
+
+    private static ChallengeEvaluationResult evaluate(ChallengeEvaluationInput input) {
+        return ReferenceChallengeEvaluationPolicy.evaluate(input);
+    }
+
+    private static ChallengeEvaluationInput input(boolean complete, Long completionTick, long cost) {
+        return new ChallengeEvaluationInput(ChallengeFixtures.referenceChallenge(), provenance(),
+                new AuthoritativeOutcomeFacts(complete, completionTick), cost);
+    }
+
+    private static EvaluationProvenance provenance() {
+        return new EvaluationProvenance("model.factory-basics:v1", "run.factory-basics:historical-1");
+    }
+
+    private static List<String> codes(ChallengeEvaluationResult result) {
+        return result.issues().stream().map(ChallengeEvaluationIssue::code).toList();
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicyTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.arcogine.challenge.ChallengeDefinition;
 import com.arcogine.challenge.ChallengeFixtures;
 import com.arcogine.challenge.EvaluationPolicyIdentity;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class ReferenceChallengeEvaluationPolicyTest {
         assertEquals(first, second);
         assertEquals(50L, first.deadlineMarginTicks());
         assertEquals(30_000L, first.unusedBudgetCredits());
-        assertEquals(30_051L, first.score());
+        assertEquals(BigInteger.valueOf(30_051L), first.score());
         assertEquals(ChallengeFixtures.referenceChallenge().identity(), first.challengeIdentity());
         assertEquals(ChallengeFixtures.referenceChallenge().evaluationPolicy(), first.evaluationPolicy());
         assertEquals("model.factory-basics:v1", first.provenance().publishedModelReference());
@@ -38,7 +39,7 @@ class ReferenceChallengeEvaluationPolicyTest {
         assertTrue(result.successful());
         assertEquals(0L, result.deadlineMarginTicks());
         assertEquals(0L, result.unusedBudgetCredits());
-        assertEquals(1L, result.score());
+        assertEquals(BigInteger.ONE, result.score());
         assertThrows(ClassNotFoundException.class,
                 () -> Class.forName("com.arcogine.factory.process.FactoryRuntime"));
     }
@@ -51,7 +52,7 @@ class ReferenceChallengeEvaluationPolicyTest {
         assertEquals(List.of("challenge.contract.incomplete"), codes(result));
         assertEquals(null, result.deadlineMarginTicks());
         assertEquals(40_000L, result.unusedBudgetCredits());
-        assertEquals(0L, result.score());
+        assertEquals(BigInteger.ZERO, result.score());
     }
 
     @Test
@@ -76,8 +77,24 @@ class ReferenceChallengeEvaluationPolicyTest {
 
         assertEquals(25L, result.deadlineMarginTicks());
         assertEquals(28_000L, result.unusedBudgetCredits());
-        assertEquals(28_026L, result.score());
+        assertEquals(BigInteger.valueOf(28_026L), result.score());
         assertTrue(result.successful());
+    }
+
+    @Test
+    void scoreIsExactForTheLargestC1ValidDeadlineAndBudget() {
+        ChallengeDefinition reference = ChallengeFixtures.referenceChallenge();
+        ChallengeDefinition challenge = new ChallengeDefinition(reference.identity(), reference.floor(),
+                Long.MAX_VALUE, reference.workload(), reference.availableEquipment(), Long.MAX_VALUE,
+                reference.evaluationPolicy(), reference.catalogueIdentity(),
+                reference.catalogueSemanticFingerprint());
+
+        ChallengeEvaluationResult result = evaluate(new ChallengeEvaluationInput(challenge, provenance(),
+                new AuthoritativeOutcomeFacts(true, 0L), 0L));
+
+        assertTrue(result.successful());
+        assertEquals(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TWO).add(BigInteger.ONE),
+                result.score());
     }
 
     @Test
@@ -121,7 +138,7 @@ class ReferenceChallengeEvaluationPolicyTest {
         assertThrows(IllegalArgumentException.class, () -> new ChallengeEvaluationResult(
                 ChallengeFixtures.referenceChallenge().identity(),
                 ChallengeFixtures.referenceChallenge().evaluationPolicy(), provenance(), false, issues,
-                null, 0L, 0L));
+                null, 0L, BigInteger.ZERO));
     }
 
     private static ChallengeEvaluationResult evaluate(ChallengeEvaluationInput input) {

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicyTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/evaluation/ReferenceChallengeEvaluationPolicyTest.java
@@ -116,6 +116,42 @@ class ReferenceChallengeEvaluationPolicyTest {
     }
 
     @Test
+    void valueContractsRejectNullRequiredValues() {
+        ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
+        AuthoritativeOutcomeFacts outcome = new AuthoritativeOutcomeFacts(true, 1L);
+        ChallengeEvaluationIssue issue = new ChallengeEvaluationIssue("code", "path", "message");
+
+        assertThrows(NullPointerException.class,
+                () -> new ChallengeEvaluationInput(null, provenance(), outcome, 0L));
+        assertThrows(NullPointerException.class,
+                () -> new ChallengeEvaluationInput(challenge, null, outcome, 0L));
+        assertThrows(NullPointerException.class,
+                () -> new ChallengeEvaluationInput(challenge, provenance(), null, 0L));
+        assertThrows(NullPointerException.class, () -> new EvaluationProvenance(null, "run"));
+        assertThrows(NullPointerException.class, () -> new EvaluationProvenance("model", null));
+        assertThrows(IllegalArgumentException.class, () -> new EvaluationProvenance("model", " "));
+        assertThrows(NullPointerException.class, () -> new ChallengeEvaluationIssue(null, "path", "message"));
+        assertThrows(NullPointerException.class, () -> new ChallengeEvaluationIssue("code", null, "message"));
+        assertThrows(NullPointerException.class, () -> new ChallengeEvaluationIssue("code", "path", null));
+        assertThrows(NullPointerException.class, () -> new ChallengeEvaluationResult(null,
+                challenge.evaluationPolicy(), provenance(), true, List.of(), 0L, 0L, BigInteger.ONE));
+        assertThrows(NullPointerException.class, () -> new ChallengeEvaluationResult(challenge.identity(), null,
+                provenance(), true, List.of(), 0L, 0L, BigInteger.ONE));
+        assertThrows(NullPointerException.class, () -> new ChallengeEvaluationResult(challenge.identity(),
+                challenge.evaluationPolicy(), null, true, List.of(), 0L, 0L, BigInteger.ONE));
+        assertThrows(NullPointerException.class, () -> new ChallengeEvaluationResult(challenge.identity(),
+                challenge.evaluationPolicy(), provenance(), true, null, 0L, 0L, BigInteger.ONE));
+        assertThrows(NullPointerException.class, () -> new ChallengeEvaluationResult(challenge.identity(),
+                challenge.evaluationPolicy(), provenance(), true, List.of(), 0L, 0L, null));
+        assertThrows(IllegalArgumentException.class, () -> new ChallengeEvaluationResult(challenge.identity(),
+                challenge.evaluationPolicy(), provenance(), true, List.of(issue), 0L, 0L, BigInteger.ONE));
+        assertThrows(IllegalArgumentException.class, () -> new ChallengeEvaluationResult(challenge.identity(),
+                challenge.evaluationPolicy(), provenance(), true, List.of(), null, 0L, BigInteger.ONE));
+        assertThrows(IllegalArgumentException.class, () -> new ChallengeEvaluationResult(challenge.identity(),
+                challenge.evaluationPolicy(), provenance(), false, List.of(issue), null, 0L, BigInteger.ONE));
+    }
+
+    @Test
     void unsupportedPolicyAndMalformedChallengeAreRejected() {
         ChallengeDefinition challenge = ChallengeFixtures.referenceChallenge();
         ChallengeDefinition unsupported = new ChallengeDefinition(challenge.identity(), challenge.floor(),
@@ -130,6 +166,7 @@ class ReferenceChallengeEvaluationPolicyTest {
                 unsupported, provenance(), new AuthoritativeOutcomeFacts(true, 1L), 0L)));
         assertThrows(IllegalArgumentException.class, () -> evaluate(new ChallengeEvaluationInput(
                 invalidDeadline, provenance(), new AuthoritativeOutcomeFacts(true, 1L), 0L)));
+        assertThrows(NullPointerException.class, () -> evaluate(null));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add a headless, immutable C3 evaluation seam with supplied authoritative outcome facts and opaque model/run provenance.
- Implement policy.contract-completion v1: contract completion, deadline, and construction-budget success conditions with stable structured reasons.
- Use an exact-integer v1 score: 1 + deadline margin + unused budget on success; C4/C5 remain deferred.

## Boundary
No dependency on factory/runtime, scheduler, simulation, Finance, API, or frontend types. The evaluator consumes supplied facts and does not reconstruct production semantics.

## Validation
- Docker development environment: cd product && ./gradlew :challenge:check --console=plain (passed).