### PR TITLE
feat(challenge): C5 content loading and canonical-vs-admissible proving case

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -426,8 +426,12 @@ product/
 ├── consumer/
 │   └── challenge/        Challenge Readiness: game-owned challenge definition/validation,
 │                         catalogue/economics, candidate admissibility, deterministic
-│                         challenge evaluation, and attempt provenance/design-to-design
-│                         comparison (see
+│                         challenge evaluation, attempt provenance/design-to-design
+│                         comparison, and (C5) a rendering-technology-independent JSON
+│                         content-loading layer — schema-versioned decode, catalogue
+│                         loading, and evaluation-policy resolution — that reuses the
+│                         existing definition/catalogue validators rather than
+│                         reimplementing their rules (see
 │                         docs/planning/factory-design-game-challenge-readiness.md).
 │                         Headless — no dependency on any module below.
 └── interfaces/

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -536,11 +536,21 @@ C5's content-loading layer is implemented in `com.arcogine.challenge.content`
 plain JSON -- independent of any rendering technology -- and requires a `schemaVersion` field
 (`"challenge-content:v1"` / `"equipment-catalogue:v1"`) distinct from `ChallengeIdentity.version`
 and `EvaluationPolicyIdentity.version`, so content-format evolution and challenge-semantics
-versioning can move independently. The loader does not reimplement validation rules: it decodes
-JSON into the existing C1/C2 types and then delegates to the existing
-`ChallengeDefinitionValidator` and `EquipmentCatalogueValidator`, returning separate, structured
-`ChallengeContentIssue` outcomes for decode failures, definition-validator failures,
-catalogue-validator failures, and unsupported-evaluation-policy failures. `EvaluationPolicyResolver`
+versioning can move independently. The loader does not reimplement validation rules, but its three
+entry points draw the decode/validate boundary differently: `load(String)` performs structural
+decoding only -- consistent with `ChallengeContentLoadResult`'s own contract that a decoded
+definition's content validity is a separate, later caller step -- and never itself invokes
+`ChallengeDefinitionValidator`; `loadCatalogue(String)` decodes and then always runs
+`EquipmentCatalogueValidator.validate` before reporting success; and
+`loadChallengeWithCatalogue(String, String)` is the one entry point that aggregates both decode
+steps, both content validators (`ChallengeDefinitionValidator` and
+`EquipmentCatalogueValidator.validate`), catalogue-provenance binding/verification (challenge
+`catalogueIdentity`/`catalogueSemanticFingerprint` against the actually resolved catalogue), and
+`EquipmentCatalogueValidator.validateChallengeResolution` into one deterministic, structured
+`ChallengeContentIssue` outcome. A caller that needs `load(String)`'s decoded definition to also be
+content-valid must run it through `ChallengeDefinitionValidator` itself, exactly as
+`ChallengeContentLoaderTest.loadsAMinimalValidDefinition` and the other single-document tests do.
+`EvaluationPolicyResolver`
 is an immutable static registry, currently mapping only
 `ReferenceChallengeEvaluationPolicy` (`policy.contract-completion` / version `"1"`). Covered by
 `JsonTest`, `ChallengeContentLoaderTest`, and `EvaluationPolicyResolverTest`.
@@ -571,13 +581,20 @@ budget, floor-bounds, and overlap outcomes.
    `ChallengeContentLoaderTest.loadsMultipleDistinctChallengeDefinitionsThroughTheSameContentPath`
    loads five JSON fixtures with distinct floor size, starting budget, deadline, workload quantity,
    and available-equipment sets (spanning bottleneck-relief, capacity/cost-tradeoff, and
-   tight-deadline archetypes) through the single `ChallengeContentLoader.load(String)` entry point,
-   asserts each round-trips to a distinct, content-valid `ChallengeDefinition`, and confirms each
-   passes `ChallengeDefinitionValidator`.
+   tight-deadline archetypes) through the single `ChallengeContentLoader.load(String)` entry point
+   and asserts each round-trips to a distinct, structurally complete `ChallengeDefinition`.
+   `load(String)` itself performs structural decoding only -- it never calls
+   `ChallengeDefinitionValidator` (see the implementation-status note above); content validity of
+   these particular fixtures is not asserted by this test. A caller that needs both decoding and
+   content validation for a single challenge document must additionally run the decoded definition
+   through `ChallengeDefinitionValidator.validate(...)`, or use
+   `loadChallengeWithCatalogue(String, String)`, which runs the full pipeline in one call.
 2. **Content validation is independent of rendering technology -- met.** `ChallengeContentLoader`
-   decodes plain JSON via the game-owned `Json` parser and delegates to
-   `ChallengeDefinitionValidator`/`EquipmentCatalogueValidator`; nothing in the content-loading
-   package depends on a UI, rendering, or presentation technology.
+   decodes plain JSON via the game-owned `Json` parser, and `loadCatalogue`/
+   `loadChallengeWithCatalogue` delegate content validation to `ChallengeDefinitionValidator`/
+   `EquipmentCatalogueValidator` (see the implementation-status note above on which entry point
+   validates what); nothing in the content-loading package depends on a UI, rendering, or
+   presentation technology.
 3. **Reference fixtures cover challenge-definition failures, candidate-admissibility failures,
    pass/fail boundaries, and score/rating thresholds -- met.** Challenge-definition failures:
    `ChallengeContentLoaderTest.loadingSucceedsButValidatorCatchesContentInvalidValues` and the

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -581,14 +581,16 @@ budget, floor-bounds, and overlap outcomes.
    `ChallengeContentLoaderTest.loadsMultipleDistinctChallengeDefinitionsThroughTheSameContentPath`
    loads five JSON fixtures with distinct floor size, starting budget, deadline, workload quantity,
    and available-equipment sets (spanning bottleneck-relief, capacity/cost-tradeoff, and
-   tight-deadline archetypes) through the single `ChallengeContentLoader.load(String)` entry point
-   and asserts each round-trips to a distinct, structurally complete `ChallengeDefinition`.
-   `load(String)` itself performs structural decoding only -- it never calls
-   `ChallengeDefinitionValidator` (see the implementation-status note above); content validity of
-   these particular fixtures is not asserted by this test. A caller that needs both decoding and
-   content validation for a single challenge document must additionally run the decoded definition
-   through `ChallengeDefinitionValidator.validate(...)`, or use
-   `loadChallengeWithCatalogue(String, String)`, which runs the full pipeline in one call.
+   tight-deadline archetypes) through the single `ChallengeContentLoader.load(String)` entry point,
+   asserts each round-trips to a distinct, structurally complete `ChallengeDefinition`, and then
+   additionally runs each decoded definition through `ChallengeDefinitionValidator.validate(...)`
+   itself and asserts it is content-valid. `load(String)` itself performs structural decoding only
+   -- it never calls `ChallengeDefinitionValidator` (see the implementation-status note above); the
+   content validity asserted here is established by the test's own explicit validator call, not by
+   `load(String)`. A caller that needs both decoding and content validation for a single challenge
+   document must likewise run the decoded definition through `ChallengeDefinitionValidator.validate(
+   ...)` itself, or use `loadChallengeWithCatalogue(String, String)`, which runs the full pipeline
+   in one call.
 2. **Content validation is independent of rendering technology -- met.** `ChallengeContentLoader`
    decodes plain JSON via the game-owned `Json` parser, and `loadCatalogue`/
    `loadChallengeWithCatalogue` delegate content validation to `ChallengeDefinitionValidator`/
@@ -625,13 +627,17 @@ budget, floor-bounds, and overlap outcomes.
    `CandidateAdmissibilityPolicy.assess()` purely on budget (`candidate.budget.exceeded`).
 
 Additionally, `ChallengeContentLoader.loadChallengeWithCatalogue(String, String)` was added to
-close a real content-loading gap identified during this pass: `load(String)` and
-`loadCatalogue(String)` each validate one document in isolation and neither previously called
-`EquipmentCatalogueValidator.validateChallengeResolution`, so an unknown or ambiguous
-catalogue reference in `availableEquipment` was never checked by the content-loading layer itself
-(only by tests that constructed both sides in Java). The new method decodes and content-validates
-both documents and then cross-resolves references, aggregating every issue into one deterministic
-result; it is covered by `loadsChallengeWithCatalogueWhenEveryReferenceResolves`,
+close a real content-loading gap identified during this pass: `load(String)` decodes a challenge
+document structurally only (it never itself calls `ChallengeDefinitionValidator`), `loadCatalogue`
+decodes and always content-validates one catalogue document in isolation, and neither previously
+called `EquipmentCatalogueValidator.validateChallengeResolution` or bound/verified catalogue
+provenance, so an unknown or ambiguous catalogue reference in `availableEquipment` -- and a
+challenge/catalogue pair C2's `CandidateAdmissibilityPolicy` would reject on catalogue identity or
+semantic fingerprint -- was never checked by the content-loading layer itself (only by tests that
+constructed both sides in Java). The new method decodes both documents, content-validates the
+challenge definition and the catalogue, binds/verifies catalogue-identity and
+semantic-fingerprint provenance, and then cross-resolves references, aggregating every issue into
+one deterministic result; it is covered by `loadsChallengeWithCatalogueWhenEveryReferenceResolves`,
 `rejectsChallengeWithCatalogueWhenAnAvailableEquipmentReferenceIsUnknown`,
 `rejectsChallengeWithCatalogueWhenCatalogueItselfHasDuplicateItemIds`, and
 `rejectsChallengeWithCatalogueWhenTheDefinitionItselfIsContentInvalid`.

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -341,8 +341,8 @@ C2 completion does not make the game playable and satisfies no Engine Readiness 
 candidate is not canonically executable: a later game-owned projection still requires Arcogine
 canonical validation before publication/run. Conversely, a canonically executable factory may
 remain inadmissible under a particular challenge. C3 is implemented independently of that
-projection; C3 and C4 are now implemented, and C5 is partially implemented (see its
-"Implementation status" subsection below).
+projection; C3, C4, and C5 are now implemented (see C5's "Implementation status" subsection
+below).
 
 ## 7. C3 — Deterministic challenge evaluation
 
@@ -527,7 +527,7 @@ C5 is ready when:
 5. Content does not require engine behavior absent from the applicable readiness gates.
 6. At least one fixture proves a candidate can be canonically executable yet challenge-inadmissible.
 
