### PR TITLE
test: improve Java and frontend coverage

### DIFF
--- a/product/interfaces/api/src/test/java/com/arcogine/api/ApiSmokeTest.java
+++ b/product/interfaces/api/src/test/java/com/arcogine/api/ApiSmokeTest.java
@@ -442,7 +442,7 @@ class ApiSmokeTest {
     }
 
     @Test
-    void sseStreamDeliversAuthoritativeRuntimeEventPayload() throws Exception {
+    void sseStreamDeliversPriceChangeEventPayload() throws Exception {
         longClient().post()
                 .uri("/api/scenario")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -452,18 +452,23 @@ class ApiSmokeTest {
                 .isOk();
         sleepQuietly(100);
 
-        CompletableFuture<ServerSentEvent<String>> received = CompletableFuture.supplyAsync(() -> longClient()
+        // exchange() blocks until the response status/headers arrive, and the
+        // controller registers its SimThread listener before it sends the
+        // priming comment that flushes those headers (see SseController), so
+        // by the time exchange() returns the listener is already registered.
+        // Only the wait for the next data event needs to move to the
+        // background so the price-change POST below can proceed.
+        Flux<ServerSentEvent<String>> body = longClient()
                 .get()
                 .uri("/api/events/stream")
                 .exchange()
                 .expectStatus()
                 .isOk()
                 .returnResult(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
-                .getResponseBody()
-                .filter(event -> event.data() != null)
-                .next()
-                .block(Duration.ofSeconds(5)));
-        sleepQuietly(200);
+                .getResponseBody();
+
+        CompletableFuture<ServerSentEvent<String>> received = CompletableFuture.supplyAsync(
+                () -> body.filter(event -> event.data() != null).next().block(Duration.ofSeconds(5)));
 
         client.post()
                 .uri("/api/price")

--- a/product/interfaces/api/src/test/java/com/arcogine/api/ApiSmokeTest.java
+++ b/product/interfaces/api/src/test/java/com/arcogine/api/ApiSmokeTest.java
@@ -10,12 +10,16 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -435,6 +439,45 @@ class ApiSmokeTest {
                 .isOk()
                 .expectHeader()
                 .contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM);
+    }
+
+    @Test
+    void sseStreamDeliversAuthoritativeRuntimeEventPayload() throws Exception {
+        longClient().post()
+                .uri("/api/scenario")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("{\"toml\":" + jsonString(BASIC_SCENARIO_TOML) + "}")
+                .exchange()
+                .expectStatus()
+                .isOk();
+        sleepQuietly(100);
+
+        CompletableFuture<ServerSentEvent<String>> received = CompletableFuture.supplyAsync(() -> longClient()
+                .get()
+                .uri("/api/events/stream")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .returnResult(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
+                .getResponseBody()
+                .filter(event -> event.data() != null)
+                .next()
+                .block(Duration.ofSeconds(5)));
+        sleepQuietly(200);
+
+        client.post()
+                .uri("/api/price")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("{\"price\":12.5}")
+                .exchange()
+                .expectStatus()
+                .isOk();
+
+        ServerSentEvent<String> event = received.get(5, TimeUnit.SECONDS);
+        assertNotNull(event);
+        assertNotNull(event.data());
+        assertTrue(event.data().contains("PriceChange"), event.data());
+        assertTrue(event.data().contains("12.5"), event.data());
     }
 
     @Test

--- a/product/interfaces/cli/src/test/java/com/arcogine/cli/ArcogineCommandTest.java
+++ b/product/interfaces/cli/src/test/java/com/arcogine/cli/ArcogineCommandTest.java
@@ -70,7 +70,26 @@ class ArcogineCommandTest {
     @Test
     void springCommandLineRunnerDoesNotExecuteTheCliMode() {
         ArcogineCommand command = new ArcogineCommand();
-        command.run("run", "scenario.toml");
+
+        PrintStream originalOut = System.out;
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream capturedOut = new ByteArrayOutputStream();
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(capturedOut, true, StandardCharsets.UTF_8));
+            System.setErr(new PrintStream(capturedErr, true, StandardCharsets.UTF_8));
+            command.run("run", "scenario.toml");
+        } finally {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+        }
+
+        // If Spring's run(...) ever started delegating to headless CLI
+        // execution, running against the non-existent "scenario.toml" would
+        // print either the completion summary or a "Error: ..." message -
+        // either way, output that this no-op must not produce.
+        assertEquals("", capturedOut.toString(StandardCharsets.UTF_8));
+        assertEquals("", capturedErr.toString(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/product/interfaces/cli/src/test/java/com/arcogine/cli/ArcogineCommandTest.java
+++ b/product/interfaces/cli/src/test/java/com/arcogine/cli/ArcogineCommandTest.java
@@ -68,6 +68,12 @@ class ArcogineCommandTest {
     }
 
     @Test
+    void springCommandLineRunnerDoesNotExecuteTheCliMode() {
+        ArcogineCommand command = new ArcogineCommand();
+        command.run("run", "scenario.toml");
+    }
+
+    @Test
     void runModeWithMissingFileReturnsErrorExitCode() {
         int exitCode = new CommandLine(new ArcogineCommand())
                 .execute("run", "does-not-exist.toml");

--- a/product/interfaces/web/src/api/sse.test.ts
+++ b/product/interfaces/web/src/api/sse.test.ts
@@ -83,6 +83,15 @@ describe('SseClient', () => {
     expect(eventSpy).not.toHaveBeenCalled();
   });
 
+  it('connect is idempotent while the initial connection is still opening', () => {
+    client.connect();
+    const connectingSource = (client as unknown as { es: MockEventSource }).es;
+
+    client.connect();
+
+    expect((client as unknown as { es: MockEventSource }).es).toBe(connectingSource);
+  });
+
   it('onEvent callback fires for valid JSON payloads', async () => {
     client.connect();
     await vi.advanceTimersByTimeAsync(0);
@@ -201,5 +210,33 @@ describe('SseClient', () => {
     expect(es2).not.toBe(es1);
 
     delayedClient.disconnect();
+  });
+
+  it('resets reconnect delay after a successful connection', async () => {
+    client.connect();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const firstSource = (client as unknown as { es: MockEventSource }).es;
+    firstSource.simulateError();
+    await vi.advanceTimersByTimeAsync(100);
+
+    const reconnectedSource = (client as unknown as { es: MockEventSource }).es;
+    reconnectedSource.simulateError();
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect((client as unknown as { es: MockEventSource | null }).es).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect((client as unknown as { es: MockEventSource | null }).es).not.toBeNull();
+  });
+
+  it('uses the default stream URL when no options are supplied', () => {
+    const defaultClient = new SseClient(eventSpy);
+    defaultClient.connect();
+
+    const es = (defaultClient as unknown as { es: MockEventSource }).es;
+    expect(es.url).toBe('/api/events/stream');
+
+    defaultClient.disconnect();
   });
 });

--- a/product/interfaces/web/src/components/dashboard/JobTracker.test.tsx
+++ b/product/interfaces/web/src/components/dashboard/JobTracker.test.tsx
@@ -203,4 +203,73 @@ describe('JobTracker', () => {
     fireEvent.click(header);
     expect(header.textContent).toContain('↑');
   });
+
+  it('renders all supported status styles and sorts numeric values with nulls last', () => {
+    useSimulationStore.setState({
+      snapshot: makeSnapshot([
+        {
+          job_id: 1,
+          product_id: 1,
+          quantity: 1,
+          status: 'InProgress',
+          current_step: 1,
+          total_steps: 2,
+          created_at: 5,
+          completed_at: null,
+          revenue: 10,
+        },
+        {
+          job_id: 2,
+          product_id: 2,
+          quantity: 1,
+          status: 'Cancelled',
+          current_step: 0,
+          total_steps: 2,
+          created_at: 10,
+          completed_at: null,
+          revenue: null,
+        },
+        {
+          job_id: 3,
+          product_id: 3,
+          quantity: 1,
+          status: 'Queued',
+          current_step: 0,
+          total_steps: 2,
+          created_at: 15,
+          completed_at: null,
+          revenue: 5,
+        },
+        {
+          job_id: 4,
+          product_id: 4,
+          quantity: 1,
+          status: 'Queued',
+          current_step: 0,
+          total_steps: 2,
+          created_at: 20,
+          completed_at: null,
+          revenue: null,
+        },
+      ]),
+    });
+    render(<JobTracker />);
+
+    expect(screen.getByText('InProgress').className).toContain('bg-sky-500/20');
+    expect(screen.getByText('Cancelled').className).toContain('bg-red-500/20');
+
+    fireEvent.click(screen.getByText(/Unit value/));
+    const jobIdsAfterAscendingSort = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => row.querySelector('td')?.textContent);
+    expect(jobIdsAfterAscendingSort).toEqual(['3', '1', '2', '4']);
+
+    fireEvent.click(screen.getByText(/Unit value/));
+    const jobIdsAfterDescendingSort = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => row.querySelector('td')?.textContent);
+    expect(jobIdsAfterDescendingSort).toEqual(['1', '3', '2', '4']);
+  });
 });

--- a/product/interfaces/web/src/components/experiment/BaselineCompare.test.tsx
+++ b/product/interfaces/web/src/components/experiment/BaselineCompare.test.tsx
@@ -69,6 +69,15 @@ describe('BaselineCompare', () => {
     promptSpy.mockRestore();
   });
 
+  it('does not save a blank baseline name', () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('   ');
+    useSimulationStore.setState({ snapshot: makeSnapshot() });
+    render(<BaselineCompare />);
+    fireEvent.click(screen.getByRole('button', { name: /save baseline/i }));
+    expect(screen.getByText(/no saved baselines/i)).toBeInTheDocument();
+    promptSpy.mockRestore();
+  });
+
   it('removes a baseline when remove is clicked', () => {
     const snap = makeSnapshot();
     useSimulationStore.setState({ snapshot: snap });
@@ -101,5 +110,36 @@ describe('BaselineCompare', () => {
     useBaselinesStore.getState().saveBaseline('base', makeSnapshot({ total_revenue: 1000 }));
     render(<BaselineCompare />);
     expect(screen.getByText('Revenue')).toBeInTheDocument();
+  });
+
+  it('renders all metric verdicts, including neutral and zero-baseline values', () => {
+    const baseline = makeSnapshot({ total_revenue: 100, backlog: 4, completed_sales: 8, current_time: 40 });
+    const current = makeSnapshot({ total_revenue: 100, backlog: 3, completed_sales: 0, current_time: 0 });
+    useSimulationStore.setState({ snapshot: current });
+    useBaselinesStore.getState().saveBaseline('All metrics', baseline);
+    render(<BaselineCompare />);
+
+    expect(screen.getByText('Backlog')).toBeInTheDocument();
+    expect(screen.getByText('Lead time')).toBeInTheDocument();
+    expect(screen.getByText('Throughput')).toBeInTheDocument();
+    expect(screen.getAllByText((_, element) => element?.textContent === '(0.0%)')).toHaveLength(2);
+    expect(screen.getAllByText('0').length).toBeGreaterThan(0);
+  });
+
+  it('renders a worsening backlog and lead time with negative delta styling', () => {
+    const baseline = makeSnapshot({
+      backlog: 2,
+      kpis: [{ name: 'lead_time', value: 10, unit: 'ticks' }],
+    });
+    const current = makeSnapshot({
+      backlog: 5,
+      kpis: [{ name: 'lead_time', value: 50, unit: 'ticks' }],
+    });
+    useSimulationStore.setState({ snapshot: current });
+    useBaselinesStore.getState().saveBaseline('Worse', baseline);
+    render(<BaselineCompare />);
+
+    expect(document.querySelectorAll('svg.text-red-500')).toHaveLength(2);
+    expect(document.querySelectorAll('.text-red-400')).toHaveLength(2);
   });
 });

--- a/product/interfaces/web/src/stores/baselines.test.ts
+++ b/product/interfaces/web/src/stores/baselines.test.ts
@@ -130,4 +130,14 @@ describe('useBaselinesStore', () => {
     const deltas = useBaselinesStore.getState().getDeltas(currentSnap, id);
     expect(deltas.revenue.pct).toBe(0);
   });
+
+  it('uses zero when optional lead-time and throughput KPIs are absent', () => {
+    const snap = makeSnapshot({ kpis: [] });
+    useBaselinesStore.getState().saveBaseline('missing-kpis', snap);
+    const id = useBaselinesStore.getState().baselines[0].id;
+
+    const deltas = useBaselinesStore.getState().getDeltas(snap, id);
+    expect(deltas.lead_time).toMatchObject({ current: 0, baseline: 0, delta: 0, pct: 0 });
+    expect(deltas.throughput).toMatchObject({ current: 0, baseline: 0, delta: 0, pct: 0 });
+  });
 });

