### PR TITLE
docs: reconcile D5 and G2 planning status

### DIFF
--- a/docs/planning/factory-design-capability.md
+++ b/docs/planning/factory-design-capability.md
@@ -84,7 +84,7 @@ D6  Shared draft lifecycle (deferred until justified)
 D7  Factory adoption of governed change (deferred until justified; owned cross-domain by Governance and Conformance G1/G2/G6, with Operational Execution owning deployment application)
 ```
 
-D1-D4 form the immediate implementation sequence. D5, D6, and D7 are explicitly deferred and are not prerequisites for engine runtime work or a first game consumer.
+D1-D4 form the immediate implementation sequence. D5 has an implemented initial slice covering factory semantic comparison for resources, operations, and products through the Governance `SemanticChangeExtractor` seam (see §9); finer-grained D5 comparison such as route/policy/constraint-level taxonomy remains future work triggered by concrete consumer need. D6 and D7 remain deferred. D5 is not a prerequisite for engine runtime work or a first game consumer unless a specific consumer requirement depends on its semantic-diff capability.
 
 The initial spike should establish the model seam without simultaneously redesigning order execution, dispatch policy, spatial behavior, operational deployment, or the public HTTP contract.
 

--- a/docs/planning/factory-design-game-vertical-slice.md
+++ b/docs/planning/factory-design-game-vertical-slice.md
@@ -62,7 +62,7 @@ The player decides where additional compatible resources are worth their capital
 
 Adding capacity at a true bottleneck should be capable of reducing queueing or completion time. Adding capacity away from the bottleneck may produce little or no benefit. Solving one bottleneck may expose another.
 
-For the fixed-contract reference challenge below, this requirement applies to one accepted production requirement, not to a game-authored collection of artificial independent orders. Arcogine's accepted W1 architecture is now recorded by ADR-0010: one accepted quantity-`N` `Order` decomposes into `N` independently dispatchable unit-quantity `Job`s, while aggregate progress and completion remain order-level. That architecture must be implemented and proven headlessly before the second-cutter strategy can be used as runtime evidence.
+For the fixed-contract reference challenge below, this requirement applies to one accepted production requirement, not to a game-authored collection of artificial independent orders. Arcogine's accepted W1 architecture is recorded by ADR-0010 and is current implemented Engine Readiness semantics, including the 100,000-child benchmark: one accepted quantity-`N` `Order` decomposes into `N` independently dispatchable unit-quantity `Job`s, while aggregate progress and completion remain order-level. The game must not manufacture multiple orders to obtain parallelism; the second-cutter strategy relies on this existing W1 runtime evidence.
 
 ### 3.2 Resource eligibility and dispatch
 
@@ -140,9 +140,9 @@ At minimum the player should be able to answer:
 - How far is the contract from completion?
 - How did this attempt's outcome compare with the previous attempt?
 
-For the vertical slice, design-to-design comparison does **not** require Arcogine's deferred D5 semantic-comparison capability. The game may retain immutable game-owned draft snapshots for each attempt and pair them with the published model provenance and supported run outcomes. It can therefore show player-authored design differences from its own snapshots and compare authoritative run results without claiming a canonical semantic diff between two published Arcogine models.
+For the vertical slice, design-to-design comparison does **not** require Arcogine's semantic-model-diffing capability. The game may retain immutable game-owned draft snapshots for each attempt and pair them with the published model provenance and supported run outcomes. It can therefore show player-authored design differences from its own snapshots and compare authoritative run results without claiming a canonical semantic diff between two published Arcogine models. D5's existing initial slice ([Factory Design Capability](factory-design-capability.md#9-d5--semantic-comparison-and-design-alternatives)) is available but is not required for this vertical slice.
 
-If a future product requirement needs Arcogine itself to explain semantic differences between published model versions, that requirement becomes a concrete trigger to revisit D5 in [Factory Design Capability](factory-design-capability.md).
+If a future product requirement needs Arcogine itself to explain semantic differences between published model versions, that requirement should extend the existing D5 capability with finer-grained comparison semantics rather than create a second diff abstraction.
 
 ## 6. Product success criteria
 

--- a/docs/planning/governance-conformance-capability.md
+++ b/docs/planning/governance-conformance-capability.md
@@ -112,7 +112,7 @@ Governance G5
 
 Operational Execution owns telemetry/external-observation acquisition, operational source trust/authenticity provenance, command/result facts, deployment target application/effective artifact provenance, and modeled-versus-observed reconciliation. Governance owns the durable revision/change/evaluation/evidence-use/finding semantics that may reference those facts.
 
-Operational work may proceed headlessly with clearly scoped synthetic ChangeSet, conformance, or evidence-use fixtures while G2/G4/G5 are incomplete. G1 revision fixtures are no longer required: the Governance-owned authoritative revision identity/history contract is available. Fixtures for later gates do not satisfy those Governance gates and must not escape as duplicate shared production abstractions.
+Governance G2's initial `ChangeSet`/`ImpactScope`/`SemanticChange` slice is implemented. New Operational work that needs semantic ChangeSets or impact attribution must consume the Governance-owned G2 contracts rather than create new synthetic or parallel `ChangeSet`/impact production abstractions for O7 or similar downstream work. Clearly scoped synthetic fixtures remain acceptable only for genuinely outstanding sibling-owned capabilities such as G4 conformance/findings and G5 evidence-use semantics. Such fixtures do not satisfy the corresponding Governance gates and must not escape test/fixture scope as duplicate shared production abstractions. G1 revision fixtures are likewise no longer appropriate: G1 is complete, and the Governance-owned authoritative revision identity/history contract is available.
 
 ## 3. Delivery principles
 


### PR DESCRIPTION
## Summary
- Reconcile `docs/planning/factory-design-capability.md`'s delivery-policy status wording: D1-D4 remain the immediate sequence, D5 now has an implemented initial slice (factory semantic comparison for resources/operations/products via the Governance `SemanticChangeExtractor` seam) with finer-grained comparison left as future work, and D6/D7 remain deferred.
- Reconcile `docs/planning/factory-design-game-vertical-slice.md`: describe W1 as current implemented Engine Readiness semantics (including the 100,000-child benchmark) rather than something that still needs to be "implemented and proven," and stop describing D5 as "deferred" or something to "revisit" — the vertical slice still doesn't require Arcogine semantic diffing, but the existing D5 initial slice is available and any future richer need should extend it rather than create a second diff abstraction.
- Reconcile `docs/planning/governance-conformance-capability.md`'s Operational Execution boundary guidance: new Operational work needing semantic ChangeSets/impact attribution must consume the now-implemented Governance G2 contracts instead of synthetic fixtures; synthetic fixtures remain acceptable only for genuinely outstanding G4/G5 capabilities; G1 revision fixtures are no longer appropriate since G1 is complete.

Documentation-only change; no source, test, ADR, or public API behavior touched.

## Test plan
- [x] Verified stale phrases no longer appear in planning docs (`D5, D6, and D7 are explicitly deferred`, `deferred D5`, `revisit D5`, `must be implemented and proven headlessly`, `synthetic ChangeSet`, `while G2/G4/G5 are incomplete`)
- [x] Cross-checked resulting wording against `docs/planning/factory-simulation-engine-readiness.md` and `docs/planning/operational-execution-digital-twin-readiness.md`, which already describe G2 as "complete (initial slice)"
- No Java/frontend test run required per AGENTS.md for documentation-only changes