-### Implementation status (C5 — partially implemented)
+### Implementation status (C5 — complete)
 
 C5's content-loading layer is implemented in `com.arcogine.challenge.content`
 (`ChallengeContentLoader`, `EvaluationPolicyResolver`, `Json`/`JsonSyntaxException`,
@@ -565,14 +565,68 @@ which asserts that evaluating the same `ChallengeEvaluationInput` twice produces
 existing `CandidateAdmissibilityPolicyTest` cases for admitted, unavailable-item, quantity-limit,
 budget, floor-bounds, and overlap outcomes.
 
-Not yet done: criterion 3's challenge-definition-failure and score/rating-threshold fixture
-coverage has not been audited or extended beyond what already exists, and criterion 1's "multiple
-challenge definitions loaded through one supported content path" is exercised only by the content
-loader's own tests, not by a fixture set spanning several distinct challenge archetypes as
-suggested in the C5 goal above (bottleneck relief, capacity/cost tradeoff, capacity/transfer
-tradeoff, tighter budget/deadline). C5 is therefore **partially, not fully,** implemented: the
-content-loading path and the AC6 proving case exist and are tested; a fuller reference-fixture
-catalogue across multiple challenge archetypes does not yet exist.
+### Acceptance-criterion-by-criterion status
+
+1. **Multiple challenge definitions loadable through one supported content path -- met.**
+   `ChallengeContentLoaderTest.loadsMultipleDistinctChallengeDefinitionsThroughTheSameContentPath`
+   loads five JSON fixtures with distinct floor size, starting budget, deadline, workload quantity,
+   and available-equipment sets (spanning bottleneck-relief, capacity/cost-tradeoff, and
+   tight-deadline archetypes) through the single `ChallengeContentLoader.load(String)` entry point,
+   asserts each round-trips to a distinct, content-valid `ChallengeDefinition`, and confirms each
+   passes `ChallengeDefinitionValidator`.
+2. **Content validation is independent of rendering technology -- met.** `ChallengeContentLoader`
+   decodes plain JSON via the game-owned `Json` parser and delegates to
+   `ChallengeDefinitionValidator`/`EquipmentCatalogueValidator`; nothing in the content-loading
+   package depends on a UI, rendering, or presentation technology.
+3. **Reference fixtures cover challenge-definition failures, candidate-admissibility failures,
+   pass/fail boundaries, and score/rating thresholds -- met.** Challenge-definition failures:
+   `ChallengeContentLoaderTest.loadingSucceedsButValidatorCatchesContentInvalidValues` and the
+   dedicated `ChallengeDefinitionValidatorTest` cases (blank ids, non-positive dimensions/budget/
+   deadline/quantity, duplicate/blank available-equipment ids --
+   `duplicateAvailableEquipmentIdsAreRejected`, `blankAvailableEquipmentIdIsRejected`). Candidate-
+   admissibility failures: `CandidateAdmissibilityPolicyTest` (unavailable/unknown items, quantity
+   limits, budget, floor bounds, overlap). Pass/fail boundaries and score/rating thresholds:
+   `ReferenceChallengeEvaluationPolicyTest.deadlineAndBudgetFailuresAreExplainedInStableRuleOrder`,
+   `scoreIsExactForTheLargestC1ValidDeadlineAndBudget`, and the exact-limit-vs-one-over deadline/
+   budget cases. Content-loading-specific catalogue-resolution failures (unknown catalogue
+   reference, duplicate catalogue item id) are covered by
+   `ChallengeContentLoaderTest.rejectsChallengeWithCatalogueWhenAnAvailableEquipmentReferenceIsUnknown`
+   and `rejectsChallengeWithCatalogueWhenCatalogueItselfHasDuplicateItemIds`.
+4. **Synthetic outcome fixtures prove evaluation determinism -- met.**
+   `ReferenceChallengeEvaluationPolicyTest.completedOnTimeAndWithinBudgetIsSuccessfulAndDeterministic`
+   asserts that evaluating the same `ChallengeEvaluationInput` twice produces an equal
+   `ChallengeEvaluationResult`; `ChallengeContentLoaderTest.isDeterministicAcrossRepeatedLoads`
+   covers the content-loading layer's own determinism.
+5. **Content does not require engine behavior absent from the applicable readiness gates -- met.**
+   The content-loading layer (`com.arcogine.challenge.content`) has no dependency on `:types`,
+   `:simulation`, `:factory`, `:economy`, `:finance`, `:api`, or `:cli`; it only decodes JSON into
+   existing C1/C2 game-owned types.
+6. **At least one fixture proves a candidate can be canonically executable yet
+   challenge-inadmissible -- met.** `CanonicalExecutableButChallengeInadmissibleTest`
+   (module `consumer/challenge-factory-integration-test`) constructs a `FactoryModel` accepted by
+   `:factory`'s `FactoryModelValidator` and a corresponding candidate draft rejected by
+   `CandidateAdmissibilityPolicy.assess()` purely on budget (`candidate.budget.exceeded`).
+
+Additionally, `ChallengeContentLoader.loadChallengeWithCatalogue(String, String)` was added to
+close a real content-loading gap identified during this pass: `load(String)` and
+`loadCatalogue(String)` each validate one document in isolation and neither previously called
+`EquipmentCatalogueValidator.validateChallengeResolution`, so an unknown or ambiguous
+catalogue reference in `availableEquipment` was never checked by the content-loading layer itself
+(only by tests that constructed both sides in Java). The new method decodes and content-validates
+both documents and then cross-resolves references, aggregating every issue into one deterministic
+result; it is covered by `loadsChallengeWithCatalogueWhenEveryReferenceResolves`,
+`rejectsChallengeWithCatalogueWhenAnAvailableEquipmentReferenceIsUnknown`,
+`rejectsChallengeWithCatalogueWhenCatalogueItselfHasDuplicateItemIds`, and
+`rejectsChallengeWithCatalogueWhenTheDefinitionItselfIsContentInvalid`.
+
+With this pass, all six C5 acceptance criteria have executable proof. C5 is now considered
+**complete**. As with C1-C4, this does not make the game playable, is not Engine Readiness
+evidence, and does not itself expand the fixture set into every archetype named in the C5 goal
+narrative (identify-and-relieve-bottleneck, capacity/cost, capacity/transfer, tighter budget/
+deadline) as a full production content library -- it demonstrates that the content-loading path,
+once exercised by several varied fixtures, satisfies every stated acceptance criterion. A larger
+production reference-content catalogue remains a content-authoring task for later game
+integration, not an open C5 acceptance gap.
 
 ## 10. Relationship to Engine Readiness
 

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -341,7 +341,8 @@ C2 completion does not make the game playable and satisfies no Engine Readiness 
 candidate is not canonically executable: a later game-owned projection still requires Arcogine
 canonical validation before publication/run. Conversely, a canonically executable factory may
 remain inadmissible under a particular challenge. C3 is implemented independently of that
-projection; C3 and C4 are now implemented and C5 remains deferred.
+projection; C3 and C4 are now implemented, and C5 is partially implemented (see its
+"Implementation status" subsection below).
 
 ## 7. C3 — Deterministic challenge evaluation
 
@@ -525,6 +526,53 @@ C5 is ready when:
 4. Synthetic outcome fixtures prove evaluation determinism.
 5. Content does not require engine behavior absent from the applicable readiness gates.
 6. At least one fixture proves a candidate can be canonically executable yet challenge-inadmissible.
+
+### Implementation status (C5 — partially implemented)
+
+C5's content-loading layer is implemented in `com.arcogine.challenge.content`
+(`ChallengeContentLoader`, `EvaluationPolicyResolver`, `Json`/`JsonSyntaxException`,
+`ChallengeContentIssue`, `ChallengeContentLoadResult`,
+`EquipmentCatalogueContentLoadResult`). It decodes challenge and equipment-catalogue content from
+plain JSON -- independent of any rendering technology -- and requires a `schemaVersion` field
+(`"challenge-content:v1"` / `"equipment-catalogue:v1"`) distinct from `ChallengeIdentity.version`
+and `EvaluationPolicyIdentity.version`, so content-format evolution and challenge-semantics
+versioning can move independently. The loader does not reimplement validation rules: it decodes
+JSON into the existing C1/C2 types and then delegates to the existing
+`ChallengeDefinitionValidator` and `EquipmentCatalogueValidator`, returning separate, structured
+`ChallengeContentIssue` outcomes for decode failures, definition-validator failures,
+catalogue-validator failures, and unsupported-evaluation-policy failures. `EvaluationPolicyResolver`
+is an immutable static registry, currently mapping only
+`ReferenceChallengeEvaluationPolicy` (`policy.contract-completion` / version `"1"`). Covered by
+`JsonTest`, `ChallengeContentLoaderTest`, and `EvaluationPolicyResolverTest`.
+
+Acceptance criterion 6 -- proving a candidate can be canonically Factory-executable yet
+challenge-inadmissible -- is met by
+`CanonicalExecutableButChallengeInadmissibleTest` (module
+`consumer/challenge-factory-integration-test`, a new test-only Gradle module that is the only place
+in the repository with a test dependency on both `:factory` and `:challenge`; neither production
+module depends on the other). The test constructs a structurally valid `FactoryModel` accepted by
+`:factory`'s `FactoryModelValidator`, and a corresponding candidate draft rejected by
+`CandidateAdmissibilityPolicy.assess()` purely for exceeding the challenge's starting credit
+budget (`candidate.budget.exceeded`) -- a game rule with no counterpart in Factory's structural
+validation.
+
+Criterion 4 (synthetic outcome fixtures proving evaluation determinism) is substantively covered by
+existing `ReferenceChallengeEvaluationPolicyTest` cases predating this work: deadline exactly at the
+limit vs. one tick over, construction cost exactly at budget vs. one credit over, successful
+completion, and non-completion, plus `completedOnTimeAndWithinBudgetIsSuccessfulAndDeterministic`,
+which asserts that evaluating the same `ChallengeEvaluationInput` twice produces an equal
+`ChallengeEvaluationResult`. Criterion 3's candidate-admissibility half is similarly covered by
+existing `CandidateAdmissibilityPolicyTest` cases for admitted, unavailable-item, quantity-limit,
+budget, floor-bounds, and overlap outcomes.
+
+Not yet done: criterion 3's challenge-definition-failure and score/rating-threshold fixture
+coverage has not been audited or extended beyond what already exists, and criterion 1's "multiple
+challenge definitions loaded through one supported content path" is exercised only by the content
+loader's own tests, not by a fixture set spanning several distinct challenge archetypes as
+suggested in the C5 goal above (bottleneck relief, capacity/cost tradeoff, capacity/transfer
+tradeoff, tighter budget/deadline). C5 is therefore **partially, not fully,** implemented: the
+content-loading path and the AC6 proving case exist and are tested; a fuller reference-fixture
+catalogue across multiple challenge archetypes does not yet exist.
 
 ## 10. Relationship to Engine Readiness
 

--- a/product/consumer/challenge-factory-integration-test/build.gradle.kts
+++ b/product/consumer/challenge-factory-integration-test/build.gradle.kts
@@ -1,0 +1,16 @@
+// This module is test-only proof scaffolding: it has no production sources
+// and exists solely to demonstrate, in one place with an actual dependency on
+// both sides, that canonical Factory-executability (:factory's
+// FactoryModelValidator) and challenge admissibility (:challenge's
+// CandidateAdmissibilityPolicy) are independent validation axes. Neither
+// :factory nor :challenge gains a dependency on the other from this module;
+// only this dedicated test-only module depends on both.
+dependencies {
+    testImplementation(project(":factory"))
+    testImplementation(project(":types"))
+    testImplementation(project(":challenge"))
+}
+
+// Proof-only module: no production code exists to cover, so unlike other
+// modules this one does not wire jacocoTestCoverageVerification into `check`
+// (there is no main source set to hold a coverage floor against).

--- a/product/consumer/challenge-factory-integration-test/src/test/java/com/arcogine/challenge/factoryintegration/CanonicalExecutableButChallengeInadmissibleTest.java
+++ b/product/consumer/challenge-factory-integration-test/src/test/java/com/arcogine/challenge/factoryintegration/CanonicalExecutableButChallengeInadmissibleTest.java
@@ -1,0 +1,112 @@
+package com.arcogine.challenge.factoryintegration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.ChallengeIdentity;
+import com.arcogine.challenge.ChallengeWorkload;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import com.arcogine.challenge.FactoryFloorConstraint;
+import com.arcogine.challenge.admissibility.CandidateAdmissibilityPolicy;
+import com.arcogine.challenge.admissibility.CandidateAdmissibilityResult;
+import com.arcogine.challenge.admissibility.CandidateDraftSnapshot;
+import com.arcogine.challenge.admissibility.EquipmentOccurrenceId;
+import com.arcogine.challenge.admissibility.GridPlacement;
+import com.arcogine.challenge.admissibility.PlacedEquipment;
+import com.arcogine.challenge.catalogue.EquipmentCatalogue;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
+import com.arcogine.challenge.catalogue.EquipmentOffer;
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.OperationDefinition;
+import com.arcogine.factory.model.OperationStepDefinition;
+import com.arcogine.factory.model.ProductDefinition;
+import com.arcogine.factory.model.ResourceDefinition;
+import com.arcogine.factory.model.validation.FactoryModelValidator;
+import com.arcogine.factory.model.validation.ModelValidationResult;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * C5 acceptance criterion 6: canonical Factory-executability and challenge admissibility are
+ * independent validation axes. This is the only module in the repository with a test dependency
+ * on both {@code :factory} and {@code :challenge}; neither of those production modules depends on
+ * the other, and this module carries no production sources of its own.
+ *
+ * <p>The proof: a design can pass {@link FactoryModelValidator#validate} — the structural,
+ * game-rule-agnostic notion of "this factory graph is well-formed and could run" — while the
+ * corresponding candidate draft in a challenge is rejected by {@link CandidateAdmissibilityPolicy}
+ * for a purely game-rule reason (here: exceeding the challenge's starting credit budget) that has
+ * nothing to do with structural validity. Nine cutters is a perfectly coherent, executable factory
+ * shape; it is inadmissible only because this challenge's economy caps spend at 40,000 credits.
+ */
+class CanonicalExecutableButChallengeInadmissibleTest {
+
+    @Test
+    void factoryValidCandidateCanStillBeChallengeInadmissibleOnBudget() {
+        FactoryModel factoryModel = new FactoryModel(
+                List.of(mill()),
+                List.of(routing()),
+                List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
+
+        ModelValidationResult factoryResult = FactoryModelValidator.validate(factoryModel);
+        assertTrue(factoryResult.isValid(),
+                () -> "expected a canonically well-formed, executable factory model: "
+                        + factoryResult.errors());
+
+        EquipmentCatalogueItemId cutter = new EquipmentCatalogueItemId("equipment.cutter");
+        long cutterCostCredits = 5_000L;
+        long startingBudget = 40_000L;
+        int cutterCount = 9;
+        long totalCost = cutterCostCredits * cutterCount;
+        assertTrue(totalCost > startingBudget,
+                "the fixture must actually exceed budget for this proof to hold");
+
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(
+                new EquipmentCatalogueIdentity("catalogue.challenge.factory-basics", "1"),
+                List.of(EquipmentOffer.of(cutter, cutterCostCredits)));
+
+        ChallengeDefinition challenge = new ChallengeDefinition(
+                new ChallengeIdentity("challenge.factory-basics", "1"),
+                new FactoryFloorConstraint(12, 10),
+                startingBudget,
+                new ChallengeWorkload("product.product-a", 20),
+                List.of(cutter),
+                400L,
+                new EvaluationPolicyIdentity("policy.contract-completion", "1"),
+                catalogue.identity(),
+                catalogue.semanticFingerprint());
+
+        List<PlacedEquipment> occurrences = new ArrayList<>();
+        for (int i = 0; i < cutterCount; i++) {
+            occurrences.add(new PlacedEquipment(
+                    new EquipmentOccurrenceId("cutter-" + i), cutter, new GridPlacement(i, 0)));
+        }
+        CandidateDraftSnapshot candidate = new CandidateDraftSnapshot(occurrences);
+
+        CandidateAdmissibilityResult admissibility =
+                CandidateAdmissibilityPolicy.assess(challenge, catalogue, candidate);
+
+        assertEquals(false, admissibility.admitted(),
+                () -> "expected a game-rule (budget) rejection, not structural invalidity");
+        assertEquals("candidate.budget.exceeded", admissibility.issues().get(0).code(),
+                "the rejection must be a challenge/economy game rule, not a factory structural "
+                        + "rule -- FactoryModelValidator has no concept of credits or budgets at all");
+    }
+
+    private static ResourceDefinition mill() {
+        return new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0);
+    }
+
+    private static OperationDefinition routing() {
+        return new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)));
+    }
+}

--- a/product/consumer/challenge-factory-integration-test/src/test/java/com/arcogine/challenge/factoryintegration/CanonicalExecutableButChallengeInadmissibleTest.java
+++ b/product/consumer/challenge-factory-integration-test/src/test/java/com/arcogine/challenge/factoryintegration/CanonicalExecutableButChallengeInadmissibleTest.java
@@ -38,31 +38,35 @@ import org.junit.jupiter.api.Test;
  * on both {@code :factory} and {@code :challenge}; neither of those production modules depends on
  * the other, and this module carries no production sources of its own.
  *
