### PR TITLE
Harden ADR immutability metadata normalization

### DIFF
--- a/.github/scripts/check-adr-immutability.py
+++ b/.github/scripts/check-adr-immutability.py
@@ -19,10 +19,19 @@ from typing import Iterable
 
 ADR_DIR = "docs/architecture/decisions"
 ADR_NAME = re.compile(r"^(\d{4})-[^/]+\.md$")
-STATUS = re.compile(r"^Status:\s*(\S+)\s*$", re.MULTILINE)
-SUPERSEDED_BY = re.compile(r"^Superseded by:\s*(ADR-\d{4})\s*$", re.MULTILINE)
-SUPERSEDES = re.compile(r"^Supersedes:\s*(ADR-\d{4})\s*$", re.MULTILINE)
-ALLOWED_MUTABLE_METADATA = re.compile(r"^(?:Status|Superseded by):.*(?:\n|$)", re.MULTILINE)
+STATUS = re.compile(r"^Status:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
+SUPERSEDED_BY = re.compile(r"^Superseded by:[ \t]*(ADR-\d{4})[ \t]*$", re.MULTILINE)
+SUPERSEDES = re.compile(r"^Supersedes:[ \t]*(ADR-\d{4})[ \t]*$", re.MULTILINE)
+ALLOWED_MUTABLE_METADATA = re.compile(
+    r"^(?:Status:[ \t]*\S+[ \t]*|Superseded by:[ \t]*ADR-\d{4}[ \t]*)(?:\r?\n|$)",
+    re.MULTILINE,
+)
+SECTION_HEADING = re.compile(r"^##\s", re.MULTILINE)
+HEADER_METADATA = (
+    ("Status", STATUS),
+    ("Superseded by", SUPERSEDED_BY),
+    ("Supersedes", SUPERSEDES),
+)
 
 
 def run_git(*args: str, check: bool = True) -> str:
@@ -36,18 +45,39 @@ def run_git(*args: str, check: bool = True) -> str:
     return result.stdout
 
 
+def metadata_header(text: str) -> str:
+    """Return only the ADR header area before the first level-two section."""
+    match = SECTION_HEADING.search(text)
+    return text if match is None else text[: match.start()]
+
+
+def duplicate_header_metadata(text: str) -> list[str]:
+    """Return singular metadata field names that occur more than once in the ADR header."""
+    header = metadata_header(text)
+    return [name for name, pattern in HEADER_METADATA if len(pattern.findall(header)) > 1]
+
+
 def status(text: str) -> str | None:
-    match = STATUS.search(text)
+    match = STATUS.search(metadata_header(text))
     return match.group(1) if match else None
 
 
 def superseded_by(text: str) -> str | None:
-    match = SUPERSEDED_BY.search(text)
+    match = SUPERSEDED_BY.search(metadata_header(text))
+    return match.group(1) if match else None
+
+
+def supersedes(text: str) -> str | None:
+    match = SUPERSEDES.search(metadata_header(text))
     return match.group(1) if match else None
 
 
 def immutable_body(text: str) -> str:
-    return ALLOWED_MUTABLE_METADATA.sub("", text)
+    match = SECTION_HEADING.search(text)
+    if match is None:
+        return ALLOWED_MUTABLE_METADATA.sub("", text)
+    header = ALLOWED_MUTABLE_METADATA.sub("", text[: match.start()])
+    return header + text[match.start() :]
 
 
 def adr_id(path: str) -> str:
@@ -110,6 +140,13 @@ def validate(base_ref: str) -> list[str]:
             errors.append(f"{path}: accepted ADRs may not be deleted or renamed")
             continue
 
+        duplicates = duplicate_header_metadata(after)
+        if duplicates:
+            errors.append(
+                f"{path}: duplicate ADR header metadata is not allowed: {', '.join(duplicates)}"
+            )
+            continue
+
         if immutable_body(before) != immutable_body(after):
             errors.append(
                 f"{path}: {before_status} ADR body changed; create a superseding ADR instead"
@@ -151,15 +188,21 @@ def validate(base_ref: str) -> list[str]:
             )
             continue
 
+        new_duplicates = duplicate_header_metadata(new_text)
+        if new_duplicates:
+            errors.append(
+                f"{target}: duplicate ADR header metadata is not allowed: {', '.join(new_duplicates)}"
+            )
+            continue
+
         if status(new_text) != "Accepted":
             errors.append(
                 f"{target}: superseding ADR must be `Status: Accepted` before {adr_id(path)} can become Superseded"
             )
             continue
 
-        match = SUPERSEDES.search(new_text)
         expected = adr_id(path)
-        if not match or match.group(1) != expected:
+        if supersedes(new_text) != expected:
             errors.append(
                 f"{target}: must declare `Supersedes: {expected}` when replacing {path}"
             )

--- a/.github/scripts/check-adr-immutability.test.py
+++ b/.github/scripts/check-adr-immutability.test.py
@@ -38,14 +38,15 @@ def commit(cwd: Path, message: str) -> str:
     return run(cwd, "git", "rev-parse", "HEAD").stdout.strip()
 
 
-def check_case(name: str, mutate, expected_ok: bool) -> None:
+def check_case(name: str, mutate, expected_ok: bool, accepted_body: str = "Keep history.\n") -> None:
     with tempfile.TemporaryDirectory() as tmp:
         repo = Path(tmp)
         git_init(repo)
         write(
             repo,
             "0001-example.md",
-            "# ADR-0001: Example\n\nStatus: Accepted\nDate: 2026-01-01\n\n## Decision\n\nKeep history.\n",
+            "# ADR-0001: Example\n\nStatus: Accepted\nDate: 2026-01-01\n\n## Decision\n\n"
+            + accepted_body,
         )
         write(
             repo,
@@ -80,6 +81,47 @@ def main() -> None:
 
     check_case("accepted ADR body edit is rejected", edit_body, False)
 
+    def edit_body_status_line(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        path.write_text(path.read_text().replace("Status: Example", "Status: Changed"))
+
+    check_case(
+        "accepted ADR body Status line remains immutable",
+        edit_body_status_line,
+        False,
+        accepted_body="Status: Example\n",
+    )
+
+    check_case(
+        "accepted ADR body Superseded-by line is not treated as header metadata",
+        lambda repo: None,
+        True,
+        accepted_body="Superseded by: ADR-9999\n",
+    )
+
+    def edit_body_superseded_by_line(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        path.write_text(path.read_text().replace("Superseded by: ADR-9999", "Superseded by: ADR-9998"))
+
+    check_case(
+        "accepted ADR body Superseded-by line remains immutable",
+        edit_body_superseded_by_line,
+        False,
+        accepted_body="Superseded by: ADR-9999\n",
+    )
+
+    def duplicate_header_status(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        path.write_text(path.read_text().replace("Date: 2026-01-01\n", "Date: 2026-01-01\nStatus: Superseded\n"))
+
+    check_case("duplicate header Status metadata is rejected", duplicate_header_status, False)
+
+    def malformed_header_status(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        path.write_text(path.read_text().replace("Date: 2026-01-01\n", "Date: 2026-01-01\nStatus: invalid value\n"))
+
+    check_case("malformed extra header Status line remains protected", malformed_header_status, False)
+
     def delete_accepted(repo: Path) -> None:
         (repo / "docs/architecture/decisions/0001-example.md").unlink()
 
@@ -113,6 +155,34 @@ def main() -> None:
         )
 
     check_case("proposed ADR cannot supersede accepted ADR", supersede_with_proposed, False)
+
+    def supersede_with_duplicate_target(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        text = path.read_text().replace(
+            "Status: Accepted\n", "Status: Superseded\nSuperseded by: ADR-0003\nSuperseded by: ADR-0004\n"
+        )
+        path.write_text(text)
+        write(
+            repo,
+            "0003-replacement.md",
+            "# ADR-0003: Replacement\n\nStatus: Accepted\nSupersedes: ADR-0001\n\n## Decision\n\nNew decision.\n",
+        )
+
+    check_case("duplicate Superseded-by metadata is rejected", supersede_with_duplicate_target, False)
+
+    def supersede_with_duplicate_supersedes(repo: Path) -> None:
+        path = repo / "docs/architecture/decisions/0001-example.md"
+        text = path.read_text().replace(
+            "Status: Accepted\n", "Status: Superseded\nSuperseded by: ADR-0003\n"
+        )
+        path.write_text(text)
+        write(
+            repo,
+            "0003-replacement.md",
+            "# ADR-0003: Replacement\n\nStatus: Accepted\nSupersedes: ADR-0001\nSupersedes: ADR-0002\n\n## Decision\n\nNew decision.\n",
+        )
+
+    check_case("duplicate Supersedes metadata is rejected", supersede_with_duplicate_supersedes, False)
 
     def valid_supersession(repo: Path) -> None:
         path = repo / "docs/architecture/decisions/0001-example.md"


### PR DESCRIPTION
Closes #223.

Tightens the ADR immutability guard so metadata parsing/normalization is scoped to the ADR header before the first level-two section instead of matching `Status:`, `Superseded by:`, or `Supersedes:` anywhere in the document.

This preserves existing valid metadata-only Accepted -> Superseded transitions while ensuring metadata-looking body/example lines remain ordinary immutable ADR content and cannot influence metadata validation.

Regression coverage proves:
- accepted ADR body edits remain rejected;
- body lines beginning with `Status:` remain protected;
- body lines beginning with `Superseded by:` are not treated as header metadata and remain protected;
- proposed ADRs remain editable;
- matching Accepted supersession transitions remain valid.