--- a/product/interfaces/web/src/stores/simulation.test.ts
+++ b/product/interfaces/web/src/stores/simulation.test.ts
@@ -88,14 +88,13 @@ describe('useSimulationStore', () => {
       }));
       useSimulationStore.setState({ kpiHistory: existing });
 
-      const { postScenario, getSnapshot } = await import('../api/client');
-      (postScenario as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
-      (getSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue(makeSnapshot(999));
+      const { postSimRun } = await import('../api/client');
+      (postSimRun as ReturnType<typeof vi.fn>).mockResolvedValue(makeSnapshot(999));
 
-      await useSimulationStore.getState().loadScenario('test');
-      expect(useSimulationStore.getState().kpiHistory.length).toBeLessThanOrEqual(
-        MAX_KPI_HISTORY_POINTS,
-      );
+      await useSimulationStore.getState().runSim();
+      const history = useSimulationStore.getState().kpiHistory;
+      expect(history).toHaveLength(MAX_KPI_HISTORY_POINTS);
+      expect(history.at(-1)).toEqual({ time: 999, values: { event_count: 999 } });
     });
   });
 
@@ -139,6 +138,15 @@ describe('useSimulationStore', () => {
       await useSimulationStore.getState().runSim();
       expect(useSimulationStore.getState().loading).toBe(false);
       expect(useSimulationStore.getState().error).toBe('fail');
+    });
+
+    it('stringifies non-Error command failures', async () => {
+      const { postSimRun } = await import('../api/client');
+      (postSimRun as ReturnType<typeof vi.fn>).mockRejectedValue('service unavailable');
+
+      await useSimulationStore.getState().runSim();
+
+      expect(useSimulationStore.getState().error).toBe('service unavailable');
     });
 
     it('inserts KPI history points to keep sorted order', async () => {
@@ -210,6 +218,15 @@ describe('useSimulationStore', () => {
       await useSimulationStore.getState().fetchSnapshot();
       expect(useSimulationStore.getState().error).toBe('api down');
     });
+
+    it('stringifies non-Error snapshot failures', async () => {
+      const { getSnapshot } = await import('../api/client');
+      (getSnapshot as ReturnType<typeof vi.fn>).mockRejectedValue('snapshot unavailable');
+
+      await useSimulationStore.getState().fetchSnapshot();
+
+      expect(useSimulationStore.getState().error).toBe('snapshot unavailable');
+    });
   });
 
   describe('clearError', () => {
@@ -240,6 +257,15 @@ describe('useSimulationStore', () => {
       expect(useSimulationStore.getState().error).toBe('bad scenario');
       expect(useSimulationStore.getState().snapshot).toBeNull();
     });
+
+    it('stringifies non-Error scenario failures', async () => {
+      const { postScenario } = await import('../api/client');
+      (postScenario as ReturnType<typeof vi.fn>).mockRejectedValue('invalid scenario');
+
+      await useSimulationStore.getState().loadScenario('toml-content');
+
+      expect(useSimulationStore.getState().error).toBe('invalid scenario');
+    });
   });
 
   describe('resetSim', () => {
@@ -268,6 +294,15 @@ describe('useSimulationStore', () => {
       await useSimulationStore.getState().resetSim();
       expect(useSimulationStore.getState().loading).toBe(false);
       expect(useSimulationStore.getState().error).toBe('reset failed');
+    });
+
+    it('stringifies non-Error reset failures', async () => {
+      const { postSimReset } = await import('../api/client');
+      (postSimReset as ReturnType<typeof vi.fn>).mockRejectedValue('reset unavailable');
+
+      await useSimulationStore.getState().resetSim();
+
+      expect(useSimulationStore.getState().error).toBe('reset unavailable');
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds CLI test coverage for Spring runner behavior (does not execute CLI mode when running under Spring).
- Adds frontend tests covering edge cases in SSE handling, JobTracker, BaselineCompare, and the baselines/simulation stores.
- Adds an API test verifying the SSE stream delivers the actual `PriceChange` event payload (type + new price), not just a heartbeat frame.

## Test plan
- [x] `cd product && ./gradlew compileTestJava test jacocoTestReport jacocoTestCoverageVerification` — all tests pass, coverage gates met.
- [x] `cd product/interfaces/web && npm run test:coverage` — 94 tests pass, 97% statements / 91.2% branches / 100% funcs / 98.1% lines.