- * <p>The proof: a design can pass {@link FactoryModelValidator#validate} — the structural,
- * game-rule-agnostic notion of "this factory graph is well-formed and could run" — while the
- * corresponding candidate draft in a challenge is rejected by {@link CandidateAdmissibilityPolicy}
- * for a purely game-rule reason (here: exceeding the challenge's starting credit budget) that has
- * nothing to do with structural validity. Nine cutters is a perfectly coherent, executable factory
- * shape; it is inadmissible only because this challenge's economy caps spend at 40,000 credits.
+ * <p>The proof: ONE conceptual candidate -- nine cutter/mill occurrences -- is used both ways. The
+ * Factory model built from it contains the same nine machines and passes {@link
+ * FactoryModelValidator#validate} -- the structural, game-rule-agnostic notion of "this factory
+ * graph is well-formed and could run". The equal-shaped challenge candidate draft (nine placed
+ * occurrences of the same catalogue item) is rejected by {@link CandidateAdmissibilityPolicy} for
+ * a purely game-rule reason (exceeding the challenge's starting credit budget) that has nothing to
+ * do with structural validity. Nine cutters is a perfectly coherent, executable factory shape; it
+ * is inadmissible only because this challenge's economy caps spend at 40,000 credits.
  */
 class CanonicalExecutableButChallengeInadmissibleTest {
+
+    private static final int CUTTER_COUNT = 9;
 
     @Test
     void factoryValidCandidateCanStillBeChallengeInadmissibleOnBudget() {
         FactoryModel factoryModel = new FactoryModel(
-                List.of(mill()),
+                mills(),
                 List.of(routing()),
                 List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
 
         ModelValidationResult factoryResult = FactoryModelValidator.validate(factoryModel);
         assertTrue(factoryResult.isValid(),
-                () -> "expected a canonically well-formed, executable factory model: "
-                        + factoryResult.errors());
+                () -> "expected a canonically well-formed, executable factory model mirroring the "
+                        + "nine-occurrence candidate draft: " + factoryResult.errors());
 
         EquipmentCatalogueItemId cutter = new EquipmentCatalogueItemId("equipment.cutter");
         long cutterCostCredits = 5_000L;
         long startingBudget = 40_000L;
-        int cutterCount = 9;
+        int cutterCount = CUTTER_COUNT;
         long totalCost = cutterCostCredits * cutterCount;
         assertTrue(totalCost > startingBudget,
                 "the fixture must actually exceed budget for this proof to hold");
@@ -99,14 +103,22 @@ class CanonicalExecutableButChallengeInadmissibleTest {
                         + "rule -- FactoryModelValidator has no concept of credits or budgets at all");
     }
 
-    private static ResourceDefinition mill() {
-        return new ResourceDefinition(new MachineId(1), "Mill", 1, null, 0);
+    private static List<ResourceDefinition> mills() {
+        List<ResourceDefinition> resources = new ArrayList<>();
+        for (int i = 1; i <= CUTTER_COUNT; i++) {
+            resources.add(new ResourceDefinition(new MachineId(i), "Mill " + i, 1, null, 0));
+        }
+        return resources;
     }
 
     private static OperationDefinition routing() {
+        Set<MachineId> eligibleResources = new java.util.LinkedHashSet<>();
+        for (int i = 1; i <= CUTTER_COUNT; i++) {
+            eligibleResources.add(new MachineId(i));
+        }
         return new OperationDefinition(
                 100,
                 "Widget routing",
-                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)));
+                List.of(new OperationStepDefinition(1, "Rough milling", eligibleResources, 5)));
     }
 }

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentIssue.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentIssue.java
@@ -1,0 +1,36 @@
+package com.arcogine.challenge.content;
+
+/**
+ * A single deterministic diagnostic produced while decoding an untrusted external representation
+ * (e.g. loaded JSON) into a {@code ChallengeDefinition}.
+ *
+ * <p>This is a distinct failure domain from {@code
+ * com.arcogine.challenge.validation.ChallengeDefinitionIssue}: a {@code ChallengeContentIssue}
+ * means the external representation itself was absent, malformed, or mistyped and a {@code
+ * ChallengeDefinition} could not even be constructed. It never overlaps with, extends, or shares a
+ * result type with {@code ChallengeDefinitionIssue}, which instead diagnoses the scalar/structural
+ * content of an already-constructed definition.
+ *
+ * @param code stable, machine-readable issue code (e.g. {@code "content.field.missing"})
+ * @param path field path the issue applies to (e.g. {@code "identity.id"})
+ * @param message human-readable description of the issue
+ */
+public record ChallengeContentIssue(String code, String path, String message) {
+
+    public ChallengeContentIssue {
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
+        if (path == null) {
+            throw new NullPointerException("path");
+        }
+        if (message == null) {
+            throw new NullPointerException("message");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return path + " [" + code + "]: " + message;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoadResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoadResult.java
@@ -1,0 +1,39 @@
+package com.arcogine.challenge.content;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import java.util.List;
+
+/**
+ * Deterministic, structured result of decoding an untrusted external representation into a {@link
+ * ChallengeDefinition}.
+ *
+ * <p>Exactly one of {@link #definition()} or a non-empty {@link #issues()} is populated: either
+ * decoding succeeded and produced a structurally complete {@code ChallengeDefinition} (content
+ * validity of that definition is a separate, later step -- see {@code
+ * com.arcogine.challenge.validation.ChallengeDefinitionValidator}), or it failed and every reason
+ * is reported as a {@link ChallengeContentIssue} rather than as an uncaught exception.
+ */
+public record ChallengeContentLoadResult(ChallengeDefinition definition, List<ChallengeContentIssue> issues) {
+
+    public ChallengeContentLoadResult {
+        issues = issues == null ? List.of() : List.copyOf(issues);
+        if (definition == null && issues.isEmpty()) {
+            throw new IllegalArgumentException("either definition or issues must be populated");
+        }
+        if (definition != null && !issues.isEmpty()) {
+            throw new IllegalArgumentException("definition and issues are mutually exclusive");
+        }
+    }
+
+    static ChallengeContentLoadResult success(ChallengeDefinition definition) {
+        return new ChallengeContentLoadResult(definition, List.of());
+    }
+
+    static ChallengeContentLoadResult failure(List<ChallengeContentIssue> issues) {
+        return new ChallengeContentLoadResult(null, issues);
+    }
+
+    public boolean isSuccess() {
+        return definition != null;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
@@ -162,6 +162,13 @@ public final class ChallengeContentLoader {
         boolean explicitCatalogueIdentity = catalogueIdentityNode != null;
         boolean explicitCatalogueFingerprint = catalogueSemanticFingerprint != null;
 
+        if (explicitCatalogueFingerprint && !explicitCatalogueIdentity) {
+            issues.add(new ChallengeContentIssue(
+                    "content.catalogueIdentity.missing-for-fingerprint",
+                    "catalogueIdentity",
+                    "catalogueIdentity is required when catalogueSemanticFingerprint is supplied"));
+        }
+
         if (!issues.isEmpty()) {
             return new ChallengeDecodeOutcome(
                     null, issues, explicitCatalogueIdentity, explicitCatalogueFingerprint);

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
@@ -60,22 +60,54 @@ public final class ChallengeContentLoader {
 
     /** Decodes {@code source} (a JSON document) into a {@link ChallengeContentLoadResult}. */
     public static ChallengeContentLoadResult load(String source) {
+        ChallengeDecodeOutcome outcome = decodeChallenge(source);
+        if (outcome.definition() == null) {
+            return ChallengeContentLoadResult.failure(outcome.issues());
+        }
+        return ChallengeContentLoadResult.success(outcome.definition());
+    }
+
+    /**
+     * Internal decode outcome carrying not just the decoded {@link ChallengeDefinition} (or
+     * failure issues) but also whether the source document explicitly declared a
+     * {@code catalogueIdentity}/{@code catalogueSemanticFingerprint} binding, as opposed to
+     * {@code ChallengeDefinition} synthesizing its own default. {@link #load(String)} discards
+     * this distinction; {@link #loadChallengeWithCatalogue} needs it to decide whether an
+     * unspecified binding should be verified against the real catalogue or bound to it.
+     */
+    private record ChallengeDecodeOutcome(
+            ChallengeDefinition definition,
+            List<ChallengeContentIssue> issues,
+            boolean explicitCatalogueIdentity,
+            boolean explicitCatalogueFingerprint) {}
+
+    private static ChallengeDecodeOutcome decodeChallenge(String source) {
         if (source == null) {
-            return ChallengeContentLoadResult.failure(
-                    List.of(new ChallengeContentIssue("content.source.null", "$", "source must not be null")));
+            return new ChallengeDecodeOutcome(
+                    null,
+                    List.of(new ChallengeContentIssue("content.source.null", "$", "source must not be null")),
+                    false,
+                    false);
         }
 
         Object parsed;
         try {
             parsed = Json.parse(source);
         } catch (JsonSyntaxException e) {
-            return ChallengeContentLoadResult.failure(
-                    List.of(new ChallengeContentIssue("content.malformed-json", "$", e.getMessage())));
+            return new ChallengeDecodeOutcome(
+                    null,
+                    List.of(new ChallengeContentIssue("content.malformed-json", "$", e.getMessage())),
+                    false,
+                    false);
         }
 
         if (!(parsed instanceof Map<?, ?> rawRoot)) {
-            return ChallengeContentLoadResult.failure(List.of(
-                    new ChallengeContentIssue("content.root.not-object", "$", "root value must be a JSON object")));
+            return new ChallengeDecodeOutcome(
+                    null,
+                    List.of(new ChallengeContentIssue(
+                            "content.root.not-object", "$", "root value must be a JSON object")),
+                    false,
+                    false);
         }
 
         List<ChallengeContentIssue> issues = new ArrayList<>();
@@ -120,15 +152,19 @@ public final class ChallengeContentLoader {
                 : requireString(catalogueIdentityNode, "catalogueIdentity.version", issues);
 
         String catalogueSemanticFingerprint =
-                optionalString(root, "catalogueSemanticFingerprint", issues);
+                optionalNonBlankString(root, "catalogueSemanticFingerprint", issues);
 
         if (policyId != null && policyVersion != null) {
             EvaluationPolicyResolver.resolve(new EvaluationPolicyIdentity(policyId, policyVersion))
                     .ifPresent(issue -> issues.add(issue));
         }
 
+        boolean explicitCatalogueIdentity = catalogueIdentityNode != null;
+        boolean explicitCatalogueFingerprint = catalogueSemanticFingerprint != null;
+
         if (!issues.isEmpty()) {
-            return ChallengeContentLoadResult.failure(issues);
+            return new ChallengeDecodeOutcome(
+                    null, issues, explicitCatalogueIdentity, explicitCatalogueFingerprint);
         }
 
         ChallengeIdentity identity = new ChallengeIdentity(identityId, identityVersion);
@@ -154,7 +190,8 @@ public final class ChallengeContentLoader {
             definition = new ChallengeDefinition(
                     identity, floor, startingBudget, workload, availableEquipment, deadline, evaluationPolicy);
         }
-        return ChallengeContentLoadResult.success(definition);
+        return new ChallengeDecodeOutcome(
+                definition, List.of(), explicitCatalogueIdentity, explicitCatalogueFingerprint);
     }
 
     /** Decodes {@code source} (a JSON document) into an {@link EquipmentCatalogueContentLoadResult}. */
@@ -220,23 +257,68 @@ public final class ChallengeContentLoader {
      */
     public static ChallengeWithCatalogueLoadResult loadChallengeWithCatalogue(
             String challengeSource, String catalogueSource) {
-        ChallengeContentLoadResult challengeResult = load(challengeSource);
+        ChallengeDecodeOutcome challengeOutcome = decodeChallenge(challengeSource);
         EquipmentCatalogueContentLoadResult catalogueResult = loadCatalogue(catalogueSource);
 
         List<ChallengeContentIssue> issues = new ArrayList<>();
-        issues.addAll(challengeResult.issues());
+        issues.addAll(challengeOutcome.issues());
         issues.addAll(catalogueResult.issues());
         if (!issues.isEmpty()) {
             return ChallengeWithCatalogueLoadResult.failure(issues);
         }
 
-        ChallengeDefinition definition = challengeResult.definition();
+        ChallengeDefinition definition = challengeOutcome.definition();
         EquipmentCatalogue catalogue = catalogueResult.catalogue();
 
         List<ChallengeDefinitionIssue> definitionIssues =
                 ChallengeDefinitionValidator.validate(definition).issues();
         for (ChallengeDefinitionIssue issue : definitionIssues) {
             issues.add(new ChallengeContentIssue("definition." + issue.code(), issue.path(), issue.message()));
+        }
+
+        // C2's CandidateAdmissibilityPolicy independently rejects a catalogue identity mismatch
+        // or an unbound/mismatched semantic fingerprint. A definition/catalogue pair loaded here
+        // as "success" must not be one C2 would immediately reject on those grounds. When the
+        // source explicitly declared a catalogueIdentity/catalogueSemanticFingerprint, that is an
+        // assertion this method verifies against the actually-resolved catalogue; when it did
+        // not, ChallengeDefinition's own default synthesized a placeholder that this method binds
+        // to the real, resolved catalogue instead of leaving unbound/mismatched.
+        if (challengeOutcome.explicitCatalogueIdentity()
+                && !definition.catalogueIdentity().equals(catalogue.identity())) {
+            issues.add(new ChallengeContentIssue(
+                    "content.catalogue.identity-mismatch",
+                    "catalogueIdentity",
+                    "challenge catalogueIdentity does not match the loaded catalogue's identity: "
+                            + catalogue.identity()));
+        }
+        if (challengeOutcome.explicitCatalogueFingerprint()
+                && !definition.catalogueSemanticFingerprint().equals(catalogue.semanticFingerprint())) {
+            issues.add(new ChallengeContentIssue(
+                    "content.catalogue.semantic-fingerprint-mismatch",
+                    "catalogueSemanticFingerprint",
+                    "catalogue content does not match the challenge's declared semantic fingerprint"));
+        }
+
+        if (!issues.isEmpty()) {
+            return ChallengeWithCatalogueLoadResult.failure(issues);
+        }
+
+        if (!challengeOutcome.explicitCatalogueIdentity() || !challengeOutcome.explicitCatalogueFingerprint()) {
+            EquipmentCatalogueIdentity boundIdentity =
+                    challengeOutcome.explicitCatalogueIdentity() ? definition.catalogueIdentity() : catalogue.identity();
+            String boundFingerprint = challengeOutcome.explicitCatalogueFingerprint()
+                    ? definition.catalogueSemanticFingerprint()
+                    : catalogue.semanticFingerprint();
+            definition = new ChallengeDefinition(
+                    definition.identity(),
+                    definition.floor(),
+                    definition.startingBudget(),
+                    definition.workload(),
+                    definition.availableEquipment(),
+                    definition.deadline(),
+                    definition.evaluationPolicy(),
+                    boundIdentity,
+                    boundFingerprint);
         }
 
         List<EquipmentCatalogueIssue> resolutionIssues =
@@ -296,11 +378,20 @@ public final class ChallengeContentLoader {
             return null;
         }
         Object value = offerNode.get("quantityLimit");
-        if (!(value instanceof Double d) || d != Math.floor(d) || d.isInfinite()) {
+        if (value instanceof Double) {
             issues.add(new ChallengeContentIssue("content.field.type", path, "must be an integer"));
             return null;
         }
-        return d.intValue();
+        if (!(value instanceof Number n)) {
+            issues.add(new ChallengeContentIssue("content.field.type", path, "must be an integer"));
+            return null;
+        }
+        if (value instanceof java.math.BigInteger || n.longValue() < Integer.MIN_VALUE || n.longValue() > Integer.MAX_VALUE) {
+            issues.add(new ChallengeContentIssue(
+                    "content.field.out-of-range", path, "must be within the 32-bit integer range"));
+            return null;
+        }
+        return n.intValue();
     }
 
     private static void requireSchemaVersion(
@@ -393,14 +484,37 @@ public final class ChallengeContentLoader {
         return s;
     }
 
+    /**
+     * Like {@link #optionalString}, but also rejects a present-but-blank value with a structured
+     * issue rather than letting it reach a downstream constructor that itself throws for a blank
+     * value (see {@code ChallengeDefinition}'s constructor check on {@code
+     * catalogueSemanticFingerprint}).
+     */
+    private static String optionalNonBlankString(
+            Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
+        String value = optionalString(parent, path, issues);
+        if (value != null && value.isBlank()) {
+            issues.add(new ChallengeContentIssue("content.field.blank", path, "must not be blank when present"));
+            return null;
+        }
+        return value;
+    }
+
     private static Integer requireInt(
             Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
-        Double value = requireNumber(parent, path, issues);
+        Number value = requireNumber(parent, path, issues);
         if (value == null) {
             return null;
         }
-        if (value != Math.floor(value) || value.isInfinite()) {
+        if (value instanceof Double) {
             issues.add(new ChallengeContentIssue("content.field.type", path, "must be an integer"));
+            return null;
+        }
+        if (value instanceof java.math.BigInteger
+                || value.longValue() < Integer.MIN_VALUE
+                || value.longValue() > Integer.MAX_VALUE) {
+            issues.add(new ChallengeContentIssue(
+                    "content.field.out-of-range", path, "must be within the 32-bit integer range"));
             return null;
         }
         return value.intValue();
@@ -408,18 +522,23 @@ public final class ChallengeContentLoader {
 
     private static Long requireLong(
             Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
-        Double value = requireNumber(parent, path, issues);
+        Number value = requireNumber(parent, path, issues);
         if (value == null) {
             return null;
         }
-        if (value != Math.floor(value) || value.isInfinite()) {
+        if (value instanceof Double) {
             issues.add(new ChallengeContentIssue("content.field.type", path, "must be an integer"));
+            return null;
+        }
+        if (value instanceof java.math.BigInteger) {
+            issues.add(new ChallengeContentIssue(
+                    "content.field.out-of-range", path, "must be within the 64-bit integer range"));
             return null;
         }
         return value.longValue();
     }
 
-    private static Double requireNumber(
+    private static Number requireNumber(
             Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
         String simpleKey = simpleKey(path);
         if (!parent.containsKey(simpleKey) || parent.get(simpleKey) == null) {
@@ -427,11 +546,11 @@ public final class ChallengeContentLoader {
             return null;
         }
         Object value = parent.get(simpleKey);
-        if (!(value instanceof Double d)) {
+        if (!(value instanceof Number n)) {
             issues.add(new ChallengeContentIssue("content.field.type", path, "must be a number"));
             return null;
         }
-        return d;
+        return n;
     }
 
     private static String simpleKey(String path) {

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
@@ -11,6 +11,8 @@ import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
 import com.arcogine.challenge.catalogue.EquipmentCatalogueIssue;
 import com.arcogine.challenge.catalogue.EquipmentCatalogueValidator;
 import com.arcogine.challenge.catalogue.EquipmentOffer;
+import com.arcogine.challenge.validation.ChallengeDefinitionIssue;
+import com.arcogine.challenge.validation.ChallengeDefinitionValidator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -201,6 +203,50 @@ public final class ChallengeContentLoader {
         }
 
         return EquipmentCatalogueContentLoadResult.success(catalogue);
+    }
+
+    /**
+     * Decodes {@code challengeSource} and {@code catalogueSource} together and confirms that
+     * every catalogue reference the challenge declares actually resolves against the decoded
+     * catalogue.
+     *
+     * <p>{@link #load(String)} and {@link #loadCatalogue(String)} each decode and content-validate
+     * one document in isolation; neither calls {@code
+     * EquipmentCatalogueValidator#validateChallengeResolution}, since that check requires both
+     * documents at once. This method runs the full pipeline -- decode both, content-validate both
+     * ({@code ChallengeDefinitionValidator} and {@code EquipmentCatalogueValidator#validate}), then
+     * cross-resolve -- and aggregates every issue from every step into one deterministic, ordered
+     * result rather than stopping at the first failing step.
+     */
+    public static ChallengeWithCatalogueLoadResult loadChallengeWithCatalogue(
+            String challengeSource, String catalogueSource) {
+        ChallengeContentLoadResult challengeResult = load(challengeSource);
+        EquipmentCatalogueContentLoadResult catalogueResult = loadCatalogue(catalogueSource);
+
+        List<ChallengeContentIssue> issues = new ArrayList<>();
+        issues.addAll(challengeResult.issues());
+        issues.addAll(catalogueResult.issues());
+        if (!issues.isEmpty()) {
+            return ChallengeWithCatalogueLoadResult.failure(issues);
+        }
+
+        ChallengeDefinition definition = challengeResult.definition();
+        EquipmentCatalogue catalogue = catalogueResult.catalogue();
+
+        List<ChallengeDefinitionIssue> definitionIssues =
+                ChallengeDefinitionValidator.validate(definition).issues();
+        for (ChallengeDefinitionIssue issue : definitionIssues) {
+            issues.add(new ChallengeContentIssue("definition." + issue.code(), issue.path(), issue.message()));
+        }
+
+        List<EquipmentCatalogueIssue> resolutionIssues =
+                EquipmentCatalogueValidator.validateChallengeResolution(definition, catalogue).issues();
+        issues.addAll(translateCatalogueIssues(resolutionIssues));
+
+        if (!issues.isEmpty()) {
+            return ChallengeWithCatalogueLoadResult.failure(issues);
+        }
+        return ChallengeWithCatalogueLoadResult.success(definition, catalogue);
     }
 
     private static List<ChallengeContentIssue> translateCatalogueIssues(List<EquipmentCatalogueIssue> issues) {

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
@@ -1,0 +1,257 @@
+package com.arcogine.challenge.content;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.ChallengeIdentity;
+import com.arcogine.challenge.ChallengeWorkload;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import com.arcogine.challenge.FactoryFloorConstraint;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The C5 content-loading layer: converts an untrusted external JSON representation of a challenge
+ * into a structurally complete {@link ChallengeDefinition}, or into deterministic, actionable
+ * {@link ChallengeContentIssue} diagnostics explaining why it could not.
+ *
+ * <p>This is the layer C1 explicitly deferred: {@code ChallengeDefinition} and its nested value
+ * records reject structurally absent fields via ordinary constructor {@code
+ * NullPointerException}s, which is unsuitable for untrusted input. {@code ChallengeContentLoader}
+ * never lets a malformed or incomplete external representation reach a {@code
+ * ChallengeDefinition} constructor uncaught -- every missing, mistyped, or malformed field is
+ * translated into a {@link ChallengeContentIssue} before construction is attempted.
+ *
+ * <p>This loader decodes content only. It does not decide whether an already-constructed
+ * definition's scalar content is valid (that is {@code ChallengeDefinitionValidator}'s job) and it
+ * does not resolve catalogue references against a real catalogue (that is {@code
+ * EquipmentCatalogueValidator}'s job). Callers that need both structural decoding and content
+ * validation should call {@link #load(String)} and then run the returned definition through {@code
+ * ChallengeDefinitionValidator} themselves.
+ *
+ * <p>Loading is pure and deterministic: it performs no I/O of its own (callers supply the source
+ * text), consults no wall-clock time or random state, and produces an equal result for equal
+ * input every time.
+ */
+public final class ChallengeContentLoader {
+
+    private ChallengeContentLoader() {}
+
+    /** Decodes {@code source} (a JSON document) into a {@link ChallengeContentLoadResult}. */
+    public static ChallengeContentLoadResult load(String source) {
+        if (source == null) {
+            return ChallengeContentLoadResult.failure(
+                    List.of(new ChallengeContentIssue("content.source.null", "$", "source must not be null")));
+        }
+
+        Object parsed;
+        try {
+            parsed = Json.parse(source);
+        } catch (JsonSyntaxException e) {
+            return ChallengeContentLoadResult.failure(
+                    List.of(new ChallengeContentIssue("content.malformed-json", "$", e.getMessage())));
+        }
+
+        if (!(parsed instanceof Map<?, ?> rawRoot)) {
+            return ChallengeContentLoadResult.failure(List.of(
+                    new ChallengeContentIssue("content.root.not-object", "$", "root value must be a JSON object")));
+        }
+
+        List<ChallengeContentIssue> issues = new ArrayList<>();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> root = (Map<String, Object>) rawRoot;
+
+        Map<String, Object> identityNode = requireObject(root, "identity", issues);
+        String identityId = identityNode == null ? null : requireString(identityNode, "identity.id", issues);
+        String identityVersion =
+                identityNode == null ? null : requireString(identityNode, "identity.version", issues);
+
+        Map<String, Object> floorNode = requireObject(root, "floor", issues);
+        Integer floorWidth = floorNode == null ? null : requireInt(floorNode, "floor.width", issues);
+        Integer floorHeight = floorNode == null ? null : requireInt(floorNode, "floor.height", issues);
+
+        Long startingBudget = requireLong(root, "startingBudget", issues);
+
+        Map<String, Object> workloadNode = requireObject(root, "workload", issues);
+        String productReference =
+                workloadNode == null ? null : requireString(workloadNode, "workload.productReference", issues);
+        Integer requiredQuantity =
+                workloadNode == null ? null : requireInt(workloadNode, "workload.requiredQuantity", issues);
+
+        List<EquipmentCatalogueItemId> availableEquipment =
+                readAvailableEquipment(root, issues);
+
+        Long deadline = requireLong(root, "deadline", issues);
+
+        Map<String, Object> policyNode = requireObject(root, "evaluationPolicy", issues);
+        String policyId = policyNode == null ? null : requireString(policyNode, "evaluationPolicy.id", issues);
+        String policyVersion =
+                policyNode == null ? null : requireString(policyNode, "evaluationPolicy.version", issues);
+
+        Map<String, Object> catalogueIdentityNode = optionalObject(root, "catalogueIdentity", issues);
+        String catalogueId = catalogueIdentityNode == null
+                ? null
+                : requireString(catalogueIdentityNode, "catalogueIdentity.id", issues);
+        String catalogueVersion = catalogueIdentityNode == null
+                ? null
+                : requireString(catalogueIdentityNode, "catalogueIdentity.version", issues);
+
+        String catalogueSemanticFingerprint =
+                optionalString(root, "catalogueSemanticFingerprint", issues);
+
+        if (!issues.isEmpty()) {
+            return ChallengeContentLoadResult.failure(issues);
+        }
+
+        ChallengeIdentity identity = new ChallengeIdentity(identityId, identityVersion);
+        FactoryFloorConstraint floor = new FactoryFloorConstraint(floorWidth, floorHeight);
+        ChallengeWorkload workload = new ChallengeWorkload(productReference, requiredQuantity);
+        EvaluationPolicyIdentity evaluationPolicy = new EvaluationPolicyIdentity(policyId, policyVersion);
+
+        ChallengeDefinition definition;
+        if (catalogueIdentityNode != null) {
+            EquipmentCatalogueIdentity catalogueIdentity =
+                    new EquipmentCatalogueIdentity(catalogueId, catalogueVersion);
+            definition = new ChallengeDefinition(
+                    identity,
+                    floor,
+                    startingBudget,
+                    workload,
+                    availableEquipment,
+                    deadline,
+                    evaluationPolicy,
+                    catalogueIdentity,
+                    catalogueSemanticFingerprint);
+        } else {
+            definition = new ChallengeDefinition(
+                    identity, floor, startingBudget, workload, availableEquipment, deadline, evaluationPolicy);
+        }
+        return ChallengeContentLoadResult.success(definition);
+    }
+
+    private static List<EquipmentCatalogueItemId> readAvailableEquipment(
+            Map<String, Object> root, List<ChallengeContentIssue> issues) {
+        Object raw = root.get("availableEquipment");
+        if (raw == null) {
+            return List.of();
+        }
+        if (!(raw instanceof List<?> rawList)) {
+            issues.add(new ChallengeContentIssue(
+                    "content.field.type", "availableEquipment", "must be an array of strings"));
+            return List.of();
+        }
+        List<EquipmentCatalogueItemId> result = new ArrayList<>();
+        for (int i = 0; i < rawList.size(); i++) {
+            Object element = rawList.get(i);
+            String path = "availableEquipment[" + i + "]";
+            if (!(element instanceof String value)) {
+                issues.add(new ChallengeContentIssue("content.field.type", path, "must be a string"));
+                continue;
+            }
+            result.add(new EquipmentCatalogueItemId(value));
+        }
+        return result;
+    }
+
+    private static Map<String, Object> requireObject(
+            Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
+        if (!parent.containsKey(path)) {
+            issues.add(new ChallengeContentIssue("content.field.missing", path, "field is required"));
+            return null;
+        }
+        return asObject(parent.get(path), path, issues);
+    }
+
+    private static Map<String, Object> optionalObject(
+            Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
+        if (!parent.containsKey(path) || parent.get(path) == null) {
+            return null;
+        }
+        return asObject(parent.get(path), path, issues);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asObject(
+            Object value, String path, List<ChallengeContentIssue> issues) {
+        if (!(value instanceof Map<?, ?> map)) {
+            issues.add(new ChallengeContentIssue("content.field.type", path, "must be a JSON object"));
+            return null;
+        }
+        return (Map<String, Object>) map;
+    }
+
+    private static String requireString(
+            Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
+        String simpleKey = simpleKey(path);
+        if (!parent.containsKey(simpleKey) || parent.get(simpleKey) == null) {
+            issues.add(new ChallengeContentIssue("content.field.missing", path, "field is required"));
+            return null;
+        }
+        Object value = parent.get(simpleKey);
+        if (!(value instanceof String s)) {
+            issues.add(new ChallengeContentIssue("content.field.type", path, "must be a string"));
+            return null;
+        }
+        return s;
+    }
+
+    private static String optionalString(
+            Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
+        if (!parent.containsKey(path) || parent.get(path) == null) {
+            return null;
+        }
+        Object value = parent.get(path);
+        if (!(value instanceof String s)) {
+            issues.add(new ChallengeContentIssue("content.field.type", path, "must be a string"));
+            return null;
+        }
+        return s;
+    }
+
+    private static Integer requireInt(
+            Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
+        Double value = requireNumber(parent, path, issues);
+        if (value == null) {
+            return null;
+        }
+        if (value != Math.floor(value) || value.isInfinite()) {
+            issues.add(new ChallengeContentIssue("content.field.type", path, "must be an integer"));
+            return null;
+        }
+        return value.intValue();
+    }
+
+    private static Long requireLong(
+            Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
+        Double value = requireNumber(parent, path, issues);
+        if (value == null) {
+            return null;
+        }
+        if (value != Math.floor(value) || value.isInfinite()) {
+            issues.add(new ChallengeContentIssue("content.field.type", path, "must be an integer"));
+            return null;
+        }
+        return value.longValue();
+    }
+
+    private static Double requireNumber(
+            Map<String, Object> parent, String path, List<ChallengeContentIssue> issues) {
+        String simpleKey = simpleKey(path);
+        if (!parent.containsKey(simpleKey) || parent.get(simpleKey) == null) {
+            issues.add(new ChallengeContentIssue("content.field.missing", path, "field is required"));
+            return null;
+        }
+        Object value = parent.get(simpleKey);
+        if (!(value instanceof Double d)) {
+            issues.add(new ChallengeContentIssue("content.field.type", path, "must be a number"));
+            return null;
+        }
+        return d;
+    }
+
+    private static String simpleKey(String path) {
+        int dot = path.lastIndexOf('.');
+        return dot < 0 ? path : path.substring(dot + 1);
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
@@ -6,7 +6,11 @@ import com.arcogine.challenge.ChallengeWorkload;
 import com.arcogine.challenge.EquipmentCatalogueItemId;
 import com.arcogine.challenge.EvaluationPolicyIdentity;
 import com.arcogine.challenge.FactoryFloorConstraint;
+import com.arcogine.challenge.catalogue.EquipmentCatalogue;
 import com.arcogine.challenge.catalogue.EquipmentCatalogueIdentity;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueIssue;
+import com.arcogine.challenge.catalogue.EquipmentCatalogueValidator;
+import com.arcogine.challenge.catalogue.EquipmentOffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +40,20 @@ import java.util.Map;
  */
 public final class ChallengeContentLoader {
 
+    /**
+     * The only content schema version this loader accepts for challenge definition documents.
+     *
+     * <p>This is a content-profile concept, distinct from {@link ChallengeIdentity#version()} (the
+     * identity/version of a particular challenge's own content) and from {@link
+     * EvaluationPolicyIdentity#version()} (the version of the evaluation policy a challenge
+     * selects). Bumping it is a breaking change to the JSON document shape this loader understands,
+     * not a change to any individual challenge or policy.
+     */
+    public static final String CHALLENGE_SCHEMA_VERSION = "challenge-content:v1";
+
+    /** The only content schema version this loader accepts for equipment catalogue documents. */
+    public static final String CATALOGUE_SCHEMA_VERSION = "equipment-catalogue:v1";
+
     private ChallengeContentLoader() {}
 
     /** Decodes {@code source} (a JSON document) into a {@link ChallengeContentLoadResult}. */
@@ -61,6 +79,8 @@ public final class ChallengeContentLoader {
         List<ChallengeContentIssue> issues = new ArrayList<>();
         @SuppressWarnings("unchecked")
         Map<String, Object> root = (Map<String, Object>) rawRoot;
+
+        requireSchemaVersion(root, CHALLENGE_SCHEMA_VERSION, issues);
 
         Map<String, Object> identityNode = requireObject(root, "identity", issues);
         String identityId = identityNode == null ? null : requireString(identityNode, "identity.id", issues);
@@ -100,6 +120,11 @@ public final class ChallengeContentLoader {
         String catalogueSemanticFingerprint =
                 optionalString(root, "catalogueSemanticFingerprint", issues);
 
+        if (policyId != null && policyVersion != null) {
+            EvaluationPolicyResolver.resolve(new EvaluationPolicyIdentity(policyId, policyVersion))
+                    .ifPresent(issue -> issues.add(issue));
+        }
+
         if (!issues.isEmpty()) {
             return ChallengeContentLoadResult.failure(issues);
         }
@@ -128,6 +153,119 @@ public final class ChallengeContentLoader {
                     identity, floor, startingBudget, workload, availableEquipment, deadline, evaluationPolicy);
         }
         return ChallengeContentLoadResult.success(definition);
+    }
+
+    /** Decodes {@code source} (a JSON document) into an {@link EquipmentCatalogueContentLoadResult}. */
+    public static EquipmentCatalogueContentLoadResult loadCatalogue(String source) {
+        if (source == null) {
+            return EquipmentCatalogueContentLoadResult.failure(
+                    List.of(new ChallengeContentIssue("content.source.null", "$", "source must not be null")));
+        }
+
+        Object parsed;
+        try {
+            parsed = Json.parse(source);
+        } catch (JsonSyntaxException e) {
+            return EquipmentCatalogueContentLoadResult.failure(
+                    List.of(new ChallengeContentIssue("content.malformed-json", "$", e.getMessage())));
+        }
+
+        if (!(parsed instanceof Map<?, ?> rawRoot)) {
+            return EquipmentCatalogueContentLoadResult.failure(List.of(
+                    new ChallengeContentIssue("content.root.not-object", "$", "root value must be a JSON object")));
+        }
+
+        List<ChallengeContentIssue> issues = new ArrayList<>();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> root = (Map<String, Object>) rawRoot;
+
+        requireSchemaVersion(root, CATALOGUE_SCHEMA_VERSION, issues);
+
+        Map<String, Object> identityNode = requireObject(root, "identity", issues);
+        String identityId = identityNode == null ? null : requireString(identityNode, "identity.id", issues);
+        String identityVersion =
+                identityNode == null ? null : requireString(identityNode, "identity.version", issues);
+
+        List<EquipmentOffer> offers = readOffers(root, issues);
+
+        if (!issues.isEmpty()) {
+            return EquipmentCatalogueContentLoadResult.failure(issues);
+        }
+
+        EquipmentCatalogue catalogue = new EquipmentCatalogue(
+                new EquipmentCatalogueIdentity(identityId, identityVersion), offers);
+
+        List<EquipmentCatalogueIssue> validationIssues = EquipmentCatalogueValidator.validate(catalogue).issues();
+        if (!validationIssues.isEmpty()) {
+            return EquipmentCatalogueContentLoadResult.failure(translateCatalogueIssues(validationIssues));
+        }
+
+        return EquipmentCatalogueContentLoadResult.success(catalogue);
+    }
+
+    private static List<ChallengeContentIssue> translateCatalogueIssues(List<EquipmentCatalogueIssue> issues) {
+        List<ChallengeContentIssue> translated = new ArrayList<>();
+        for (EquipmentCatalogueIssue issue : issues) {
+            translated.add(new ChallengeContentIssue(
+                    "catalogue." + issue.code(), issue.path(), issue.message()));
+        }
+        return translated;
+    }
+
+    private static List<EquipmentOffer> readOffers(Map<String, Object> root, List<ChallengeContentIssue> issues) {
+        if (!root.containsKey("offers")) {
+            issues.add(new ChallengeContentIssue("content.field.missing", "offers", "field is required"));
+            return List.of();
+        }
+        Object raw = root.get("offers");
+        if (!(raw instanceof List<?> rawList)) {
+            issues.add(new ChallengeContentIssue("content.field.type", "offers", "must be an array"));
+            return List.of();
+        }
+        List<EquipmentOffer> offers = new ArrayList<>();
+        for (int i = 0; i < rawList.size(); i++) {
+            Object element = rawList.get(i);
+            String path = "offers[" + i + "]";
+            Map<String, Object> offerNode = asObject(element, path, issues);
+            if (offerNode == null) {
+                continue;
+            }
+            String itemId = requireString(offerNode, path + ".itemId", issues);
+            Long purchaseCostCredits = requireLong(offerNode, path + ".purchaseCostCredits", issues);
+            Integer quantityLimit = optionalOfferQuantityLimit(offerNode, path, issues);
+            if (itemId == null || purchaseCostCredits == null) {
+                continue;
+            }
+            offers.add(quantityLimit == null
+                    ? EquipmentOffer.of(new EquipmentCatalogueItemId(itemId), purchaseCostCredits)
+                    : EquipmentOffer.of(new EquipmentCatalogueItemId(itemId), purchaseCostCredits, quantityLimit));
+        }
+        return offers;
+    }
+
+    private static Integer optionalOfferQuantityLimit(
+            Map<String, Object> offerNode, String offerPath, List<ChallengeContentIssue> issues) {
+        String path = offerPath + ".quantityLimit";
+        if (!offerNode.containsKey("quantityLimit") || offerNode.get("quantityLimit") == null) {
+            return null;
+        }
+        Object value = offerNode.get("quantityLimit");
+        if (!(value instanceof Double d) || d != Math.floor(d) || d.isInfinite()) {
+            issues.add(new ChallengeContentIssue("content.field.type", path, "must be an integer"));
+            return null;
+        }
+        return d.intValue();
+    }
+
+    private static void requireSchemaVersion(
+            Map<String, Object> root, String expected, List<ChallengeContentIssue> issues) {
+        String schemaVersion = requireString(root, "schemaVersion", issues);
+        if (schemaVersion != null && !expected.equals(schemaVersion)) {
+            issues.add(new ChallengeContentIssue(
+                    "content.schemaVersion.unsupported",
+                    "schemaVersion",
+                    "unsupported schema version: " + schemaVersion + " (expected " + expected + ")"));
+        }
     }
 
     private static List<EquipmentCatalogueItemId> readAvailableEquipment(

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
@@ -29,12 +29,17 @@ import java.util.Map;
  * ChallengeDefinition} constructor uncaught -- every missing, mistyped, or malformed field is
  * translated into a {@link ChallengeContentIssue} before construction is attempted.
  *
- * <p>This loader decodes content only. It does not decide whether an already-constructed
+ * <p>The three entry points draw the decode/validate boundary differently. {@link #load(String)}
+ * decodes a challenge document only: it does not decide whether an already-constructed
  * definition's scalar content is valid (that is {@code ChallengeDefinitionValidator}'s job) and it
- * does not resolve catalogue references against a real catalogue (that is {@code
- * EquipmentCatalogueValidator}'s job). Callers that need both structural decoding and content
- * validation should call {@link #load(String)} and then run the returned definition through {@code
- * ChallengeDefinitionValidator} themselves.
+ * does not resolve catalogue references or bind/verify catalogue provenance against a real
+ * catalogue (that is {@code EquipmentCatalogueValidator}'s job); a caller that needs both
+ * structural decoding and content validation for a single challenge document should call {@link
+ * #load(String)} and then run the returned definition through {@code ChallengeDefinitionValidator}
+ * itself. {@link #loadCatalogue(String)} decodes a catalogue document and always additionally runs
+ * {@code EquipmentCatalogueValidator#validate}. {@link #loadChallengeWithCatalogue(String, String)}
+ * is the one entry point that validates both documents, binds/verifies catalogue-identity and
+ * semantic-fingerprint provenance, and cross-resolves catalogue references.
  *
  * <p>Loading is pure and deterministic: it performs no I/O of its own (callers supply the source
  * text), consults no wall-clock time or random state, and produces an equal result for equal

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeContentLoader.java
@@ -254,13 +254,16 @@ public final class ChallengeContentLoader {
      * every catalogue reference the challenge declares actually resolves against the decoded
      * catalogue.
      *
-     * <p>{@link #load(String)} and {@link #loadCatalogue(String)} each decode and content-validate
-     * one document in isolation; neither calls {@code
+     * <p>{@link #load(String)} performs structural decoding only and never itself invokes {@code
+     * ChallengeDefinitionValidator}; {@link #loadCatalogue(String)} decodes and always runs {@code
+     * EquipmentCatalogueValidator#validate}. Neither calls {@code
      * EquipmentCatalogueValidator#validateChallengeResolution}, since that check requires both
-     * documents at once. This method runs the full pipeline -- decode both, content-validate both
-     * ({@code ChallengeDefinitionValidator} and {@code EquipmentCatalogueValidator#validate}), then
-     * cross-resolve -- and aggregates every issue from every step into one deterministic, ordered
-     * result rather than stopping at the first failing step.
+     * documents at once, and neither binds or verifies catalogue provenance against a real
+     * catalogue. This method is the one entry point that runs the full pipeline -- decode both,
+     * content-validate both ({@code ChallengeDefinitionValidator} and {@code
+     * EquipmentCatalogueValidator#validate}), bind/verify catalogue-identity and
+     * semantic-fingerprint provenance, then cross-resolve -- and aggregates every issue from every
+     * step into one deterministic, ordered result rather than stopping at the first failing step.
      */
     public static ChallengeWithCatalogueLoadResult loadChallengeWithCatalogue(
             String challengeSource, String catalogueSource) {

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeWithCatalogueLoadResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/ChallengeWithCatalogueLoadResult.java
@@ -1,0 +1,51 @@
+package com.arcogine.challenge.content;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.catalogue.EquipmentCatalogue;
+import java.util.List;
+
+/**
+ * Deterministic, structured result of loading a {@link ChallengeDefinition} and an {@link
+ * EquipmentCatalogue} together and confirming that every catalogue reference the challenge
+ * declares actually resolves against that catalogue.
+ *
+ * <p>This is the aggregate outcome of {@link ChallengeContentLoader#loadChallengeWithCatalogue}:
+ * decoding both documents ({@link ChallengeContentLoader#load} and {@link
+ * ChallengeContentLoader#loadCatalogue}), running {@code ChallengeDefinitionValidator} on the
+ * decoded definition, running {@code EquipmentCatalogueValidator#validate} on the decoded
+ * catalogue, and running {@code EquipmentCatalogueValidator#validateChallengeResolution} across
+ * both. Exactly one of ({@link #definition()} and {@link #catalogue()}) or a non-empty {@link
+ * #issues()} is populated -- either every step succeeded, or every reason from every step is
+ * reported as a {@link ChallengeContentIssue} rather than as an uncaught exception or a partial
+ * result.
+ */
+public record ChallengeWithCatalogueLoadResult(
+        ChallengeDefinition definition, EquipmentCatalogue catalogue, List<ChallengeContentIssue> issues) {
+
+    public ChallengeWithCatalogueLoadResult {
+        issues = issues == null ? List.of() : List.copyOf(issues);
+        boolean bothPresent = definition != null && catalogue != null;
+        boolean bothAbsent = definition == null && catalogue == null;
+        if (!bothPresent && !bothAbsent) {
+            throw new IllegalArgumentException("definition and catalogue must both be present or both be absent");
+        }
+        if (bothAbsent && issues.isEmpty()) {
+            throw new IllegalArgumentException("either definition/catalogue or issues must be populated");
+        }
+        if (bothPresent && !issues.isEmpty()) {
+            throw new IllegalArgumentException("definition/catalogue and issues are mutually exclusive");
+        }
+    }
+
+    static ChallengeWithCatalogueLoadResult success(ChallengeDefinition definition, EquipmentCatalogue catalogue) {
+        return new ChallengeWithCatalogueLoadResult(definition, catalogue, List.of());
+    }
+
+    static ChallengeWithCatalogueLoadResult failure(List<ChallengeContentIssue> issues) {
+        return new ChallengeWithCatalogueLoadResult(null, null, issues);
+    }
+
+    public boolean isSuccess() {
+        return definition != null && catalogue != null;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/EquipmentCatalogueContentLoadResult.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/EquipmentCatalogueContentLoadResult.java
@@ -1,0 +1,40 @@
+package com.arcogine.challenge.content;
+
+import com.arcogine.challenge.catalogue.EquipmentCatalogue;
+import java.util.List;
+
+/**
+ * Deterministic, structured result of decoding an untrusted external representation into an
+ * {@link EquipmentCatalogue}.
+ *
+ * <p>Exactly one of {@link #catalogue()} or a non-empty {@link #issues()} is populated: either
+ * decoding (and, once decoded, {@code EquipmentCatalogueValidator} content validation) succeeded,
+ * or it failed and every reason is reported as a {@link ChallengeContentIssue} rather than as an
+ * uncaught exception. A validation failure is folded into this same result rather than exposed as
+ * a separate stage, mirroring {@link ChallengeContentLoadResult}'s decode-only contract but for
+ * catalogue content, where {@code EquipmentCatalogueValidator#validate} is cheap and always run.
+ */
+public record EquipmentCatalogueContentLoadResult(EquipmentCatalogue catalogue, List<ChallengeContentIssue> issues) {
+
+    public EquipmentCatalogueContentLoadResult {
+        issues = issues == null ? List.of() : List.copyOf(issues);
+        if (catalogue == null && issues.isEmpty()) {
+            throw new IllegalArgumentException("either catalogue or issues must be populated");
+        }
+        if (catalogue != null && !issues.isEmpty()) {
+            throw new IllegalArgumentException("catalogue and issues are mutually exclusive");
+        }
+    }
+
+    static EquipmentCatalogueContentLoadResult success(EquipmentCatalogue catalogue) {
+        return new EquipmentCatalogueContentLoadResult(catalogue, List.of());
+    }
+
+    static EquipmentCatalogueContentLoadResult failure(List<ChallengeContentIssue> issues) {
+        return new EquipmentCatalogueContentLoadResult(null, issues);
+    }
+
+    public boolean isSuccess() {
+        return catalogue != null;
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/EvaluationPolicyResolver.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/EvaluationPolicyResolver.java
@@ -1,0 +1,56 @@
+package com.arcogine.challenge.content;
+
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import com.arcogine.challenge.evaluation.ReferenceChallengeEvaluationPolicy;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A small immutable static registry of evaluation policy (id, version) pairs this build knows how
+ * to evaluate.
+ *
+ * <p>This exists so untrusted content that names an unknown or unsupported {@link
+ * EvaluationPolicyIdentity} fails with a deterministic, structured {@link ChallengeContentIssue}
+ * rather than reaching {@code ReferenceChallengeEvaluationPolicy.evaluate} and throwing an
+ * uncaught {@code IllegalArgumentException} later, at evaluation time instead of load time.
+ *
+ * <p>It does not evaluate anything itself; it only answers "is this policy identity supported by
+ * this build". Adding a new evaluation policy version means adding both the new policy
+ * implementation and a new entry here -- an unregistered policy stays unsupported even if a class
+ * implementing it exists.
+ */
+public final class EvaluationPolicyResolver {
+
+    private static final Set<EvaluationPolicyIdentity> SUPPORTED = Set.of(new EvaluationPolicyIdentity(
+            ReferenceChallengeEvaluationPolicy.POLICY_ID, ReferenceChallengeEvaluationPolicy.POLICY_VERSION));
+
+    private EvaluationPolicyResolver() {}
+
+    /** Returns {@code true} when {@code identity} names a policy this build can evaluate. */
+    public static boolean isSupported(EvaluationPolicyIdentity identity) {
+        if (identity == null) {
+            throw new NullPointerException("identity");
+        }
+        return SUPPORTED.contains(identity);
+    }
+
+    /**
+     * Resolves {@code identity}, returning an empty {@link Optional} when it is supported, or a
+     * structured {@link ChallengeContentIssue} (code {@code "evaluationPolicy.unsupported"}) at
+     * {@code path} when it is not.
+     */
+    public static Optional<ChallengeContentIssue> resolve(EvaluationPolicyIdentity identity, String path) {
+        if (isSupported(identity)) {
+            return Optional.empty();
+        }
+        return Optional.of(new ChallengeContentIssue(
+                "evaluationPolicy.unsupported",
+                path,
+                "unsupported evaluation policy: " + identity.id() + " v" + identity.version()));
+    }
+
+    /** Convenience overload resolving at the conventional {@code "evaluationPolicy"} path. */
+    public static Optional<ChallengeContentIssue> resolve(EvaluationPolicyIdentity identity) {
+        return resolve(identity, "evaluationPolicy");
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
@@ -13,6 +13,15 @@ import java.util.Map;
  * null), reports malformed input as a {@link JsonSyntaxException} carrying a human-readable
  * position, and introduces no third-party dependency into the headless {@code :challenge} module.
  *
+ * <p>Numbers are decoded exactly rather than round-tripped through {@code double}: a JSON numeric
+ * literal with no fraction or exponent part is decoded as a {@link Long} when it fits in a {@code
+ * long}, or a {@link java.math.BigInteger} when it does not (preserving the exact authored value
+ * for range checking by callers); a literal with a fraction or exponent part is decoded as a
+ * {@link Double}. This matters because {@code double} cannot exactly represent every {@code long}
+ * (values beyond 2^53 silently lose precision), and this content format's numeric fields (budgets,
+ * deadlines, costs, dimensions, quantities) are all integers where silent rounding would change
+ * authored semantics.
+ *
  * <p>Parsing is pure: it performs no I/O, holds no mutable static state, and always produces an
  * equal result tree for equal input.
  */
@@ -181,8 +190,9 @@ final class Json {
         throw error("invalid literal");
     }
 
-    private Double parseNumber() throws JsonSyntaxException {
+    private Number parseNumber() throws JsonSyntaxException {
         int start = position;
+        boolean isIntegerLiteral = true;
         if (peek() == '-') {
             position++;
         }
@@ -190,12 +200,14 @@ final class Json {
             position++;
         }
         if (position < source.length() && source.charAt(position) == '.') {
+            isIntegerLiteral = false;
             position++;
             while (position < source.length() && Character.isDigit(source.charAt(position))) {
                 position++;
             }
         }
         if (position < source.length() && (source.charAt(position) == 'e' || source.charAt(position) == 'E')) {
+            isIntegerLiteral = false;
             position++;
             if (position < source.length()
                     && (source.charAt(position) == '+' || source.charAt(position) == '-')) {
@@ -208,8 +220,20 @@ final class Json {
         if (position == start) {
             throw error("invalid number");
         }
+        String token = source.substring(start, position);
+        if (isIntegerLiteral) {
+            try {
+                return Long.parseLong(token);
+            } catch (NumberFormatException e) {
+                try {
+                    return new java.math.BigInteger(token);
+                } catch (NumberFormatException e2) {
+                    throw error("invalid number");
+                }
+            }
+        }
         try {
-            return Double.parseDouble(source.substring(start, position));
+            return Double.parseDouble(token);
         } catch (NumberFormatException e) {
             throw error("invalid number");
         }

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
@@ -203,14 +203,21 @@ final class Json {
             position++;
         }
         int integerPartLength = position - integerPartStart;
+        if (integerPartLength == 0) {
+            throw error("invalid number: expected a digit before any '.' or exponent");
+        }
         if (integerPartLength > 1 && source.charAt(integerPartStart) == '0') {
             throw error("leading zero not allowed in number");
         }
         if (position < source.length() && source.charAt(position) == '.') {
             isIntegerLiteral = false;
             position++;
+            int fractionStart = position;
             while (position < source.length() && Character.isDigit(source.charAt(position))) {
                 position++;
+            }
+            if (position == fractionStart) {
+                throw error("invalid number: expected a digit after '.'");
             }
         }
         if (position < source.length() && (source.charAt(position) == 'e' || source.charAt(position) == 'E')) {
@@ -220,8 +227,12 @@ final class Json {
                     && (source.charAt(position) == '+' || source.charAt(position) == '-')) {
                 position++;
             }
+            int exponentDigitsStart = position;
             while (position < source.length() && Character.isDigit(source.charAt(position))) {
                 position++;
+            }
+            if (position == exponentDigitsStart) {
+                throw error("invalid number: expected a digit in the exponent");
             }
         }
         if (position == start) {
@@ -260,10 +271,19 @@ final class Json {
         return source.charAt(position);
     }
 
+    /**
+     * Skips exactly JSON's own insignificant whitespace set (space, tab, line feed, carriage
+     * return) rather than {@link Character#isWhitespace}, which also accepts characters such as
+     * form feed or vertical tab that the JSON grammar does not permit between tokens.
+     */
     private void skipWhitespace() {
-        while (position < source.length() && Character.isWhitespace(source.charAt(position))) {
+        while (position < source.length() && isJsonWhitespace(source.charAt(position))) {
             position++;
         }
+    }
+
+    private static boolean isJsonWhitespace(char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r';
     }
 
     private JsonSyntaxException error(String message) {

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
@@ -1,0 +1,241 @@
+package com.arcogine.challenge.content;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A minimal, dependency-free JSON parser used only to decode game-owned challenge content.
+ *
+ * <p>This is deliberately not a general-purpose JSON library: it supports exactly the value
+ * shapes the challenge content format needs (objects, arrays, strings, numbers, booleans, and
+ * null), reports malformed input as a {@link JsonSyntaxException} carrying a human-readable
+ * position, and introduces no third-party dependency into the headless {@code :challenge} module.
+ *
+ * <p>Parsing is pure: it performs no I/O, holds no mutable static state, and always produces an
+ * equal result tree for equal input.
+ */
+final class Json {
+
+    private final String source;
+    private int position;
+
+    private Json(String source) {
+        this.source = source;
+    }
+
+    /**
+     * Parses {@code source} as a single JSON value and returns the decoded tree ({@link Map},
+     * {@link List}, {@link String}, {@link Double}, {@link Boolean}, or {@code null}).
+     */
+    static Object parse(String source) throws JsonSyntaxException {
+        if (source == null) {
+            throw new JsonSyntaxException("source must not be null");
+        }
+        Json parser = new Json(source);
+        parser.skipWhitespace();
+        Object value = parser.parseValue();
+        parser.skipWhitespace();
+        if (parser.position != parser.source.length()) {
+            throw parser.error("unexpected trailing content");
+        }
+        return value;
+    }
+
+    private Object parseValue() throws JsonSyntaxException {
+        if (position >= source.length()) {
+            throw error("unexpected end of input");
+        }
+        char c = source.charAt(position);
+        return switch (c) {
+            case '{' -> parseObject();
+            case '[' -> parseArray();
+            case '"' -> parseString();
+            case 't', 'f' -> parseBoolean();
+            case 'n' -> parseNull();
+            default -> parseNumber();
+        };
+    }
+
+    private Map<String, Object> parseObject() throws JsonSyntaxException {
+        expect('{');
+        Map<String, Object> result = new LinkedHashMap<>();
+        skipWhitespace();
+        if (peek() == '}') {
+            position++;
+            return result;
+        }
+        while (true) {
+            skipWhitespace();
+            if (peek() != '"') {
+                throw error("expected string key");
+            }
+            String key = parseString();
+            skipWhitespace();
+            expect(':');
+            skipWhitespace();
+            Object value = parseValue();
+            result.put(key, value);
+            skipWhitespace();
+            char next = peek();
+            if (next == ',') {
+                position++;
+            } else if (next == '}') {
+                position++;
+                return result;
+            } else {
+                throw error("expected ',' or '}'");
+            }
+        }
+    }
+
+    private List<Object> parseArray() throws JsonSyntaxException {
+        expect('[');
+        List<Object> result = new ArrayList<>();
+        skipWhitespace();
+        if (peek() == ']') {
+            position++;
+            return result;
+        }
+        while (true) {
+            skipWhitespace();
+            result.add(parseValue());
+            skipWhitespace();
+            char next = peek();
+            if (next == ',') {
+                position++;
+            } else if (next == ']') {
+                position++;
+                return result;
+            } else {
+                throw error("expected ',' or ']'");
+            }
+        }
+    }
+
+    private String parseString() throws JsonSyntaxException {
+        expect('"');
+        StringBuilder builder = new StringBuilder();
+        while (true) {
+            if (position >= source.length()) {
+                throw error("unterminated string");
+            }
+            char c = source.charAt(position++);
+            if (c == '"') {
+                return builder.toString();
+            }
+            if (c == '\\') {
+                if (position >= source.length()) {
+                    throw error("unterminated escape");
+                }
+                char escape = source.charAt(position++);
+                switch (escape) {
+                    case '"' -> builder.append('"');
+                    case '\\' -> builder.append('\\');
+                    case '/' -> builder.append('/');
+                    case 'b' -> builder.append('\b');
+                    case 'f' -> builder.append('\f');
+                    case 'n' -> builder.append('\n');
+                    case 'r' -> builder.append('\r');
+                    case 't' -> builder.append('\t');
+                    case 'u' -> builder.append(parseUnicodeEscape());
+                    default -> throw error("invalid escape '\\" + escape + "'");
+                }
+            } else {
+                builder.append(c);
+            }
+        }
+    }
+
+    private char parseUnicodeEscape() throws JsonSyntaxException {
+        if (position + 4 > source.length()) {
+            throw error("truncated unicode escape");
+        }
+        String hex = source.substring(position, position + 4);
+        position += 4;
+        try {
+            return (char) Integer.parseInt(hex, 16);
+        } catch (NumberFormatException e) {
+            throw error("invalid unicode escape '" + hex + "'");
+        }
+    }
+
+    private Boolean parseBoolean() throws JsonSyntaxException {
+        if (source.startsWith("true", position)) {
+            position += 4;
+            return Boolean.TRUE;
+        }
+        if (source.startsWith("false", position)) {
+            position += 5;
+            return Boolean.FALSE;
+        }
+        throw error("invalid literal");
+    }
+
+    private Object parseNull() throws JsonSyntaxException {
+        if (source.startsWith("null", position)) {
+            position += 4;
+            return null;
+        }
+        throw error("invalid literal");
+    }
+
+    private Double parseNumber() throws JsonSyntaxException {
+        int start = position;
+        if (peek() == '-') {
+            position++;
+        }
+        while (position < source.length() && Character.isDigit(source.charAt(position))) {
+            position++;
+        }
+        if (position < source.length() && source.charAt(position) == '.') {
+            position++;
+            while (position < source.length() && Character.isDigit(source.charAt(position))) {
+                position++;
+            }
+        }
+        if (position < source.length() && (source.charAt(position) == 'e' || source.charAt(position) == 'E')) {
+            position++;
+            if (position < source.length()
+                    && (source.charAt(position) == '+' || source.charAt(position) == '-')) {
+                position++;
+            }
+            while (position < source.length() && Character.isDigit(source.charAt(position))) {
+                position++;
+            }
+        }
+        if (position == start) {
+            throw error("invalid number");
+        }
+        try {
+            return Double.parseDouble(source.substring(start, position));
+        } catch (NumberFormatException e) {
+            throw error("invalid number");
+        }
+    }
+
+    private void expect(char expected) throws JsonSyntaxException {
+        if (position >= source.length() || source.charAt(position) != expected) {
+            throw error("expected '" + expected + "'");
+        }
+        position++;
+    }
+
+    private char peek() throws JsonSyntaxException {
+        if (position >= source.length()) {
+            throw error("unexpected end of input");
+        }
+        return source.charAt(position);
+    }
+
+    private void skipWhitespace() {
+        while (position < source.length() && Character.isWhitespace(source.charAt(position))) {
+            position++;
+        }
+    }
+
+    private JsonSyntaxException error(String message) {
+        return new JsonSyntaxException(message + " at position " + position);
+    }
+}

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
@@ -199,7 +199,7 @@ final class Json {
             position++;
         }
         int integerPartStart = position;
-        while (position < source.length() && Character.isDigit(source.charAt(position))) {
+        while (position < source.length() && isAsciiDigit(source.charAt(position))) {
             position++;
         }
         int integerPartLength = position - integerPartStart;
@@ -213,7 +213,7 @@ final class Json {
             isIntegerLiteral = false;
             position++;
             int fractionStart = position;
-            while (position < source.length() && Character.isDigit(source.charAt(position))) {
+            while (position < source.length() && isAsciiDigit(source.charAt(position))) {
                 position++;
             }
             if (position == fractionStart) {
@@ -228,7 +228,7 @@ final class Json {
                 position++;
             }
             int exponentDigitsStart = position;
-            while (position < source.length() && Character.isDigit(source.charAt(position))) {
+            while (position < source.length() && isAsciiDigit(source.charAt(position))) {
                 position++;
             }
             if (position == exponentDigitsStart) {
@@ -284,6 +284,15 @@ final class Json {
 
     private static boolean isJsonWhitespace(char c) {
         return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+    }
+
+    /**
+     * True only for the ASCII decimal digits {@code '0'-'9'}. JSON's number grammar permits only
+     * these; {@link Character#isDigit(char)} is broader and also accepts non-ASCII Unicode decimal
+     * digits (e.g. Arabic-indic digits), which would let non-JSON source parse successfully.
+     */
+    private static boolean isAsciiDigit(char c) {
+        return c >= '0' && c <= '9';
     }
 
     private JsonSyntaxException error(String message) {

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/Json.java
@@ -151,6 +151,8 @@ final class Json {
                     case 'u' -> builder.append(parseUnicodeEscape());
                     default -> throw error("invalid escape '\\" + escape + "'");
                 }
+            } else if (c <= 0x1F) {
+                throw error("unescaped control character in string");
             } else {
                 builder.append(c);
             }
@@ -196,8 +198,13 @@ final class Json {
         if (peek() == '-') {
             position++;
         }
+        int integerPartStart = position;
         while (position < source.length() && Character.isDigit(source.charAt(position))) {
             position++;
+        }
+        int integerPartLength = position - integerPartStart;
+        if (integerPartLength > 1 && source.charAt(integerPartStart) == '0') {
+            throw error("leading zero not allowed in number");
         }
         if (position < source.length() && source.charAt(position) == '.') {
             isIntegerLiteral = false;

--- a/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/JsonSyntaxException.java
+++ b/product/consumer/challenge/src/main/java/com/arcogine/challenge/content/JsonSyntaxException.java
@@ -1,0 +1,17 @@
+package com.arcogine.challenge.content;
+
+/**
+ * Thrown by {@link Json} when a source string is not well-formed JSON.
+ *
+ * <p>This is a content-loading concern only -- it never indicates that a structurally valid
+ * {@code ChallengeDefinition} has invalid scalar content; that remains {@code
+ * ChallengeDefinitionValidator}'s responsibility.
+ */
+public final class JsonSyntaxException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public JsonSyntaxException(String message) {
+        super(message);
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
@@ -1,0 +1,206 @@
+package com.arcogine.challenge.content;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.validation.ChallengeDefinitionValidationResult;
+import com.arcogine.challenge.validation.ChallengeDefinitionValidator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChallengeContentLoaderTest {
+
+    private static final String VALID_MINIMAL = """
+            {
+              "identity": {"id": "bottleneck-101", "version": "1"},
+              "floor": {"width": 10, "height": 8},
+              "startingBudget": 5000,
+              "workload": {"productReference": "widget", "requiredQuantity": 20},
+              "availableEquipment": ["assembler.basic", "assembler.fast"],
+              "deadline": 400,
+              "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+            }
+            """;
+
+    private static final String VALID_WITH_CATALOGUE_IDENTITY = """
+            {
+              "identity": {"id": "budget-squeeze", "version": "2"},
+              "floor": {"width": 6, "height": 6},
+              "startingBudget": 1200,
+              "workload": {"productReference": "gadget", "requiredQuantity": 5},
+              "availableEquipment": [],
+              "deadline": 200,
+              "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"},
+              "catalogueIdentity": {"id": "catalogue.core", "version": "3"},
+              "catalogueSemanticFingerprint": "fp-abc123"
+            }
+            """;
+
+    @Test
+    void loadsAMinimalValidDefinition() {
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(VALID_MINIMAL);
+
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+        ChallengeDefinition definition = result.definition();
+        assertEquals("bottleneck-101", definition.identity().id());
+        assertEquals("1", definition.identity().version());
+        assertEquals(10, definition.floor().width());
+        assertEquals(8, definition.floor().height());
+        assertEquals(5000L, definition.startingBudget());
+        assertEquals("widget", definition.workload().productReference());
+        assertEquals(20, definition.workload().requiredQuantity());
+        assertEquals(
+                List.of(new EquipmentCatalogueItemId("assembler.basic"), new EquipmentCatalogueItemId("assembler.fast")),
+                definition.availableEquipment());
+        assertEquals(400L, definition.deadline());
+        assertEquals("policy.contract-completion", definition.evaluationPolicy().id());
+
+        ChallengeDefinitionValidationResult validation = ChallengeDefinitionValidator.validate(definition);
+        assertTrue(validation.isValid(), () -> "expected content-valid definition, got: " + validation.issues());
+    }
+
+    @Test
+    void loadsADefinitionWithExplicitCatalogueIdentityAndFingerprint() {
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(VALID_WITH_CATALOGUE_IDENTITY);
+
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+        ChallengeDefinition definition = result.definition();
+        assertEquals("catalogue.core", definition.catalogueIdentity().id());
+        assertEquals("3", definition.catalogueIdentity().version());
+        assertEquals("fp-abc123", definition.catalogueSemanticFingerprint());
+    }
+
+    @Test
+    void isDeterministicAcrossRepeatedLoads() {
+        ChallengeContentLoadResult first = ChallengeContentLoader.load(VALID_MINIMAL);
+        ChallengeContentLoadResult second = ChallengeContentLoader.load(VALID_MINIMAL);
+        assertEquals(first.definition(), second.definition());
+    }
+
+    @Test
+    void rejectsMalformedJsonAsAContentIssueNotAnException() {
+        ChallengeContentLoadResult result = ChallengeContentLoader.load("{ not json");
+
+        assertFalse(result.isSuccess());
+        assertEquals(1, result.issues().size());
+        assertEquals("content.malformed-json", result.issues().get(0).code());
+    }
+
+    @Test
+    void rejectsNonObjectRoot() {
+        ChallengeContentLoadResult result = ChallengeContentLoader.load("[1, 2, 3]");
+
+        assertFalse(result.isSuccess());
+        assertEquals("content.root.not-object", result.issues().get(0).code());
+    }
+
+    @Test
+    void rejectsNullSource() {
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(null);
+
+        assertFalse(result.isSuccess());
+        assertEquals("content.source.null", result.issues().get(0).code());
+    }
+
+    @Test
+    void reportsEveryMissingRequiredFieldInOnePass() {
+        ChallengeContentLoadResult result = ChallengeContentLoader.load("{}");
+
+        assertFalse(result.isSuccess());
+        List<String> codes = result.issues().stream().map(ChallengeContentIssue::code).toList();
+        List<String> paths = result.issues().stream().map(ChallengeContentIssue::path).toList();
+        assertTrue(codes.stream().allMatch("content.field.missing"::equals));
+        assertTrue(paths.contains("identity"));
+        assertTrue(paths.contains("floor"));
+        assertTrue(paths.contains("startingBudget"));
+        assertTrue(paths.contains("workload"));
+        assertTrue(paths.contains("deadline"));
+        assertTrue(paths.contains("evaluationPolicy"));
+    }
+
+    @Test
+    void rejectsMistypedFields() {
+        String source = """
+                {
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": "wide", "height": 8},
+                  "startingBudget": "lots",
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "availableEquipment": "not-an-array",
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        List<String> paths = result.issues().stream().map(ChallengeContentIssue::path).toList();
+        assertTrue(paths.contains("floor.width"));
+        assertTrue(paths.contains("startingBudget"));
+        assertTrue(paths.contains("availableEquipment"));
+    }
+
+    @Test
+    void rejectsNonIntegerNumericFields() {
+        String source = """
+                {
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4.5, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream().anyMatch(i -> i.path().equals("floor.width")));
+    }
+
+    @Test
+    void rejectsMistypedAvailableEquipmentElements() {
+        String source = """
+                {
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "availableEquipment": ["ok", 5],
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream().anyMatch(i -> i.path().equals("availableEquipment[1]")));
+    }
+
+    @Test
+    void loadingSucceedsButValidatorCatchesContentInvalidValues() {
+        String source = """
+                {
+                  "identity": {"id": "", "version": "1"},
+                  "floor": {"width": -1, "height": 8},
+                  "startingBudget": -5,
+                  "workload": {"productReference": "widget", "requiredQuantity": 0},
+                  "deadline": 0,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertTrue(result.isSuccess(), () -> "structural decoding should succeed: " + result.issues());
+        ChallengeDefinitionValidationResult validation = ChallengeDefinitionValidator.validate(result.definition());
+        assertFalse(validation.isValid());
+        assertTrue(validation.issues().size() >= 5);
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
@@ -323,4 +323,171 @@ class ChallengeContentLoaderTest {
         assertTrue(result.issues().stream()
                 .anyMatch(i -> i.code().equals("content.field.missing") && i.path().equals("schemaVersion")));
     }
+
+    private static final String VALID_CAPACITY_COST_TRADEOFF = """
+            {
+              "schemaVersion": "challenge-content:v1",
+              "identity": {"id": "capacity-cost-tradeoff", "version": "1"},
+              "floor": {"width": 14, "height": 12},
+              "startingBudget": 20000,
+              "workload": {"productReference": "widget", "requiredQuantity": 500},
+              "availableEquipment": ["assembler.basic", "assembler.fast", "assembler.premium"],
+              "deadline": 1000,
+              "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+            }
+            """;
+
+    private static final String VALID_TIGHT_DEADLINE = """
+            {
+              "schemaVersion": "challenge-content:v1",
+              "identity": {"id": "tight-deadline", "version": "1"},
+              "floor": {"width": 8, "height": 8},
+              "startingBudget": 3000,
+              "workload": {"productReference": "gizmo", "requiredQuantity": 12},
+              "availableEquipment": ["assembler.basic"],
+              "deadline": 60,
+              "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+            }
+            """;
+
+    private static final String VALID_LARGE_FLOOR_BOTTLENECK = """
+            {
+              "schemaVersion": "challenge-content:v1",
+              "identity": {"id": "bottleneck-relief", "version": "3"},
+              "floor": {"width": 30, "height": 24},
+              "startingBudget": 75000,
+              "workload": {"productReference": "widget-pro", "requiredQuantity": 2000},
+              "availableEquipment": ["assembler.basic", "assembler.fast", "packer.standard"],
+              "deadline": 5000,
+              "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+            }
+            """;
+
+    @Test
+    void loadsMultipleDistinctChallengeDefinitionsThroughTheSameContentPath() {
+        List<String> sources = List.of(
+                VALID_MINIMAL,
+                VALID_WITH_CATALOGUE_IDENTITY,
+                VALID_CAPACITY_COST_TRADEOFF,
+                VALID_TIGHT_DEADLINE,
+                VALID_LARGE_FLOOR_BOTTLENECK);
+
+        List<ChallengeDefinition> definitions = sources.stream()
+                .map(ChallengeContentLoader::load)
+                .map(result -> {
+                    assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+                    return result.definition();
+                })
+                .toList();
+
+        // Every fixture loads through the same ChallengeContentLoader.load(...) entry point yet
+        // produces a distinct, content-valid ChallengeDefinition with meaningfully varied floor
+        // size, budget, deadline, workload quantity, and equipment set.
+        assertEquals(5, definitions.stream().map(ChallengeDefinition::identity).distinct().count());
+        assertEquals(
+                5,
+                definitions.stream()
+                        .map(d -> d.floor().width() + "x" + d.floor().height())
+                        .distinct()
+                        .count());
+        assertEquals(5, definitions.stream().map(ChallengeDefinition::startingBudget).distinct().count());
+        assertEquals(5, definitions.stream().map(ChallengeDefinition::deadline).distinct().count());
+        assertEquals(
+                5,
+                definitions.stream()
+                        .map(d -> d.workload().requiredQuantity())
+                        .distinct()
+                        .count());
+
+        for (ChallengeDefinition definition : definitions) {
+            ChallengeDefinitionValidationResult validation = ChallengeDefinitionValidator.validate(definition);
+            assertTrue(validation.isValid(), () -> "expected content-valid definition, got: " + validation.issues());
+        }
+    }
+
+    private static final String CATALOGUE_CORE = """
+            {
+              "schemaVersion": "equipment-catalogue:v1",
+              "identity": {"id": "catalogue.core", "version": "1"},
+              "offers": [
+                {"itemId": "assembler.basic", "purchaseCostCredits": 500},
+                {"itemId": "assembler.fast", "purchaseCostCredits": 900, "quantityLimit": 2}
+              ]
+            }
+            """;
+
+    @Test
+    void loadsChallengeWithCatalogueWhenEveryReferenceResolves() {
+        ChallengeWithCatalogueLoadResult result =
+                ChallengeContentLoader.loadChallengeWithCatalogue(VALID_MINIMAL, CATALOGUE_CORE);
+
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+        assertEquals("bottleneck-101", result.definition().identity().id());
+        assertEquals("catalogue.core", result.catalogue().identity().id());
+    }
+
+    @Test
+    void rejectsChallengeWithCatalogueWhenAnAvailableEquipmentReferenceIsUnknown() {
+        String challengeWithUnknownReference = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "bottleneck-101", "version": "1"},
+                  "floor": {"width": 10, "height": 8},
+                  "startingBudget": 5000,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "availableEquipment": ["assembler.basic", "assembler.unknown"],
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeWithCatalogueLoadResult result = ChallengeContentLoader.loadChallengeWithCatalogue(
+                challengeWithUnknownReference, CATALOGUE_CORE);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("catalogue.challenge.availableEquipment.unresolved")
+                        && i.path().equals("availableEquipment[1]")));
+    }
+
+    @Test
+    void rejectsChallengeWithCatalogueWhenCatalogueItselfHasDuplicateItemIds() {
+        String catalogueWithDuplicates = """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": [
+                    {"itemId": "assembler.basic", "purchaseCostCredits": 500},
+                    {"itemId": "assembler.basic", "purchaseCostCredits": 600}
+                  ]
+                }
+                """;
+
+        ChallengeWithCatalogueLoadResult result =
+                ChallengeContentLoader.loadChallengeWithCatalogue(VALID_MINIMAL, catalogueWithDuplicates);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream().anyMatch(i -> i.code().equals("catalogue.offers.itemId.duplicate")));
+    }
+
+    @Test
+    void rejectsChallengeWithCatalogueWhenTheDefinitionItselfIsContentInvalid() {
+        String invalidChallenge = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": -5,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeWithCatalogueLoadResult result =
+                ChallengeContentLoader.loadChallengeWithCatalogue(invalidChallenge, CATALOGUE_CORE);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream().anyMatch(i -> i.code().startsWith("definition.")));
+    }
 }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
@@ -693,6 +693,64 @@ class ChallengeContentLoaderTest {
                         && i.path().equals("catalogueSemanticFingerprint")));
     }
 
+    // --- REV-001: a catalogueSemanticFingerprint supplied without a catalogueIdentity is an
+    // incomplete/invalid partial binding and must fail as a structured issue, not silently drop
+    // the fingerprint or throw a NullPointerException from loadChallengeWithCatalogue. ---
+
+    @Test
+    void rejectsCatalogueSemanticFingerprintWithoutCatalogueIdentityAsAStructuredIssue() {
+        String source = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"},
+                  "catalogueSemanticFingerprint": "fp-abc123"
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.catalogueIdentity.missing-for-fingerprint")
+                        && i.path().equals("catalogueIdentity")));
+    }
+
+    @Test
+    void loadChallengeWithCatalogueRejectsFingerprintWithoutCatalogueIdentityInsteadOfThrowing() {
+        String challengeSource = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"},
+                  "catalogueSemanticFingerprint": "fp-abc123"
+                }
+                """;
+        String catalogueSource = """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": []
+                }
+                """;
+
+        ChallengeWithCatalogueLoadResult result =
+                ChallengeContentLoader.loadChallengeWithCatalogue(challengeSource, catalogueSource);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.catalogueIdentity.missing-for-fingerprint")
+                        && i.path().equals("catalogueIdentity")));
+    }
+
     // --- Decoder error-branch coverage: mistyped nested values and accessor-misuse edge cases. ---
 
     @Test

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
@@ -15,6 +15,7 @@ class ChallengeContentLoaderTest {
 
     private static final String VALID_MINIMAL = """
             {
+              "schemaVersion": "challenge-content:v1",
               "identity": {"id": "bottleneck-101", "version": "1"},
               "floor": {"width": 10, "height": 8},
               "startingBudget": 5000,
@@ -27,6 +28,7 @@ class ChallengeContentLoaderTest {
 
     private static final String VALID_WITH_CATALOGUE_IDENTITY = """
             {
+              "schemaVersion": "challenge-content:v1",
               "identity": {"id": "budget-squeeze", "version": "2"},
               "floor": {"width": 6, "height": 6},
               "startingBudget": 1200,
@@ -187,6 +189,7 @@ class ChallengeContentLoaderTest {
     void loadingSucceedsButValidatorCatchesContentInvalidValues() {
         String source = """
                 {
+                  "schemaVersion": "challenge-content:v1",
                   "identity": {"id": "", "version": "1"},
                   "floor": {"width": -1, "height": 8},
                   "startingBudget": -5,
@@ -202,5 +205,122 @@ class ChallengeContentLoaderTest {
         ChallengeDefinitionValidationResult validation = ChallengeDefinitionValidator.validate(result.definition());
         assertFalse(validation.isValid());
         assertTrue(validation.issues().size() >= 5);
+    }
+
+    @Test
+    void rejectsMissingSchemaVersion() {
+        String source = """
+                {
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.missing") && i.path().equals("schemaVersion")));
+    }
+
+    @Test
+    void rejectsUnsupportedSchemaVersion() {
+        String source = """
+                {
+                  "schemaVersion": "challenge-content:v99",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertEquals("content.schemaVersion.unsupported", result.issues().get(0).code());
+        assertEquals("schemaVersion", result.issues().get(0).path());
+    }
+
+    @Test
+    void rejectsUnsupportedEvaluationPolicy() {
+        String source = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.unknown", "version": "7"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("evaluationPolicy.unsupported") && i.path().equals("evaluationPolicy")));
+    }
+
+    @Test
+    void loadsAValidCatalogue() {
+        String source = """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": [
+                    {"itemId": "assembler.basic", "purchaseCostCredits": 500},
+                    {"itemId": "assembler.fast", "purchaseCostCredits": 900, "quantityLimit": 2}
+                  ]
+                }
+                """;
+
+        EquipmentCatalogueContentLoadResult result = ChallengeContentLoader.loadCatalogue(source);
+
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+        assertEquals("catalogue.core", result.catalogue().identity().id());
+        assertEquals(2, result.catalogue().offers().size());
+    }
+
+    @Test
+    void rejectsCatalogueWithDuplicateItemIds() {
+        String source = """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": [
+                    {"itemId": "assembler.basic", "purchaseCostCredits": 500},
+                    {"itemId": "assembler.basic", "purchaseCostCredits": 600}
+                  ]
+                }
+                """;
+
+        EquipmentCatalogueContentLoadResult result = ChallengeContentLoader.loadCatalogue(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream().anyMatch(i -> i.code().equals("catalogue.offers.itemId.duplicate")));
+    }
+
+    @Test
+    void rejectsCatalogueMissingSchemaVersion() {
+        String source = """
+                {
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": []
+                }
+                """;
+
+        EquipmentCatalogueContentLoadResult result = ChallengeContentLoader.loadCatalogue(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.missing") && i.path().equals("schemaVersion")));
     }
 }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ChallengeContentLoaderTest.java
@@ -4,8 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import com.arcogine.challenge.ChallengeDefinition;
 import com.arcogine.challenge.EquipmentCatalogueItemId;
+import com.arcogine.challenge.admissibility.CandidateAdmissibilityPolicy;
+import com.arcogine.challenge.admissibility.CandidateAdmissibilityResult;
+import com.arcogine.challenge.admissibility.CandidateDraftSnapshot;
 import com.arcogine.challenge.validation.ChallengeDefinitionValidationResult;
 import com.arcogine.challenge.validation.ChallengeDefinitionValidator;
 import java.util.List;
@@ -489,5 +494,398 @@ class ChallengeContentLoaderTest {
 
         assertFalse(result.isSuccess());
         assertTrue(result.issues().stream().anyMatch(i -> i.code().startsWith("definition.")));
+    }
+
+    // --- REV-001: loadChallengeWithCatalogue must produce a definition that is genuinely
+    // provenance-compatible with CandidateAdmissibilityPolicy's own catalogue-identity and
+    // semantic-fingerprint checks, not just one that passes the loader's own narrower checks. ---
+
+    @Test
+    void loadChallengeWithCatalogueResultIsProvenanceCompatibleWithAdmissibility() {
+        ChallengeWithCatalogueLoadResult result =
+                ChallengeContentLoader.loadChallengeWithCatalogue(VALID_MINIMAL, CATALOGUE_CORE);
+
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+
+        CandidateDraftSnapshot emptyDraft = new CandidateDraftSnapshot(List.of());
+        CandidateAdmissibilityResult admissibility =
+                CandidateAdmissibilityPolicy.assess(result.definition(), result.catalogue(), emptyDraft);
+
+        // An empty draft has no candidate-specific issues (no occurrences, no budget spend), so a
+        // rejection here could only be a catalogue-provenance rejection -- exactly what C2
+        // independently checks and what this loader must have already ruled out.
+        assertTrue(admissibility.admitted(),
+                () -> "expected the loaded definition/catalogue pair to be provenance-compatible "
+                        + "with CandidateAdmissibilityPolicy, got: " + admissibility.issues());
+    }
+
+    @Test
+    void rejectsChallengeWithCatalogueWhenExplicitCatalogueIdentityMismatchesTheResolvedCatalogue() {
+        ChallengeWithCatalogueLoadResult result =
+                ChallengeContentLoader.loadChallengeWithCatalogue(VALID_WITH_CATALOGUE_IDENTITY, CATALOGUE_CORE);
+
+        // VALID_WITH_CATALOGUE_IDENTITY declares catalogueIdentity {"id": "catalogue.core",
+        // "version": "3"}; CATALOGUE_CORE's actual identity is {"catalogue.core", "1"} -- an
+        // explicit, mismatched assertion that must be rejected rather than silently accepted.
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.catalogue.identity-mismatch")
+                        && i.path().equals("catalogueIdentity")));
+    }
+
+    @Test
+    void rejectsChallengeWithCatalogueWhenExplicitFingerprintMismatchesTheResolvedCatalogue() {
+        String challengeWithMatchingIdentityButWrongFingerprint = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "bottleneck-101", "version": "1"},
+                  "floor": {"width": 10, "height": 8},
+                  "startingBudget": 5000,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "availableEquipment": [],
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"},
+                  "catalogueIdentity": {"id": "catalogue.core", "version": "1"},
+                  "catalogueSemanticFingerprint": "definitely-not-the-real-fingerprint"
+                }
+                """;
+
+        ChallengeWithCatalogueLoadResult result = ChallengeContentLoader.loadChallengeWithCatalogue(
+                challengeWithMatchingIdentityButWrongFingerprint, CATALOGUE_CORE);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.catalogue.semantic-fingerprint-mismatch")
+                        && i.path().equals("catalogueSemanticFingerprint")));
+    }
+
+    // --- REV-002: integer-looking JSON numbers must decode exactly, not round-trip through
+    // double (which silently loses precision above 2^53 and can saturate outside int/long). ---
+
+    private static String minimalWithStartingBudget(String budgetLiteral) {
+        return """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": %s,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """
+                .formatted(budgetLiteral);
+    }
+
+    @Test
+    void decodesIntegerLiteralsAboveDoublePrecisionExactly() {
+        // 2^53 + 1 = 9007199254740993 cannot be represented exactly as a double.
+        ChallengeContentLoadResult result =
+                ChallengeContentLoader.load(minimalWithStartingBudget("9007199254740993"));
+
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+        assertEquals(9007199254740993L, result.definition().startingBudget());
+    }
+
+    @Test
+    void decodesLongMaxValueExactlyAtTheBoundary() {
+        ChallengeContentLoadResult result =
+                ChallengeContentLoader.load(minimalWithStartingBudget(String.valueOf(Long.MAX_VALUE)));
+
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+        assertEquals(Long.MAX_VALUE, result.definition().startingBudget());
+    }
+
+    @Test
+    void rejectsAnIntegerLiteralOnePastLongMaxValueAsOutOfRangeRatherThanSaturating() {
+        java.math.BigInteger onePastLongMax =
+                java.math.BigInteger.valueOf(Long.MAX_VALUE).add(java.math.BigInteger.ONE);
+        ChallengeContentLoadResult result =
+                ChallengeContentLoader.load(minimalWithStartingBudget(onePastLongMax.toString()));
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.out-of-range") && i.path().equals("startingBudget")));
+    }
+
+    private static String minimalWithFloorWidth(String widthLiteral) {
+        return """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": %s, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """
+                .formatted(widthLiteral);
+    }
+
+    @Test
+    void decodesIntegerMaxValueExactlyAtTheBoundary() {
+        ChallengeContentLoadResult result =
+                ChallengeContentLoader.load(minimalWithFloorWidth(String.valueOf(Integer.MAX_VALUE)));
+
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+        assertEquals(Integer.MAX_VALUE, result.definition().floor().width());
+    }
+
+    @Test
+    void rejectsAnIntegerLiteralOnePastIntegerMaxValueAsOutOfRangeRatherThanSaturating() {
+        long onePastIntMax = ((long) Integer.MAX_VALUE) + 1L;
+        ChallengeContentLoadResult result =
+                ChallengeContentLoader.load(minimalWithFloorWidth(String.valueOf(onePastIntMax)));
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.out-of-range") && i.path().equals("floor.width")));
+    }
+
+    @Test
+    void rejectsAnOfferQuantityLimitOnePastIntegerMaxValue() {
+        long onePastIntMax = ((long) Integer.MAX_VALUE) + 1L;
+        String source =
+                """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": [
+                    {"itemId": "assembler.basic", "purchaseCostCredits": 500, "quantityLimit": %s}
+                  ]
+                }
+                """
+                        .formatted(onePastIntMax);
+
+        EquipmentCatalogueContentLoadResult result = ChallengeContentLoader.loadCatalogue(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.out-of-range")
+                        && i.path().equals("offers[0].quantityLimit")));
+    }
+
+    // --- REV-003: a blank (but present) catalogueSemanticFingerprint must fail as a structured
+    // issue, not reach ChallengeDefinition's constructor and throw IllegalArgumentException. ---
+
+    @Test
+    void rejectsBlankCatalogueSemanticFingerprintAsAStructuredIssueNotAThrownException() {
+        String source = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"},
+                  "catalogueIdentity": {"id": "catalogue.core", "version": "1"},
+                  "catalogueSemanticFingerprint": " "
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.blank")
+                        && i.path().equals("catalogueSemanticFingerprint")));
+    }
+
+    // --- Decoder error-branch coverage: mistyped nested values and accessor-misuse edge cases. ---
+
+    @Test
+    void rejectsNonStringIdentityIdField() {
+        String source = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": 5, "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.type") && i.path().equals("identity.id")));
+    }
+
+    @Test
+    void rejectsNonObjectIdentityField() {
+        String source = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": "not-an-object",
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.type") && i.path().equals("identity")));
+    }
+
+    @Test
+    void rejectsNonObjectCatalogueIdentityField() {
+        String source = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"},
+                  "catalogueIdentity": "not-an-object"
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.type") && i.path().equals("catalogueIdentity")));
+    }
+
+    @Test
+    void rejectsNonStringCatalogueSemanticFingerprintField() {
+        String source = """
+                {
+                  "schemaVersion": "challenge-content:v1",
+                  "identity": {"id": "x", "version": "1"},
+                  "floor": {"width": 4, "height": 8},
+                  "startingBudget": 100,
+                  "workload": {"productReference": "widget", "requiredQuantity": 20},
+                  "deadline": 400,
+                  "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"},
+                  "catalogueSemanticFingerprint": 12345
+                }
+                """;
+
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.type") && i.path().equals("catalogueSemanticFingerprint")));
+    }
+
+    @Test
+    void rejectsNonArrayOffersField() {
+        String source = """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": "not-an-array"
+                }
+                """;
+
+        EquipmentCatalogueContentLoadResult result = ChallengeContentLoader.loadCatalogue(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.type") && i.path().equals("offers")));
+    }
+
+    @Test
+    void rejectsNonObjectOfferElement() {
+        String source = """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": ["not-an-object"]
+                }
+                """;
+
+        EquipmentCatalogueContentLoadResult result = ChallengeContentLoader.loadCatalogue(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.type") && i.path().equals("offers[0]")));
+    }
+
+    @Test
+    void rejectsMissingOffersField() {
+        String source = """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"}
+                }
+                """;
+
+        EquipmentCatalogueContentLoadResult result = ChallengeContentLoader.loadCatalogue(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.missing") && i.path().equals("offers")));
+    }
+
+    @Test
+    void rejectsNonLongOfferPurchaseCostCredits() {
+        String source = """
+                {
+                  "schemaVersion": "equipment-catalogue:v1",
+                  "identity": {"id": "catalogue.core", "version": "1"},
+                  "offers": [
+                    {"itemId": "assembler.basic", "purchaseCostCredits": 4.5}
+                  ]
+                }
+                """;
+
+        EquipmentCatalogueContentLoadResult result = ChallengeContentLoader.loadCatalogue(source);
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.issues().stream()
+                .anyMatch(i -> i.code().equals("content.field.type")
+                        && i.path().equals("offers[0].purchaseCostCredits")));
+    }
+
+    @Test
+    void successfulLoadResultHasNoIssuesAndFailedLoadResultHasNoDefinition() {
+        ChallengeContentLoadResult success = ChallengeContentLoader.load(VALID_MINIMAL);
+        assertTrue(success.issues().isEmpty());
+        assertTrue(success.isSuccess());
+
+        ChallengeContentLoadResult failure = ChallengeContentLoader.load("{}");
+        assertNull(failure.definition());
+        assertFalse(failure.isSuccess());
+        assertFalse(failure.issues().isEmpty());
+    }
+
+    @Test
+    void successfulCatalogueLoadResultHasNoIssuesAndFailedResultHasNoCatalogue() {
+        EquipmentCatalogueContentLoadResult success = ChallengeContentLoader.loadCatalogue(CATALOGUE_CORE);
+        assertTrue(success.issues().isEmpty());
+        assertTrue(success.isSuccess());
+
+        EquipmentCatalogueContentLoadResult failure = ChallengeContentLoader.loadCatalogue("{}");
+        assertNull(failure.catalogue());
+        assertFalse(failure.isSuccess());
+        assertFalse(failure.issues().isEmpty());
+    }
+
+    @Test
+    void successfulAggregateLoadResultHasNoIssuesAndFailedResultHasNoDefinitionOrCatalogue() {
+        ChallengeWithCatalogueLoadResult success =
+                ChallengeContentLoader.loadChallengeWithCatalogue(VALID_MINIMAL, CATALOGUE_CORE);
+        assertTrue(success.issues().isEmpty());
+        assertTrue(success.isSuccess());
+
+        ChallengeWithCatalogueLoadResult failure = ChallengeContentLoader.loadChallengeWithCatalogue("{}", "{}");
+        assertNull(failure.definition());
+        assertNull(failure.catalogue());
+        assertFalse(failure.isSuccess());
+        assertFalse(failure.issues().isEmpty());
     }
 }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ContentDrivenAttemptComparisonTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/ContentDrivenAttemptComparisonTest.java
@@ -1,0 +1,103 @@
+package com.arcogine.challenge.content;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.ChallengeDefinition;
+import com.arcogine.challenge.admissibility.CandidateDraftSnapshot;
+import com.arcogine.challenge.admissibility.EquipmentOccurrenceId;
+import com.arcogine.challenge.admissibility.GridPlacement;
+import com.arcogine.challenge.admissibility.PlacedEquipment;
+import com.arcogine.challenge.attempt.ChallengeAttempt;
+import com.arcogine.challenge.comparison.AttemptComparison;
+import com.arcogine.challenge.comparison.AttemptComparisonWinner;
+import com.arcogine.challenge.comparison.ChallengeAttemptComparator;
+import com.arcogine.challenge.economics.DraftEconomics;
+import com.arcogine.challenge.evaluation.AuthoritativeOutcomeFacts;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationInput;
+import com.arcogine.challenge.evaluation.ChallengeEvaluationResult;
+import com.arcogine.challenge.evaluation.EvaluationProvenance;
+import com.arcogine.challenge.evaluation.ReferenceChallengeEvaluationPolicy;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves that C4's attempt/comparison contract composes correctly with C5 data-driven content:
+ * a {@link ChallengeDefinition} loaded through {@link ChallengeContentLoader} feeds two {@link
+ * ChallengeAttempt} instances with different outcomes, and {@link ChallengeAttemptComparator}
+ * ranks them deterministically without depending on attempt identity.
+ *
+ * <p>This is not a new C4 feature: it reuses the existing attempt/comparison types exactly as
+ * {@code ChallengeAttemptComparatorTest} does, but derives the challenge definition from the C5
+ * content path instead of a hand-built fixture.
+ */
+class ContentDrivenAttemptComparisonTest {
+
+    private static final String LOADED_CHALLENGE = """
+            {
+              "schemaVersion": "challenge-content:v1",
+              "identity": {"id": "content-driven-comparison", "version": "1"},
+              "floor": {"width": 10, "height": 8},
+              "startingBudget": 40000,
+              "workload": {"productReference": "widget", "requiredQuantity": 20},
+              "availableEquipment": ["equipment.cutter"],
+              "deadline": 400,
+              "evaluationPolicy": {"id": "policy.contract-completion", "version": "1"}
+            }
+            """;
+
+    @Test
+    void loadedContentFeedsDeterministicAttemptComparison() {
+        ChallengeDefinition challenge = loadDefinition();
+
+        // earlyCheaper: margin 50, unused budget 30,000, score 30,051.
+        // lateCostlier: margin 10, unused budget 28,000, score 28,011 -- earlier completion and
+        // lower construction cost score higher under the shared policy's own score ordering.
+        ChallengeAttempt earlyCheaper = attempt(challenge, 350L, 10_000L);
+        ChallengeAttempt lateCostlier = attempt(challenge, 390L, 12_000L);
+
+        AttemptComparison first = ChallengeAttemptComparator.compare(earlyCheaper, lateCostlier).comparison();
+        AttemptComparison second = ChallengeAttemptComparator.compare(earlyCheaper, lateCostlier).comparison();
+
+        assertEquals(first, second);
+        assertEquals(AttemptComparisonWinner.FIRST, first.winner());
+        assertTrue(first.firstSuccessful());
+        assertTrue(first.secondSuccessful());
+    }
+
+    @Test
+    void attemptIdentityDoesNotInfluenceContentDrivenComparison() {
+        ChallengeDefinition challenge = loadDefinition();
+
+        ChallengeAttempt earlyCheaperA = attempt(challenge, 350L, 10_000L);
+        ChallengeAttempt lateCostlierA = attempt(challenge, 390L, 12_000L);
+        ChallengeAttempt earlyCheaperB = attempt(challenge, 350L, 10_000L);
+        ChallengeAttempt lateCostlierB = attempt(challenge, 390L, 12_000L);
+
+        assertNotEquals(earlyCheaperA.id(), earlyCheaperB.id());
+        assertNotEquals(lateCostlierA.id(), lateCostlierB.id());
+        assertEquals(ChallengeAttemptComparator.compare(earlyCheaperA, lateCostlierA).comparison(),
+                ChallengeAttemptComparator.compare(earlyCheaperB, lateCostlierB).comparison());
+    }
+
+    private static ChallengeDefinition loadDefinition() {
+        ChallengeContentLoadResult result = ChallengeContentLoader.load(LOADED_CHALLENGE);
+        assertTrue(result.isSuccess(), () -> "expected success, got issues: " + result.issues());
+        return result.definition();
+    }
+
+    private static ChallengeAttempt attempt(ChallengeDefinition challenge, long completionTick, long cost) {
+        EvaluationProvenance provenance =
+                new EvaluationProvenance("model.content-driven:v1", "run.content-driven:historical-1");
+        ChallengeEvaluationInput input = new ChallengeEvaluationInput(
+                challenge, provenance, new AuthoritativeOutcomeFacts(true, completionTick), cost);
+        ChallengeEvaluationResult result = ReferenceChallengeEvaluationPolicy.evaluate(input);
+
+        CandidateDraftSnapshot snapshot = new CandidateDraftSnapshot(List.of(new PlacedEquipment(
+                new EquipmentOccurrenceId("cutter-1"), challenge.availableEquipment().get(0),
+                new GridPlacement(0, 0))));
+        DraftEconomics economics = new DraftEconomics(challenge.startingBudget(), cost, challenge.startingBudget() - cost);
+        return ChallengeAttempt.record(snapshot, economics, result);
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/EvaluationPolicyResolverTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/EvaluationPolicyResolverTest.java
@@ -1,0 +1,42 @@
+package com.arcogine.challenge.content;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.challenge.EvaluationPolicyIdentity;
+import com.arcogine.challenge.evaluation.ReferenceChallengeEvaluationPolicy;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class EvaluationPolicyResolverTest {
+
+    private static final EvaluationPolicyIdentity SUPPORTED = new EvaluationPolicyIdentity(
+            ReferenceChallengeEvaluationPolicy.POLICY_ID, ReferenceChallengeEvaluationPolicy.POLICY_VERSION);
+
+    @Test
+    void supportsTheReferencePolicyIdentity() {
+        assertTrue(EvaluationPolicyResolver.isSupported(SUPPORTED));
+        assertEquals(Optional.empty(), EvaluationPolicyResolver.resolve(SUPPORTED));
+    }
+
+    @Test
+    void rejectsAnUnknownPolicyId() {
+        EvaluationPolicyIdentity unknown = new EvaluationPolicyIdentity("policy.unknown", "1");
+
+        assertFalse(EvaluationPolicyResolver.isSupported(unknown));
+        Optional<ChallengeContentIssue> issue = EvaluationPolicyResolver.resolve(unknown, "evaluationPolicy");
+        assertTrue(issue.isPresent());
+        assertEquals("evaluationPolicy.unsupported", issue.get().code());
+        assertEquals("evaluationPolicy", issue.get().path());
+    }
+
+    @Test
+    void rejectsAKnownPolicyIdWithAnUnknownVersion() {
+        EvaluationPolicyIdentity wrongVersion =
+                new EvaluationPolicyIdentity(ReferenceChallengeEvaluationPolicy.POLICY_ID, "99");
+
+        assertFalse(EvaluationPolicyResolver.isSupported(wrongVersion));
+        assertTrue(EvaluationPolicyResolver.resolve(wrongVersion).isPresent());
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
@@ -110,6 +110,17 @@ class JsonTest {
     }
 
     @Test
+    void rejectsNonAsciiUnicodeDigits() {
+        // Arabic-indic digit one (U+0661): Character.isDigit(...) accepts it, but JSON's number
+        // grammar permits only ASCII 0-9.
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("١"));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("٠١"));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("1١"));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("1.١"));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("1e١"));
+    }
+
+    @Test
     void rejectsNonJsonWhitespaceBetweenTokens() {
         // Form feed (0x0C) is Java whitespace but not JSON insignificant whitespace.
         assertThrows(JsonSyntaxException.class, () -> Json.parse("{\"a\":\f1}"));

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
@@ -1,0 +1,60 @@
+package com.arcogine.challenge.content;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JsonTest {
+
+    @Test
+    void parsesNestedObjectsArraysAndScalars() throws JsonSyntaxException {
+        Object result = Json.parse(
+                "{\"a\": 1, \"b\": [1, 2.5, \"x\", true, false, null], \"c\": {\"d\": \"e\"}}");
+
+        assertTrue(result instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) result;
+        assertEquals(1.0, map.get("a"));
+        assertEquals(List.of(1.0, 2.5, "x", true, false), ((List<?>) map.get("b")).subList(0, 5));
+        assertNull(((List<?>) map.get("b")).get(5));
+        assertEquals("e", ((Map<?, ?>) map.get("c")).get("d"));
+    }
+
+    @Test
+    void parsesEscapedStrings() throws JsonSyntaxException {
+        Object result = Json.parse("\"a\\n\\t\\\"\\\\b\\u0041\"");
+        assertEquals("a\n\t\"\\bA", result);
+    }
+
+    @Test
+    void rejectsTrailingContent() {
+        JsonSyntaxException e = assertThrows(JsonSyntaxException.class, () -> Json.parse("{} garbage"));
+        assertTrue(e.getMessage().contains("trailing"));
+    }
+
+    @Test
+    void rejectsUnterminatedObject() {
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("{\"a\": 1"));
+    }
+
+    @Test
+    void rejectsInvalidLiteral() {
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("nul"));
+    }
+
+    @Test
+    void rejectsNullSource() {
+        assertThrows(JsonSyntaxException.class, () -> Json.parse(null));
+    }
+
+    @Test
+    void parsesEmptyObjectAndArray() throws JsonSyntaxException {
+        assertEquals(Map.of(), Json.parse("{}"));
+        assertEquals(List.of(), Json.parse("[]"));
+    }
+}

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
@@ -19,8 +19,8 @@ class JsonTest {
         assertTrue(result instanceof Map);
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) result;
-        assertEquals(1.0, map.get("a"));
-        assertEquals(List.of(1.0, 2.5, "x", true, false), ((List<?>) map.get("b")).subList(0, 5));
+        assertEquals(1L, map.get("a"));
+        assertEquals(List.of(1L, 2.5, "x", true, false), ((List<?>) map.get("b")).subList(0, 5));
         assertNull(((List<?>) map.get("b")).get(5));
         assertEquals("e", ((Map<?, ?>) map.get("c")).get("d"));
     }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
@@ -57,4 +57,29 @@ class JsonTest {
         assertEquals(Map.of(), Json.parse("{}"));
         assertEquals(List.of(), Json.parse("[]"));
     }
+
+    @Test
+    void rejectsLeadingZeroInteger() {
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("01"));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("-01"));
+    }
+
+    @Test
+    void acceptsValidZeroLedNumericLiterals() throws JsonSyntaxException {
+        assertEquals(0L, Json.parse("0"));
+        assertEquals(0.5, Json.parse("0.5"));
+        assertEquals(0L, Json.parse("-0"));
+    }
+
+    @Test
+    void rejectsRawControlCharacterInString() {
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("\"a\nb\""));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("\"a\tb\""));
+    }
+
+    @Test
+    void acceptsEscapedControlCharactersInString() throws JsonSyntaxException {
+        assertEquals("a\nb", Json.parse("\"a\\nb\""));
+        assertEquals("a\tb", Json.parse("\"a\\tb\""));
+    }
 }

--- a/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
+++ b/product/consumer/challenge/src/test/java/com/arcogine/challenge/content/JsonTest.java
@@ -82,4 +82,42 @@ class JsonTest {
         assertEquals("a\nb", Json.parse("\"a\\nb\""));
         assertEquals("a\tb", Json.parse("\"a\\tb\""));
     }
+
+    @Test
+    void rejectsANumberMissingADigitBeforeTheDecimalPoint() {
+        assertThrows(JsonSyntaxException.class, () -> Json.parse(".5"));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("-.5"));
+    }
+
+    @Test
+    void rejectsANumberMissingADigitAfterTheDecimalPoint() {
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("1."));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("-1."));
+    }
+
+    @Test
+    void rejectsANumberMissingADigitInTheExponent() {
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("1e"));
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("1e+"));
+    }
+
+    @Test
+    void acceptsWellFormedFractionalAndExponentialNumbers() throws JsonSyntaxException {
+        assertEquals(1.5, Json.parse("1.5"));
+        assertEquals(-1.5, Json.parse("-1.5"));
+        assertEquals(1.0e10, Json.parse("1e10"));
+        assertEquals(1.5e-3, Json.parse("1.5e-3"));
+    }
+
+    @Test
+    void rejectsNonJsonWhitespaceBetweenTokens() {
+        // Form feed (0x0C) is Java whitespace but not JSON insignificant whitespace.
+        assertThrows(JsonSyntaxException.class, () -> Json.parse("{\"a\":\f1}"));
+    }
+
+    @Test
+    void acceptsAllJsonInsignificantWhitespaceBetweenTokens() throws JsonSyntaxException {
+        Object result = Json.parse("{ \t\r\n\"a\"\t\r\n:\t\r\n1\t\r\n}");
+        assertEquals(Map.of("a", 1L), result);
+    }
 }

--- a/product/settings.gradle.kts
+++ b/product/settings.gradle.kts
@@ -9,6 +9,7 @@ include(
     "finance",
     "agents",
     "challenge",
+    "challenge-factory-integration-test",
     "api",
     "cli",
 )
@@ -17,6 +18,7 @@ project(":factory").projectDir = file("domains/factory")
 project(":economy").projectDir = file("domains/economy")
 project(":finance").projectDir = file("domains/finance")
 project(":challenge").projectDir = file("consumer/challenge")
+project(":challenge-factory-integration-test").projectDir = file("consumer/challenge-factory-integration-test")
 
 project(":api").projectDir = file("interfaces/api")
 project(":cli").projectDir = file("interfaces/cli")


### PR DESCRIPTION
## Summary
- Adds the C5 game-owned JSON content-loading layer for challenges and equipment catalogues (`com.arcogine.challenge.content`): schema-versioned decode, reuse of existing `ChallengeDefinitionValidator`/`EquipmentCatalogueValidator`, and `EvaluationPolicyResolver`.
- Adds a new test-only Gradle module, `consumer/challenge-factory-integration-test`, with `CanonicalExecutableButChallengeInadmissibleTest`, proving C5 acceptance criterion 6: a structurally valid Factory model (accepted by `:factory`'s `FactoryModelValidator`) has a corresponding candidate draft rejected by `:challenge`'s `CandidateAdmissibilityPolicy` purely for exceeding the challenge's credit budget. Neither `:factory` nor `:challenge` gains a production dependency on the other.
- Updates `docs/planning/factory-design-game-challenge-readiness.md` with an honest C5 implementation-status subsection (what's proven vs. still open) and corrects C4's stale "C5 remains deferred" note; updates `docs/architecture/overview.md`'s `:challenge` module description.

## Test plan
- [x] `cd product && ./gradlew.bat compileJava compileTestJava checkstyleMain checkstyleTest test jacocoTestReport jacocoTestCoverageVerification` -- BUILD SUCCESSFUL (full multi-module build)
- [x] New `CanonicalExecutableButChallengeInadmissibleTest` passes
- [x] Pre-existing `CandidateAdmissibilityPolicyTest` / `ReferenceChallengeEvaluationPolicyTest` / `ChallengeAttemptComparatorTest` continue to pass, already covering C5 ACs 3/4 candidate-admissibility and evaluation-determinism boundaries