### PR TITLE
feat(challenge): add C4 attempt provenance and design-to-design comparison

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -421,8 +421,9 @@ product/
 ├── agents/               Agent framework: SalesAgent, AgentObservation
 ├── consumer/
 │   └── challenge/        Challenge Readiness: game-owned challenge definition/validation,
-│                         catalogue/economics, candidate admissibility, and deterministic
-│                         challenge evaluation (see
+│                         catalogue/economics, candidate admissibility, deterministic
+│                         challenge evaluation, and attempt provenance/design-to-design
+│                         comparison (see
 │                         docs/planning/factory-design-game-challenge-readiness.md).
 │                         Headless — no dependency on any module below.
 └── interfaces/
@@ -455,9 +456,10 @@ Each module exposes a clean public API and hides implementation details. Event-h
 module (`com.arcogine.challenge`) that has no `project(...)` dependency on `types`, `simulation`,
 any domain module, `api`, or `cli`, and no Spring dependency. It defines immutable challenge
 definitions and validation, game-owned catalogue/economics, deterministic candidate admissibility,
-and deterministic challenge evaluation over supplied authoritative outcome facts. These are
-distinct validation domains from `FactoryModelValidator` and do not inspect factory/runtime state —
-see the Challenge Readiness planning doc for the ownership boundary.
+deterministic challenge evaluation over supplied authoritative outcome facts, and immutable attempt
+provenance with deterministic design-to-design comparison. These are distinct validation domains
+from `FactoryModelValidator` and do not inspect factory/runtime state — see the Challenge Readiness
+planning doc for the ownership boundary.
 
 ## Event Dispatch Architecture
 

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -460,6 +460,45 @@ C4 is ready when:
 7. Comparison distinguishes authoritative production facts from game-owned score/economics/draft facts.
 8. No comparison requirement implies Arcogine D5 semantic comparison unless a future product requirement explicitly asks Arcogine to explain semantic differences between published model versions.
 
+### Implementation status (C4 — complete)
+
+C4 is **complete** as a headless, deterministic attempt and comparison capability in
+`com.arcogine.challenge.attempt` and `com.arcogine.challenge.comparison`. It reuses C1-C3 facts
+rather than duplicating them: `ChallengeAttempt` retains the exact admitted `CandidateDraftSnapshot`
+(C2), the exact historical `DraftEconomics` used (C2), and the exact `ChallengeEvaluationResult`
+(C3) -- which already carries the challenge identity/version, evaluation-policy identity/version,
+and opaque model/run provenance. `ChallengeAttempt` does not recompute economics against the
+current catalogue or re-evaluate the result; `challengeIdentity()` and `evaluationPolicy()` are
+thin accessors onto the retained `ChallengeEvaluationResult`, not a second copy of those facts.
+
+`ChallengeAttemptId` is a game-owned identity for the historical occurrence of one attempt --
+distinct from, and never derived from, `ChallengeIdentity`, `EvaluationPolicyIdentity`, or any
+published-model/run reference. `ChallengeAttempt.record(...)` generates a fresh id and constructs
+an immutable attempt in one step; there is no separate lifecycle/state-machine, submission
+workflow, or persistence -- C4 needed only a reproducible completed-attempt record. Optional
+model/run provenance is carried exactly as C3 supplied it (via `EvaluationProvenance` inside the
+retained result) and is never fabricated when absent.
+
+`ChallengeAttemptComparator.compare(...)` in `com.arcogine.challenge.comparison` first checks
+`AttemptCompatibility`: two attempts are comparable only when they share the exact same
+`ChallengeIdentity` and `EvaluationPolicyIdentity` (including version). Incompatible pairs return
+stable, ordered `AttemptIncompatibilityReason` codes (`attempt.challenge.mismatch`,
+`attempt.evaluationPolicy.mismatch`) instead of a silently misleading comparison. Compatible pairs
+produce an `AttemptComparison` of score delta, deadline-margin delta, unused-budget delta, and
+construction-cost delta -- all read directly from already-owned C2/C3 facts, plus a `winner`
+(`FIRST`/`SECOND`/`TIE`) derived solely from the shared policy's own score ordering. Comparison
+never re-evaluates either attempt and never mutates its inputs; attempt identity plays no part in
+the comparison outcome.
+
+Tests in `ChallengeAttemptTest` and `ChallengeAttemptComparatorTest` cover immutability of the
+retained candidate snapshot and economics, non-recomputation of the evaluation result, deterministic
+and identity-independent comparison, and structured incompatibility for mismatched challenge or
+policy versions. C4 does not add persistence, a leaderboard, UI, REST/SSE endpoints, a generic
+comparison framework, or Governance evidence semantics; it does not claim canonical model
+projection or a completed Engine Readiness gate. Remaining work -- data-driven challenge content,
+reference-content serialization, and any durable attempt storage -- is deferred to C5 or later
+consumer integration.
+
 ## 9. C5 — Data-driven challenges and reference fixtures
 
 ### Goal

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -341,7 +341,7 @@ C2 completion does not make the game playable and satisfies no Engine Readiness 
 candidate is not canonically executable: a later game-owned projection still requires Arcogine
 canonical validation before publication/run. Conversely, a canonically executable factory may
 remain inadmissible under a particular challenge. C3 is implemented independently of that
-projection; C4-C5 remain deferred.
+projection; C3 and C4 are now implemented and C5 remains deferred.
 
 ## 7. C3 — Deterministic challenge evaluation
 
@@ -475,9 +475,12 @@ thin accessors onto the retained `ChallengeEvaluationResult`, not a second copy 
 distinct from, and never derived from, `ChallengeIdentity`, `EvaluationPolicyIdentity`, or any
 published-model/run reference. `ChallengeAttempt.record(...)` generates a fresh id and constructs
 an immutable attempt in one step; there is no separate lifecycle/state-machine, submission
-workflow, or persistence -- C4 needed only a reproducible completed-attempt record. Optional
-model/run provenance is carried exactly as C3 supplied it (via `EvaluationProvenance` inside the
-retained result) and is never fabricated when absent.
+workflow, or persistence -- C4 needed only a reproducible completed-attempt record. Model/run
+provenance is carried exactly as C3 supplied it (via the required, non-blank `EvaluationProvenance`
+inside the retained result) and is never fabricated or substituted by C4 -- C3's existing contract
+requires a caller-supplied opaque model/run reference for every evaluation, so C4 has nothing
+optional to preserve here; a later integration that needs genuinely absent runtime provenance would
+require a C3 contract change, not a C4 one.
 
 `ChallengeAttemptComparator.compare(...)` in `com.arcogine.challenge.comparison` first checks
 `AttemptCompatibility`: two attempts are comparable only when they share the exact same

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/attempt/ChallengeAttempt.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/attempt/ChallengeAttempt.java
@@ -1,0 +1,59 @@
+package com.arcogine.challenge.attempt;
+
+import com.arcogine.challenge.ChallengeIdentity;
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import com.arcogine.challenge.admissibility.CandidateDraftSnapshot;
+import com.arcogine.challenge.economics.DraftEconomics;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationResult;
+
+/**
+ * An immutable, reproducible record of one completed challenge attempt.
+ *
+ * <p>{@code ChallengeAttempt} is the C4 historical aggregate: it retains the exact admitted
+ * candidate snapshot, the exact construction economics used, and the exact C3 evaluation result
+ * (which itself already retains the exact challenge identity/version, evaluation-policy
+ * identity/version, and opaque model/run provenance). It does not recompute or duplicate any of
+ * those C3 facts -- it only adds a stable game-owned identity for the historical occurrence and
+ * guarantees the whole record stays immutable once constructed.
+ *
+ * <p>This is not an event-sourcing or workflow record: it captures one already-completed
+ * attempt/evaluation, not a lifecycle of intermediate states.
+ */
+public record ChallengeAttempt(
+        ChallengeAttemptId id,
+        CandidateDraftSnapshot candidateSnapshot,
+        DraftEconomics economics,
+        ChallengeEvaluationResult evaluationResult) {
+
+    public ChallengeAttempt {
+        if (id == null) {
+            throw new NullPointerException("id");
+        }
+        if (candidateSnapshot == null) {
+            throw new NullPointerException("candidateSnapshot");
+        }
+        if (economics == null) {
+            throw new NullPointerException("economics");
+        }
+        if (evaluationResult == null) {
+            throw new NullPointerException("evaluationResult");
+        }
+    }
+
+    /** Records a new completed attempt, generating a fresh {@link ChallengeAttemptId}. */
+    public static ChallengeAttempt record(CandidateDraftSnapshot candidateSnapshot,
+            DraftEconomics economics, ChallengeEvaluationResult evaluationResult) {
+        return new ChallengeAttempt(ChallengeAttemptId.generate(), candidateSnapshot, economics,
+                evaluationResult);
+    }
+
+    /** The exact challenge identity/version this attempt was evaluated against. */
+    public ChallengeIdentity challengeIdentity() {
+        return evaluationResult.challengeIdentity();
+    }
+
+    /** The exact evaluation-policy identity/version that produced {@link #evaluationResult()}. */
+    public EvaluationPolicyIdentity evaluationPolicy() {
+        return evaluationResult.evaluationPolicy();
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/attempt/ChallengeAttemptId.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/attempt/ChallengeAttemptId.java
@@ -1,0 +1,29 @@
+package com.arcogine.challenge.attempt;
+
+import java.util.UUID;
+
+/**
+ * Stable, game-owned identity of one historical player attempt.
+ *
+ * <p>This identifies which attempt occurred -- it is independent of {@code ChallengeIdentity}
+ * (which challenge/rules), {@code EvaluationPolicyIdentity} (which scoring rules), a published
+ * model fingerprint (which canonical semantic factory content), a controlled revision id (which
+ * governed historical model occurrence), and a run id (which simulation runtime epoch). None of
+ * those identities are derived from this one, and this one is never derived from them.
+ */
+public record ChallengeAttemptId(String value) {
+
+    public ChallengeAttemptId {
+        if (value == null) {
+            throw new NullPointerException("value");
+        }
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("value must be non-blank");
+        }
+    }
+
+    /** Generates a fresh identity for a newly recorded attempt. */
+    public static ChallengeAttemptId generate() {
+        return new ChallengeAttemptId(UUID.randomUUID().toString());
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptComparison.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptComparison.java
@@ -1,0 +1,29 @@
+package com.arcogine.challenge.comparison;
+
+import java.math.BigInteger;
+
+/**
+ * Deterministic, explainable differences between two compatible completed attempts.
+ *
+ * <p>Every field here is derived directly from facts already owned by C2 (economics) or C3
+ * (evaluation result) -- this does not introduce a second scoring or evaluation policy. All deltas
+ * are {@code second - first}, matching the order the two attempts were supplied in.
+ */
+public record AttemptComparison(
+        boolean firstSuccessful,
+        boolean secondSuccessful,
+        BigInteger scoreDelta,
+        Long deadlineMarginDeltaTicks,
+        long unusedBudgetDeltaCredits,
+        long constructionCostDeltaCredits,
+        AttemptComparisonWinner winner) {
+
+    public AttemptComparison {
+        if (scoreDelta == null) {
+            throw new NullPointerException("scoreDelta");
+        }
+        if (winner == null) {
+            throw new NullPointerException("winner");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptComparisonResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptComparisonResult.java
@@ -1,0 +1,34 @@
+package com.arcogine.challenge.comparison;
+
+import com.arcogine.challenge.attempt.ChallengeAttemptId;
+
+/**
+ * The deterministic result of attempting to compare two completed attempts.
+ *
+ * <p>{@code comparison} is present only when {@code compatibility} is comparable; when the two
+ * attempts were evaluated under materially different challenge or evaluation-policy versions,
+ * {@code comparison} is absent and {@code compatibility} carries structured, stable reasons
+ * instead of silently implying an equivalence that does not hold.
+ */
+public record AttemptComparisonResult(
+        ChallengeAttemptId first,
+        ChallengeAttemptId second,
+        AttemptCompatibility compatibility,
+        AttemptComparison comparison) {
+
+    public AttemptComparisonResult {
+        if (first == null) {
+            throw new NullPointerException("first");
+        }
+        if (second == null) {
+            throw new NullPointerException("second");
+        }
+        if (compatibility == null) {
+            throw new NullPointerException("compatibility");
+        }
+        if (compatibility.comparable() != (comparison != null)) {
+            throw new IllegalArgumentException(
+                    "comparison must be present exactly when attempts are comparable");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptComparisonWinner.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptComparisonWinner.java
@@ -1,0 +1,14 @@
+package com.arcogine.challenge.comparison;
+
+/**
+ * Which of two compared attempts scored better under their shared evaluation policy.
+ *
+ * <p>This ordering only ever applies within one {@code AttemptComparison}, whose compatibility
+ * check already guarantees both attempts share the same evaluation-policy identity/version. It is
+ * derived solely from that policy's own score, never from a game-invented cross-policy ranking.
+ */
+public enum AttemptComparisonWinner {
+    FIRST,
+    SECOND,
+    TIE
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptCompatibility.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptCompatibility.java
@@ -1,0 +1,28 @@
+package com.arcogine.challenge.comparison;
+
+import java.util.List;
+
+/** The deterministic outcome of checking whether two attempts may be meaningfully compared. */
+public record AttemptCompatibility(boolean comparable, List<AttemptIncompatibilityReason> reasons) {
+
+    public AttemptCompatibility {
+        if (reasons == null) {
+            throw new NullPointerException("reasons");
+        }
+        reasons = List.copyOf(reasons);
+        if (comparable != reasons.isEmpty()) {
+            throw new IllegalArgumentException("comparable attempts must have no reasons");
+        }
+    }
+
+    public static AttemptCompatibility compatible() {
+        return new AttemptCompatibility(true, List.of());
+    }
+
+    public static AttemptCompatibility incomparable(List<AttemptIncompatibilityReason> reasons) {
+        if (reasons == null || reasons.isEmpty()) {
+            throw new IllegalArgumentException("incomparable attempts must have reasons");
+        }
+        return new AttemptCompatibility(false, reasons);
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptIncompatibilityReason.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/AttemptIncompatibilityReason.java
@@ -1,0 +1,14 @@
+package com.arcogine.challenge.comparison;
+
+/** A stable, machine-readable reason two attempts cannot be meaningfully compared. */
+public record AttemptIncompatibilityReason(String code, String message) {
+
+    public AttemptIncompatibilityReason {
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
+        if (message == null) {
+            throw new NullPointerException("message");
+        }
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/ChallengeAttemptComparator.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/comparison/ChallengeAttemptComparator.java
@@ -1,0 +1,74 @@
+package com.arcogine.challenge.comparison;
+
+import com.arcogine.challenge.attempt.ChallengeAttempt;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationResult;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Deterministic, headless design-to-design comparison of two completed {@link ChallengeAttempt}s.
+ *
+ * <p>Comparison never re-evaluates either attempt: it only reads already-owned C2 economics and
+ * C3 evaluation facts. It first checks compatibility -- attempts must share the exact same
+ * challenge identity/version and evaluation-policy identity/version -- and only ever explains
+ * differences that already-supported facts contain. It introduces no new scoring dimension.
+ */
+public final class ChallengeAttemptComparator {
+
+    private ChallengeAttemptComparator() {}
+
+    /** Compares two attempts, returning structured incompatibility reasons if not comparable. */
+    public static AttemptComparisonResult compare(ChallengeAttempt first, ChallengeAttempt second) {
+        if (first == null) {
+            throw new NullPointerException("first");
+        }
+        if (second == null) {
+            throw new NullPointerException("second");
+        }
+
+        AttemptCompatibility compatibility = checkCompatibility(first, second);
+        if (!compatibility.comparable()) {
+            return new AttemptComparisonResult(first.id(), second.id(), compatibility, null);
+        }
+        return new AttemptComparisonResult(first.id(), second.id(), compatibility,
+                buildComparison(first, second));
+    }
+
+    private static AttemptCompatibility checkCompatibility(ChallengeAttempt first,
+            ChallengeAttempt second) {
+        List<AttemptIncompatibilityReason> reasons = new ArrayList<>();
+        if (!first.challengeIdentity().equals(second.challengeIdentity())) {
+            reasons.add(new AttemptIncompatibilityReason("attempt.challenge.mismatch",
+                    "attempts were evaluated against different challenge identities/versions"));
+        }
+        if (!first.evaluationPolicy().equals(second.evaluationPolicy())) {
+            reasons.add(new AttemptIncompatibilityReason("attempt.evaluationPolicy.mismatch",
+                    "attempts were evaluated under different evaluation-policy identities/versions"));
+        }
+        return reasons.isEmpty() ? AttemptCompatibility.compatible()
+                : AttemptCompatibility.incomparable(reasons);
+    }
+
+    private static AttemptComparison buildComparison(ChallengeAttempt first, ChallengeAttempt second) {
+        ChallengeEvaluationResult firstResult = first.evaluationResult();
+        ChallengeEvaluationResult secondResult = second.evaluationResult();
+
+        BigInteger scoreDelta = secondResult.score().subtract(firstResult.score());
+        Long deadlineMarginDelta = firstResult.deadlineMarginTicks() != null
+                        && secondResult.deadlineMarginTicks() != null
+                ? secondResult.deadlineMarginTicks() - firstResult.deadlineMarginTicks()
+                : null;
+        long unusedBudgetDelta =
+                secondResult.unusedBudgetCredits() - firstResult.unusedBudgetCredits();
+        long constructionCostDelta = second.economics().committedConstructionCostCredits()
+                - first.economics().committedConstructionCostCredits();
+
+        int comparison = scoreDelta.signum();
+        AttemptComparisonWinner winner = comparison == 0 ? AttemptComparisonWinner.TIE
+                : comparison > 0 ? AttemptComparisonWinner.SECOND : AttemptComparisonWinner.FIRST;
+
+        return new AttemptComparison(firstResult.successful(), secondResult.successful(), scoreDelta,
+                deadlineMarginDelta, unusedBudgetDelta, constructionCostDelta, winner);
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/attempt/ChallengeAttemptFixtures.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/attempt/ChallengeAttemptFixtures.java
@@ -1,0 +1,45 @@
+package com.arcogine.challenge.attempt;
+
+import com.arcogine.challenge.ChallengeFixtures;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.admissibility.CandidateDraftSnapshot;
+import com.arcogine.challenge.admissibility.EquipmentOccurrenceId;
+import com.arcogine.challenge.admissibility.GridPlacement;
+import com.arcogine.challenge.admissibility.PlacedEquipment;
+import com.arcogine.challenge.economics.DraftEconomics;
+import com.arcogine.challenge.evaluation.AuthoritativeOutcomeFacts;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationInput;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationResult;
+import com.arcogine.challenge.evaluation.EvaluationProvenance;
+import com.arcogine.challenge.evaluation.ReferenceChallengeEvaluationPolicy;
+import java.util.List;
+
+/** Shared fixtures for C4 attempt/comparison tests. */
+public final class ChallengeAttemptFixtures {
+
+    private ChallengeAttemptFixtures() {}
+
+    public static ChallengeEvaluationResult evaluate(boolean complete, Long completionTick, long cost) {
+        ChallengeEvaluationInput input = new ChallengeEvaluationInput(
+                ChallengeFixtures.referenceChallenge(), provenance(),
+                new AuthoritativeOutcomeFacts(complete, completionTick), cost);
+        return ReferenceChallengeEvaluationPolicy.evaluate(input);
+    }
+
+    public static EvaluationProvenance provenance() {
+        return new EvaluationProvenance("model.factory-basics:v1", "run.factory-basics:historical-1");
+    }
+
+    public static DraftEconomics economics(long committedCost) {
+        return new DraftEconomics(40_000L, committedCost, 40_000L - committedCost);
+    }
+
+    public static CandidateDraftSnapshot snapshot() {
+        return new CandidateDraftSnapshot(List.of(placed("cutter-1")));
+    }
+
+    public static PlacedEquipment placed(String occurrenceId) {
+        return new PlacedEquipment(new EquipmentOccurrenceId(occurrenceId),
+                new EquipmentCatalogueItemId("equipment.cutter"), new GridPlacement(0, 0));
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/attempt/ChallengeAttemptTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/attempt/ChallengeAttemptTest.java
@@ -77,7 +77,7 @@ class ChallengeAttemptTest {
     }
 
     @Test
-    void optionalRuntimeProvenanceIsNotFabricated() {
+    void requiredRuntimeProvenanceIsCarriedExactlyAsSuppliedNeverFabricated() {
         ChallengeEvaluationResult result = evaluate(true, 350L, 10_000L);
         ChallengeAttempt attempt = ChallengeAttempt.record(snapshot(), economics(10_000L), result);
 

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/attempt/ChallengeAttemptTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/attempt/ChallengeAttemptTest.java
@@ -1,0 +1,108 @@
+package com.arcogine.challenge.attempt;
+
+import static com.arcogine.challenge.attempt.ChallengeAttemptFixtures.economics;
+import static com.arcogine.challenge.attempt.ChallengeAttemptFixtures.evaluate;
+import static com.arcogine.challenge.attempt.ChallengeAttemptFixtures.placed;
+import static com.arcogine.challenge.attempt.ChallengeAttemptFixtures.snapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeFixtures;
+import com.arcogine.challenge.admissibility.CandidateDraftSnapshot;
+import com.arcogine.challenge.admissibility.PlacedEquipment;
+import com.arcogine.challenge.economics.DraftEconomics;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationResult;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChallengeAttemptTest {
+
+    @Test
+    void completedAttemptRetainsExactChallengeAndPolicyVersion() {
+        ChallengeEvaluationResult result = evaluate(true, 350L, 10_000L);
+        ChallengeAttempt attempt = ChallengeAttempt.record(snapshot(), economics(10_000L), result);
+
+        assertEquals(ChallengeFixtures.referenceChallenge().identity(), attempt.challengeIdentity());
+        assertEquals(ChallengeFixtures.referenceChallenge().evaluationPolicy(),
+                attempt.evaluationPolicy());
+        assertEquals(result, attempt.evaluationResult());
+    }
+
+    @Test
+    void recordingGeneratesDistinctIdentitiesForEquivalentInputs() {
+        ChallengeEvaluationResult result = evaluate(true, 350L, 10_000L);
+        ChallengeAttempt first = ChallengeAttempt.record(snapshot(), economics(10_000L), result);
+        ChallengeAttempt second = ChallengeAttempt.record(snapshot(), economics(10_000L), result);
+
+        assertNotEquals(first.id(), second.id());
+        assertEquals(first.evaluationResult(), second.evaluationResult());
+    }
+
+    @Test
+    void completedAttemptDefensivelyRetainsCandidateSnapshot() {
+        List<PlacedEquipment> source = new ArrayList<>(List.of(placed("cutter-1")));
+        CandidateDraftSnapshot snapshot = new CandidateDraftSnapshot(source);
+        ChallengeAttempt attempt = ChallengeAttempt.record(snapshot, economics(5_000L),
+                evaluate(true, 350L, 5_000L));
+
+        source.clear();
+
+        assertEquals(1, attempt.candidateSnapshot().placedEquipment().size());
+        assertThrows(UnsupportedOperationException.class,
+                () -> attempt.candidateSnapshot().placedEquipment().clear());
+    }
+
+    @Test
+    void historicalEconomicsDoNotChangeWhenCurrentCatalogueChanges() {
+        DraftEconomics originalEconomics = economics(10_000L);
+        ChallengeAttempt attempt = ChallengeAttempt.record(snapshot(), originalEconomics,
+                evaluate(true, 350L, 10_000L));
+
+        DraftEconomics changedCatalogueEconomics = new DraftEconomics(40_000L, 25_000L, 15_000L);
+
+        assertEquals(originalEconomics, attempt.economics());
+        assertNotEquals(changedCatalogueEconomics, attempt.economics());
+    }
+
+    @Test
+    void attemptRetainsEvaluationResultWithoutReevaluation() {
+        ChallengeEvaluationResult result = evaluate(true, 350L, 10_000L);
+        ChallengeAttempt attempt = ChallengeAttempt.record(snapshot(), economics(10_000L), result);
+
+        assertTrue(attempt.evaluationResult().successful());
+        assertEquals(result.score(), attempt.evaluationResult().score());
+    }
+
+    @Test
+    void optionalRuntimeProvenanceIsNotFabricated() {
+        ChallengeEvaluationResult result = evaluate(true, 350L, 10_000L);
+        ChallengeAttempt attempt = ChallengeAttempt.record(snapshot(), economics(10_000L), result);
+
+        assertEquals("model.factory-basics:v1",
+                attempt.evaluationResult().provenance().publishedModelReference());
+        assertEquals("run.factory-basics:historical-1",
+                attempt.evaluationResult().provenance().runReference());
+    }
+
+    @Test
+    void rejectsNullConstruction() {
+        ChallengeAttemptId id = ChallengeAttemptId.generate();
+        CandidateDraftSnapshot snapshot = snapshot();
+        DraftEconomics economics = economics(10_000L);
+        ChallengeEvaluationResult result = evaluate(true, 350L, 10_000L);
+
+        assertThrows(NullPointerException.class,
+                () -> new ChallengeAttempt(null, snapshot, economics, result));
+        assertThrows(NullPointerException.class,
+                () -> new ChallengeAttempt(id, null, economics, result));
+        assertThrows(NullPointerException.class,
+                () -> new ChallengeAttempt(id, snapshot, null, result));
+        assertThrows(NullPointerException.class,
+                () -> new ChallengeAttempt(id, snapshot, economics, null));
+        assertThrows(NullPointerException.class, () -> new ChallengeAttemptId(null));
+        assertThrows(IllegalArgumentException.class, () -> new ChallengeAttemptId(" "));
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/comparison/ChallengeAttemptComparatorTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/comparison/ChallengeAttemptComparatorTest.java
@@ -1,0 +1,190 @@
+package com.arcogine.challenge.comparison;
+
+import static com.arcogine.challenge.attempt.ChallengeAttemptFixtures.economics;
+import static com.arcogine.challenge.attempt.ChallengeAttemptFixtures.evaluate;
+import static com.arcogine.challenge.attempt.ChallengeAttemptFixtures.provenance;
+import static com.arcogine.challenge.attempt.ChallengeAttemptFixtures.snapshot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.ChallengeFixtures;
+import com.arcogine.challenge.ChallengeIdentity;
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import com.arcogine.challenge.attempt.ChallengeAttempt;
+import com.arcogine.challenge.evaluation.AuthoritativeOutcomeFacts;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationInput;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationResult;
+import com.arcogine.challenge.evaluation.ReferenceChallengeEvaluationPolicy;
+import java.math.BigInteger;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChallengeAttemptComparatorTest {
+
+    @Test
+    void compatibleAttemptsProduceDeterministicComparison() {
+        ChallengeAttempt worse = attempt(true, 350L, 10_000L);
+        ChallengeAttempt better = attempt(true, 390L, 12_000L);
+
+        AttemptComparisonResult first = ChallengeAttemptComparator.compare(worse, better);
+        AttemptComparisonResult second = ChallengeAttemptComparator.compare(worse, better);
+
+        assertTrue(first.compatibility().comparable());
+        assertEquals(first.comparison(), second.comparison());
+    }
+
+    @Test
+    void comparisonReportsScoreOrOutcomeDeltaFromExistingEvaluationFacts() {
+        // first: margin 50, unused budget 30,000, score 30,051.
+        // second: margin 10, unused budget 28,000, score 28,011 -- later completion and higher
+        // construction cost, so first wins under the shared policy's own score ordering.
+        ChallengeAttempt worse = attempt(true, 350L, 10_000L);
+        ChallengeAttempt better = attempt(true, 390L, 12_000L);
+
+        AttemptComparisonResult result = ChallengeAttemptComparator.compare(worse, better);
+
+        AttemptComparison comparison = result.comparison();
+        assertEquals(BigInteger.valueOf(-2_040L), comparison.scoreDelta());
+        assertEquals(-40L, comparison.deadlineMarginDeltaTicks());
+        assertEquals(-2_000L, comparison.unusedBudgetDeltaCredits());
+        assertEquals(2_000L, comparison.constructionCostDeltaCredits());
+        assertEquals(AttemptComparisonWinner.FIRST, comparison.winner());
+        assertTrue(comparison.firstSuccessful());
+        assertTrue(comparison.secondSuccessful());
+    }
+
+    @Test
+    void identicalAttemptsCompareAsTies() {
+        ChallengeAttempt first = attempt(true, 350L, 10_000L);
+        ChallengeAttempt second = attempt(true, 350L, 10_000L);
+
+        AttemptComparison comparison = ChallengeAttemptComparator.compare(first, second).comparison();
+
+        assertEquals(BigInteger.ZERO, comparison.scoreDelta());
+        assertEquals(0L, comparison.deadlineMarginDeltaTicks());
+        assertEquals(0L, comparison.unusedBudgetDeltaCredits());
+        assertEquals(0L, comparison.constructionCostDeltaCredits());
+        assertEquals(AttemptComparisonWinner.TIE, comparison.winner());
+    }
+
+    @Test
+    void differentChallengeVersionsAreIncomparable() {
+        ChallengeAttempt referenceAttempt = attempt(true, 350L, 10_000L);
+        ChallengeAttempt otherChallengeAttempt =
+                attemptWithChallengeIdentity(new ChallengeIdentity("challenge.factory-basics", "2"));
+
+        AttemptComparisonResult result =
+                ChallengeAttemptComparator.compare(referenceAttempt, otherChallengeAttempt);
+
+        assertFalse(result.compatibility().comparable());
+        assertNull(result.comparison());
+        assertEquals(List.of("attempt.challenge.mismatch"),
+                result.compatibility().reasons().stream()
+                        .map(AttemptIncompatibilityReason::code).toList());
+    }
+
+    @Test
+    void differentEvaluationPolicyVersionsAreIncomparable() {
+        ChallengeAttempt referenceAttempt = attempt(true, 350L, 10_000L);
+        ChallengeAttempt otherPolicyAttempt = attemptWithEvaluationPolicy(
+                new EvaluationPolicyIdentity("policy.contract-completion", "2"));
+
+        AttemptComparisonResult result =
+                ChallengeAttemptComparator.compare(referenceAttempt, otherPolicyAttempt);
+
+        assertFalse(result.compatibility().comparable());
+        assertNull(result.comparison());
+        assertEquals(List.of("attempt.evaluationPolicy.mismatch"),
+                result.compatibility().reasons().stream()
+                        .map(AttemptIncompatibilityReason::code).toList());
+    }
+
+    @Test
+    void bothMismatchesAreReportedInStableOrder() {
+        ChallengeAttempt referenceAttempt = attempt(true, 350L, 10_000L);
+        ChallengeDefinition reference = ChallengeFixtures.referenceChallenge();
+        ChallengeDefinition modified = new ChallengeDefinition(
+                new ChallengeIdentity("challenge.factory-basics", "2"), reference.floor(),
+                reference.startingBudget(), reference.workload(), reference.availableEquipment(),
+                reference.deadline(), new EvaluationPolicyIdentity("policy.contract-completion", "2"),
+                reference.catalogueIdentity(), reference.catalogueSemanticFingerprint());
+        ChallengeEvaluationResult reevaluated = evaluate(true, 350L, 10_000L);
+        ChallengeEvaluationResult withBothMismatched = new ChallengeEvaluationResult(
+                modified.identity(), modified.evaluationPolicy(), reevaluated.provenance(),
+                reevaluated.successful(), reevaluated.issues(), reevaluated.deadlineMarginTicks(),
+                reevaluated.unusedBudgetCredits(), reevaluated.score());
+        ChallengeAttempt bothMismatchedAttempt =
+                ChallengeAttempt.record(snapshot(), economics(10_000L), withBothMismatched);
+
+        AttemptComparisonResult result =
+                ChallengeAttemptComparator.compare(referenceAttempt, bothMismatchedAttempt);
+
+        assertEquals(List.of("attempt.challenge.mismatch", "attempt.evaluationPolicy.mismatch"),
+                result.compatibility().reasons().stream()
+                        .map(AttemptIncompatibilityReason::code).toList());
+    }
+
+    @Test
+    void attemptIdentityDoesNotInfluenceComparison() {
+        ChallengeAttempt worseA = attempt(true, 350L, 10_000L);
+        ChallengeAttempt betterA = attempt(true, 390L, 12_000L);
+        ChallengeAttempt worseB = attempt(true, 350L, 10_000L);
+        ChallengeAttempt betterB = attempt(true, 390L, 12_000L);
+
+        assertNotEquals(worseA.id(), worseB.id());
+        assertNotEquals(betterA.id(), betterB.id());
+        assertEquals(ChallengeAttemptComparator.compare(worseA, betterA).comparison(),
+                ChallengeAttemptComparator.compare(worseB, betterB).comparison());
+    }
+
+    @Test
+    void comparisonDoesNotMutateEitherAttempt() {
+        ChallengeAttempt worse = attempt(true, 350L, 10_000L);
+        ChallengeAttempt better = attempt(true, 390L, 12_000L);
+        ChallengeEvaluationResult worseResultBefore = worse.evaluationResult();
+        ChallengeEvaluationResult betterResultBefore = better.evaluationResult();
+
+        ChallengeAttemptComparator.compare(worse, better);
+
+        assertEquals(worseResultBefore, worse.evaluationResult());
+        assertEquals(betterResultBefore, better.evaluationResult());
+    }
+
+    @Test
+    void rejectsNullAttempts() {
+        ChallengeAttempt valid = attempt(true, 350L, 10_000L);
+        assertThrows(NullPointerException.class, () -> ChallengeAttemptComparator.compare(null, valid));
+        assertThrows(NullPointerException.class, () -> ChallengeAttemptComparator.compare(valid, null));
+    }
+
+    private static ChallengeAttempt attempt(boolean complete, Long completionTick, long cost) {
+        ChallengeEvaluationResult result = evaluate(complete, completionTick, cost);
+        return ChallengeAttempt.record(snapshot(), economics(cost), result);
+    }
+
+    private static ChallengeAttempt attemptWithChallengeIdentity(ChallengeIdentity identity) {
+        ChallengeDefinition reference = ChallengeFixtures.referenceChallenge();
+        ChallengeDefinition modified = new ChallengeDefinition(identity, reference.floor(),
+                reference.startingBudget(), reference.workload(), reference.availableEquipment(),
+                reference.deadline(), reference.evaluationPolicy(), reference.catalogueIdentity(),
+                reference.catalogueSemanticFingerprint());
+        ChallengeEvaluationResult result = ReferenceChallengeEvaluationPolicy.evaluate(
+                new ChallengeEvaluationInput(modified, provenance(),
+                        new AuthoritativeOutcomeFacts(true, 350L), 10_000L));
+        return ChallengeAttempt.record(snapshot(), economics(10_000L), result);
+    }
+
+    private static ChallengeAttempt attemptWithEvaluationPolicy(EvaluationPolicyIdentity policy) {
+        ChallengeEvaluationResult reevaluated = evaluate(true, 350L, 10_000L);
+        ChallengeEvaluationResult withDifferentPolicy = new ChallengeEvaluationResult(
+                reevaluated.challengeIdentity(), policy, reevaluated.provenance(),
+                reevaluated.successful(), reevaluated.issues(), reevaluated.deadlineMarginTicks(),
+                reevaluated.unusedBudgetCredits(), reevaluated.score());
+        return ChallengeAttempt.record(snapshot(), economics(10_000L), withDifferentPolicy);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the C4 Challenge Readiness slice: an immutable `ChallengeAttempt` aggregate (`com.arcogine.challenge.attempt`) that reuses the C1-C3 candidate snapshot, draft economics, and evaluation result without duplicating any of those facts, plus a stable game-owned `ChallengeAttemptId`.
- Adds a headless `ChallengeAttemptComparator` (`com.arcogine.challenge.comparison`) that checks challenge/evaluation-policy compatibility before producing a deterministic score/deadline-margin/unused-budget/construction-cost comparison; incompatible attempts get structured, ordered `AttemptIncompatibilityReason` codes instead of a silently misleading result.
- No new cross-module dependency: `product/consumer/challenge` remains headless (no `project(...)` deps added).
- Updates `docs/planning/factory-design-game-challenge-readiness.md` with an "Implementation status (C4 — complete)" section documenting the actual landed contract, fixes a stale "C4-C5 remain deferred" line, and updates `docs/architecture/overview.md`'s challenge-module description to include the new attempt/comparison capability.

## Test plan
- [x] `./gradlew :challenge:compileJava :challenge:compileTestJava :challenge:checkstyleMain :challenge:checkstyleTest :challenge:test` — all green
- [x] `./gradlew :challenge:jacocoTestReport :challenge:jacocoTestCoverageVerification` — passes
- [x] New tests cover: immutable retention of candidate snapshot/economics, no re-evaluation, deterministic and attempt-identity-independent comparison, and structured incompatibility for mismatched challenge/policy versions