### PR TITLE
docs(adr): capture architecture convergence decisions

### DIFF
--- a/docs/architecture/decisions/0014-factory-model-semantic-policy-evolution.md
+++ b/docs/architecture/decisions/0014-factory-model-semantic-policy-evolution.md
@@ -1,0 +1,146 @@
+# ADR-0014: Factory Model Semantic-Policy Evolution
+
+Status: Proposed
+Date: 2026-09-02
+
+## Context
+
+Arcogine's released `factory-model:v1` fingerprint policy is immutable under
+[ADR-0006](0006-durable-semantic-fingerprint-contract.md). That policy identifies the
+current canonical factory semantics and is already used by controlled revision history,
+historical semantic-state reconstruction, runtime provenance, and downstream consumers.
+
+Engine Gate 5 introduces behaviorally relevant spatial semantics. The maintained Factory
+Design and Engine plans already place stable layout inputs on the canonical model side and
+changing transfer consequences on the simulation-runtime side. In particular, moving a
+resource is intended to change transfer behavior without changing the resource's identity.
+
+`factory-model:v1` does not encode the spatial facts required for that contract. Extending
+its canonical bytes in place would break the immutability and historical reproducibility
+promise of ADR-0006. Keeping those facts outside durable semantic identity would create the
+opposite problem: two behaviorally different authored factory designs could share one
+`ModelFingerprint`.
+
+The first mature model-policy evolution therefore needs an explicit contract for how a
+released canonical semantic artifact gains new behaviorally relevant authored facts without
+rewriting historical identity.
+
+This ADR is intentionally limited to authored Factory semantic-policy evolution. It does not
+decide the Engine-owned interpretation rules that turn those facts into transfer timing;
+that sibling question is proposed separately in
+[ADR-0015](0015-engine-semantics-identity-and-reproducibility.md).
+
+## Decision
+
+The proposed decision is:
+
+1. **`factory-model:v1` remains immutable permanently.** Existing fingerprints, canonical
+   artifacts, controlled revisions, and historical resolution are never rewritten or
+   rederived under a newer policy.
+
+2. **Behaviorally relevant spatial design facts require a new fingerprint policy.** The
+   first such evolution is `factory-model:v2`.
+
+3. **`factory-model:v2` remains a complete canonical Factory semantic artifact, not a second
+   spatial sidecar fingerprint.** A v2 fingerprint identifies the exact authored Factory
+   semantics required by the v2 policy.
+
+4. **The minimum Gate 5 spatial facts proposed for v2 are authored design semantics:**
+   - factory-floor dimensions needed to interpret placements;
+   - resource position;
+   - resource footprint;
+   - stable authored transfer-cost magnitudes such as `ticksPerCell` and `handlingTicks`, if
+     the final Gate 5 decision confirms those magnitudes are properties of the designed
+     production system rather than Engine interpretation policy.
+
+   The exact final v2 field set remains subject to the focused Gate 5 transfer-semantics
+   decision. Orientation, route graphs, aisles, conveyors, transport resources, pathfinding,
+   congestion, and animation metadata are not pulled into v2 merely because they are spatial.
+
+5. **Fingerprint-policy version and controlled-revision identity remain distinct.** A
+   `ControlledRevision` continues to reference exactly one `ModelFingerprint`; lineage may
+   connect historical occurrences whose fingerprints use different supported Factory model
+   policies. Crossing a policy version does not rewrite or alias either fingerprint.
+
+6. **Cross-policy semantic equality is never assumed implicitly.** Equality of
+   `factory-model:v1` and `factory-model:v2` fingerprints has no meaning beyond ordinary
+   fingerprint inequality. Any migration/equivalence claim must use an explicit
+   Factory-domain comparison or migration contract that states how both artifacts are
+   interpreted.
+
+7. **A normal semantic comparison must not silently compare incompatible policy shapes.** For
+   an initial `v1 -> v2` transition, Arcogine must either:
+   - explicitly classify the transition as a model-policy migration; or
+   - resolve both artifacts into an explicitly chosen common semantic representation before
+     producing fine-grained semantic differences.
+
+   The first implementation should choose the narrowest of those mechanisms needed by the
+   actual v1-to-v2 proving case rather than introduce a generic migration framework.
+
+8. **Historical artifact resolution is policy-aware and permanent.** Factory supplies a
+   verifier/decoder for every released Factory model policy that must remain historically
+   resolvable. Governance stays domain-neutral: it stores and verifies immutable semantic
+   artifacts through the owning domain's policy-aware verification seam.
+
+9. **A v1 model is not silently upgraded into spatial semantics.** Gate 5 behavior requires an
+   explicitly published artifact under a policy that contains the required spatial facts.
+   Arcogine does not synthesize default positions, footprints, or transfer magnitudes for a
+   historical v1 artifact and then pretend the resulting design has the same fingerprint.
+
+10. **General evolution invariant:** when a future behaviorally relevant authored fact cannot
+    be represented by the currently released canonical policy without changing its canonical
+    meaning, Arcogine introduces a new policy `factory-model:vN+1`; old policies remain
+    immutable and historically resolvable; fingerprints are never rewritten; lineage may
+    continue across policy versions; cross-policy semantic comparison is explicit.
+
+## Alternatives considered
+
+### Extend `factory-model:v1` in place
+
+Rejected. It would make a previously released fingerprint policy produce different canonical
+bytes/meaning and would invalidate ADR-0006's historical identity contract.
+
+### Keep v1 and add an independent spatial fingerprint
+
+Rejected for the current need. Gate 5 requires one authored Factory design whose spatial facts
+are behaviorally meaningful. Splitting semantic identity into a base fingerprint plus an
+independent spatial fingerprint would complicate revision/change/evidence provenance before a
+real independently evolving component boundary has been proven necessary.
+
+### Keep spatial layout outside canonical semantic identity
+
+Rejected. Two authored layouts that produce different deterministic transfer consequences would
+then share one `ModelFingerprint`, making the fingerprint an incomplete identity for the design
+being executed.
+
+### Introduce a generic component-schema/fingerprint framework now
+
+Rejected. The first policy evolution can establish explicit versioned Factory artifact handling
+without generalizing every future domain or semantic component into an independently versioned
+framework.
+
+### Automatically migrate every v1 artifact to v2 defaults
+
+Rejected. Spatial defaults would be newly authored semantics, not a historically true
+interpretation of the v1 artifact. Migration must be explicit and provenance-preserving.
+
+## Consequences
+
+- Gate 5 model work has a durable evolution path without weakening historical v1 identity.
+- Existing controlled revisions remain valid and reconstructable exactly as recorded.
+- Factory code must become capable of verifying/decoding more than one released artifact policy
+  once v2 lands.
+- The first v1-to-v2 controlled change needs an explicit policy-migration/comparison rule.
+- Consumers must not equate fingerprint-policy migration with resource identity replacement;
+  moving or spatially changing a resource can preserve its resource identity while changing the
+  enclosing model fingerprint.
+- This ADR does not by itself determine transfer distance, rounding, destination binding, runtime
+  transfer state, or Engine provenance. Those result-affecting interpretation rules belong to
+  the Engine semantics decision and the final Gate 5 contract.
+
+## Charter alignment
+
+This proposal supports the Charter's single-semantic-source and reproducibility goals: authored
+production-system facts remain part of Arcogine's canonical model, while historical semantic
+identity remains stable across software and schema evolution. It also avoids coupling consumer
+presentation or runtime implementation mechanics to durable model identity.

--- a/docs/architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md
+++ b/docs/architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md
@@ -1,0 +1,181 @@
+# ADR-0015: Engine Semantics Identity and Reproducibility
+
+Status: Proposed
+Date: 2026-09-02
+
+## Context
+
+Arcogine already distinguishes canonical Factory model identity from runtime identity.
+`ModelFingerprint` identifies authored semantic content, while `RunId` identifies one simulation
+runtime epoch. Gate 2, W1, Gate 3, and Gate 4 also establish deterministic Engine-owned behavior
+such as resource-selection ranking, child-work decomposition, scheduler/event ordering, session
+advancement, and supported runtime observations/events.
+
+Gate 5 makes a latent gap explicit. Spatial transfer outcomes depend partly on authored Factory
+facts and partly on Arcogine's interpretation of those facts. More generally, the same canonical
+factory design could produce a different semantic outcome if a future Engine release intentionally
+changes a result-affecting dispatch, scheduling, decomposition, or transfer rule. Requiring every
+such Engine-policy change to mint a new Factory model fingerprint would conflate the design being
+executed with the Engine semantics used to interpret it.
+
+A build/release identifier is not sufficient semantic provenance: unrelated implementation or
+packaging changes may alter a build without changing observable execution semantics, while an
+intentional semantic-policy change must remain attributable even if implemented by several builds.
+The sibling Challenge capability already follows the analogous rule that result-affecting
+evaluation changes create a new evaluation-policy version, while application build identity is
+only diagnostic provenance.
+
+The runtime provenance established by
+[ADR-0011](0011-runtime-observation-and-event-contract.md) currently carries `RunId` and
+`ModelFingerprint` but no explicit identity for result-affecting Engine interpretation semantics.
+Because ADR-0011 is Accepted, any extension is recorded by a new decision rather than editing that
+historical ADR in place.
+
+## Decision
+
+The proposed decision is:
+
+1. **Introduce one `EngineSemanticsVersion` as the semantic identity of Arcogine's complete
+   result-affecting simulation interpretation for a run.** It is distinct from:
+   - `ModelFingerprint` — which authored design was executed;
+   - `RunId` — which runtime epoch produced the facts;
+   - software/build/release identity — which implementation artifact happened to execute them.
+
+2. **The durable reproducibility inputs for a simulation outcome are conceptually:**
+
+   ```text
+   ModelFingerprint
+   + EngineSemanticsVersion
+   + explicit workload
+   + seed/random inputs
+   + ordered external commands
+   ```
+
+   Additional explicit run inputs belong in this tuple when they can affect semantic outcome;
+   `RunId` itself is correlation identity, not a result-affecting input.
+
+3. **Authored production-system facts and Engine interpretation rules have different owners.**
+   - A fact describing what production system was authored belongs to the canonical domain model
+     and its `ModelFingerprint`.
+   - A rule describing how Arcogine interprets any such design belongs to
+     `EngineSemanticsVersion` when changing the rule can change semantic outcome for identical
+     explicit inputs.
+   - An implementation algorithm that can be replaced without changing observable semantic
+     outcome is not part of Engine semantic identity.
+
+4. **One Engine semantics version initially covers the complete result-affecting Engine
+   interpretation.** Do not introduce independently versioned dispatch, scheduler, decomposition,
+   transfer, or rounding policy identities unless concrete independent-evolution requirements
+   later justify them.
+
+5. **The first semantics version must normatively fix all current result-affecting Engine rules.**
+   At minimum this includes the accepted behavior of:
+   - deterministic dispatch ranking/tie-breaking;
+   - W1 decomposition/release semantics that affect execution outcome;
+   - authoritative scheduler/same-time ordering semantics;
+   - Gate 5 distance/rounding/zero-distance/destination-binding rules once they are accepted;
+   - any other Engine-owned interpretation rule whose change could alter semantic event ordering,
+     simulated times, assignments, terminal execution state, or derived outcome facts for the same
+     explicit inputs.
+
+6. **A semantics version is selected at run establishment and cannot change mid-run.** The
+   initial implementation may support exactly one current version rather than building a
+   multi-version resolver. A run performed by an implementation that does not support the
+   requested/recorded version must fail explicitly instead of silently executing under different
+   semantics.
+
+7. **Runtime provenance must carry `EngineSemanticsVersion`.** Supported observations and events
+   that already expose durable run/model provenance must also make the Engine semantics version
+   attributable. This supplements ADR-0011; it does not replace `RunId`, `ModelFingerprint`, or
+   optional controlled-revision provenance.
+
+8. **Released Engine semantics versions are immutable and never reused.** Any intentional change
+   that can alter semantic outcome for the same explicit inputs creates a new version. A
+   semantics-preserving refactor, performance optimization, dependency upgrade, or build change
+   retains the version only when it preserves the normative observable behavior.
+
+9. **The durability guarantee is attribution plus a verifiable definition, not permanent exact
+   re-execution.** For every released version Arcogine retains:
+   - an immutable written specification of the result-affecting rules; and
+   - pinned behavioral conformance fixtures mapping representative explicit inputs to expected
+     semantic outcomes.
+
+   Fixtures pin behavior such as authoritative transition ordering, dispatch/assignment choices,
+   simulated times, terminal execution state, and derived outcomes. They must not accidentally
+   make unrelated transport, serialization, projection, or non-behavioral observation-schema
+   details part of Engine semantic identity.
+
+10. **Exact historical re-execution is supported only where a compatible implementation exists;
+    it is not promised forever.** A future implementation may add a resolver capable of executing
+    older semantics versions and can prove compatibility against the retained specification and
+    fixtures, but retaining every old Engine binary/dependency stack indefinitely is not part of
+    the architecture contract.
+
+11. **Retirement removes executability, not provenance.** Even if a historical semantics version
+    is no longer executable by current software, its identifier, normative specification, and
+    conformance fixtures remain durable. Historical results remain attributable and interpretable.
+    The detailed retirement process and any multi-version execution mechanism are deferred until a
+    second semantics version makes them concrete concerns.
+
+12. **Cross-version result comparison is explicit.** A result produced under one
+    `EngineSemanticsVersion` must not be silently treated as directly comparable to a result under
+    another version where the changed semantics can affect the compared facts. Consumer-specific
+    compatibility/applicability policy belongs to the consumer (for example Challenge comparison
+    or future Governance `EvidenceUse`), not to Engine identity itself.
+
+## Alternatives considered
+
+### Treat `ModelFingerprint` as sufficient execution-semantics provenance
+
+Rejected. The same authored design can legitimately be interpreted by different accepted Engine
+semantic policies over Arcogine's lifetime. Forcing such changes into the model fingerprint would
+make Engine policy masquerade as authored Factory design.
+
+### Use ordinary application/build version
+
+Rejected. Build identity is too broad and unstable to be semantic identity. Many builds can
+preserve one semantic contract, and a semantic-policy version must remain meaningful independent of
+packaging or diagnostic build metadata.
+
+### Create one independently versioned policy per Engine concern
+
+Rejected for the first contract. Dispatch, decomposition, scheduling, and transfer semantics all
+contribute to one simulation outcome. Independent policy identities would multiply compatibility
+states before any concrete independent-evolution requirement exists.
+
+### Create one immutable run-specification identity that combines every input
+
+Deferred. A composite run-spec artifact may later be useful, but it is not required to establish
+the missing semantic distinction. The underlying model identity, Engine semantics identity, and
+explicit run inputs should remain individually meaningful and attributable.
+
+### Guarantee permanent exact execution of every released semantics version
+
+Rejected. Keeping an entire historical simulation implementation buildable and runnable against
+future JVMs, build tools, and dependencies creates an unbounded maintenance commitment. Retained
+normative semantics plus behavioral conformance fixtures provide durable verification without that
+liability.
+
+## Consequences
+
+- Gate 5 can place authored spatial facts in `factory-model:v2` while keeping distance/rounding and
+  other Arcogine interpretation rules Engine-owned.
+- A model fingerprint no longer needs to pretend to identify every possible deterministic outcome;
+  it identifies the authored semantic design.
+- Runtime observation/event provenance needs an additive semantics-version field under a new
+  accepted decision that supplements ADR-0011.
+- Historical Challenge, Governance analytical evidence, checkpoint/recovery, and Operational
+  analytics can retain Engine interpretation provenance when they begin consuming real Engine
+  results, without conflating it with their own policy/context identities.
+- No generic cross-domain policy framework is created. Challenge evaluation-policy identity,
+  Governance requirement/assertion/evidence semantics, and Operational execution-context identity
+  remain separate concepts with separate ownership.
+- The first Engine semantics release must include a normative specification and behavioral
+  conformance fixtures before later semantic evolution makes those facts unrecoverable.
+
+## Charter alignment
+
+This proposal strengthens deterministic and explainable execution while preserving Arcogine's
+separation between canonical modeled intent, runtime execution, and consumer interpretation. It
+makes historical results attributable without turning implementation binaries into permanent
+product artifacts or coupling Factory design identity to Engine release mechanics.

--- a/docs/architecture/decisions/0016-governance-evidence-provenance.md
+++ b/docs/architecture/decisions/0016-governance-evidence-provenance.md
@@ -1,0 +1,149 @@
+# ADR-0016: Governance Evidence Provenance and Derived Analytical Results
+
+Status: Proposed
+Date: 2026-09-02
+
+## Context
+
+Governance G3 already distinguishes whether an assertion can be evaluated from model state alone or
+requires evidence beyond structural model state:
+
+```text
+MODEL_STATE_SUFFICIENT
+EXTERNAL_EVIDENCE_REQUIRED
+```
+
+Governance G4 adds deterministic conformance evaluation and findings. The current G4 implementation
+work deliberately keeps G5 evidence semantics out of scope and returns `UNKNOWN` when a result
+cannot be proven from the supplied model state.
+
+The broader architecture, however, needs G5 to consume several provenance classes without lying
+about where facts came from. Examples include:
+
+- facts read directly from canonical Arcogine semantic state;
+- simulation/verification/analysis results produced by Arcogine;
+- external operational observations such as telemetry or third-party records;
+- later reconciliation-derived results that combine modeled intent and externally observed facts.
+
+The current two-member `EvidenceRequirement` answers a different question: whether an assertion can
+be decided from model state alone. It does not necessarily need to encode the provenance class of
+every evidence artifact that G5 may later bind to an evaluation.
+
+This distinction became important while reviewing Governance G4. Pulling analytical-result
+provenance into G4 would prematurely couple conformance result semantics to a not-yet-designed G5
+evidence model. Conversely, failing to make provenance explicit in G5 would risk treating
+Arcogine-derived analysis as either raw model fact or external observation, obscuring how a
+historical conformance result was established.
+
+## Decision
+
+The proposed decision is:
+
+1. **Keep assertion evidence requirement and evidence provenance as separate dimensions.**
+   `EvidenceRequirement` continues to answer whether model state alone is sufficient to evaluate an
+   assertion. G5 evidence records answer what fact/result is being supplied and where/how it was
+   produced.
+
+2. **Do not add a third `EvidenceRequirement` member merely to represent Arcogine-produced analysis.**
+   A simulation or verification result is not model state merely because Arcogine produced it, and
+   it is not an external observation merely because it is supplied to Governance from outside the
+   conformance evaluator. Evidence provenance belongs on the evidence/evidence-use side of the
+   boundary.
+
+3. **G5 must support provenance sufficient to distinguish at least these semantic origins:**
+   - authoritative modeled/semantic-state fact, where the evidence use directly addresses immutable
+     Arcogine semantic state;
+   - Arcogine-derived analytical/verification result, including simulation or deterministic
+     verification output produced from explicit inputs under attributable interpretation semantics;
+   - externally observed fact, whose source is outside Arcogine's modeled state and whose source
+     identity/authenticity provenance is retained independently;
+   - reconciliation/interpretation-derived result when a later capability explicitly combines
+     modeled intent and observations.
+
+   The exact enum/type names remain open. The requirement is semantic distinguishability, not a
+   particular Java taxonomy.
+
+4. **Evidence is not the same as `EvidenceUse`.** An evidence record preserves the independently
+   provenanced fact/result. `EvidenceUse` records how that evidence is interpreted for a particular
+   requirement/assertion/evaluation context, including model/revision/context associations that are
+   not intrinsic to the raw source fact.
+
+5. **Raw external observations remain revision-independent at ingestion.** If Arcogine later binds
+   an observation to a model fingerprint, controlled revision, execution context, deployment, or
+   reconciliation result, that relationship belongs to the interpretation/reconciliation or
+   `EvidenceUse` record rather than being fabricated as source provenance.
+
+6. **Arcogine-derived analytical evidence retains the interpretation provenance needed to explain
+   the result.** For Engine-produced simulation/verification output this includes the subject model
+   fingerprint, the applicable `EngineSemanticsVersion` once that decision is accepted, and the
+   explicit run inputs/result provenance required by the producing capability. Governance does not
+   own or redefine Engine semantics.
+
+7. **Historical evidence validity does not require permanent re-executability.** Evidence validity
+   is based on integrity, provenance, and applicability. A historical Arcogine analytical result may
+   remain valid evidence even when the old producing semantics version is no longer executable,
+   provided its semantic provenance remains attributable and verifiable. Whether it is still
+   appropriate for a new forward-looking claim is an `EvidenceUse`/applicability judgment.
+
+8. **Cross-version analytical comparison is never silently assumed.** If two analytical results
+   were produced under materially different result-affecting semantic policies, a consumer must
+   explicitly determine compatibility/applicability before comparing or combining them as evidence.
+
+9. **Verification-objective semantics remain domain-owned.** Governance owns generic
+   requirement/assertion/evaluation/evidence/finding contracts. The owning domain or capability
+   defines the meaning and evaluator for a specific objective such as throughput, lead-time,
+   utilization, safety separation, or operational reconciliation. Governance consumes the resulting
+   attributable evidence; it does not become a generic simulation/verification engine.
+
+10. **G4 remains narrow.** `PASS`, `FAIL`, `UNKNOWN`, `NOT_APPLICABLE`, immutable evaluation
+    provenance, and `Finding` are valid G4 responsibilities without G5 evidence-source taxonomy.
+    G5 composes with those results later rather than forcing G4 to freeze evidence implementation
+    details now.
+
+## Alternatives considered
+
+### Add `ARCOGINE_DERIVED_EVIDENCE` to `EvidenceRequirement`
+
+Rejected as the default design. It mixes two questions: whether model state alone is sufficient and
+where a non-model-state fact came from. An assertion may require evidence while remaining agnostic
+about whether an acceptable fact was produced analytically by Arcogine or observed externally.
+
+### Treat Arcogine analytical results as `EXTERNAL_EVIDENCE_REQUIRED` and record no further origin
+
+Rejected. While the requirement may still be evidence-requiring, provenance must distinguish a
+simulation/verification result from a PLC reading, IdP log, or other external observation so
+historical interpretation and applicability remain explainable.
+
+### Make simulation/verification output direct G4 evaluation input and skip G5 evidence
+
+Rejected. That would make G4 own producer-specific analytical provenance and would duplicate the
+future evidence/evidence-use lifecycle instead of composing with it.
+
+### Create a generic cross-domain verification framework now
+
+Rejected. Factory, Engine, Operational, Challenge, and other domains can own their concrete
+verification/evaluation semantics. Governance needs a generic way to retain attributable evidence
+and interpret its use, not a universal rule engine.
+
+## Consequences
+
+- G4 can land without prematurely designing G5.
+- G5 gets an explicit architecture question before implementation rather than inferring provenance
+  semantics from whichever first producer integrates with it.
+- Operational external observations can remain independently provenanced and later become evidence
+  without being rebound to a revision at ingestion.
+- Engine simulation/verification output can become Governance evidence while retaining
+  `ModelFingerprint` and Engine interpretation provenance rather than pretending it is structural
+  model state.
+- Future reconciliation results can remain distinct lifecycle records rather than collapsing raw
+  observation, analytical interpretation, finding, and candidate change into one object.
+- A detailed evidence identity, persistence, integrity/signature, retention, or transport schema is
+  not selected by this proposal and should receive its own decision only when a concrete G5
+  implementation requires it.
+
+## Charter alignment
+
+This proposal preserves Arcogine's distinction between modeled intent, observed reality, analytical
+interpretation, and governance decisions. It supports explainable historical results without
+centralizing domain-specific verification logic inside Governance or binding external facts to
+Arcogine semantic identities before an explicit interpretation occurs.


### PR DESCRIPTION
## Summary

Captures today's cross-track architecture conclusions in durable **Proposed ADRs** without presenting still-open decisions as established architecture.

Adds:

- ADR-0014 — Factory Model Semantic-Policy Evolution
  - keeps `factory-model:v1` immutable;
  - proposes `factory-model:v2` for behaviorally relevant authored spatial facts;
  - makes cross-policy comparison/migration explicit;
  - preserves historical controlled-revision resolution without rewriting fingerprints.

- ADR-0015 — Engine Semantics Identity and Reproducibility
  - separates authored design identity (`ModelFingerprint`) from result-affecting Engine interpretation (`EngineSemanticsVersion`);
  - records the conceptual reproducibility tuple;
  - proposes runtime provenance extension that supplements ADR-0011 rather than rewriting it;
  - fixes the lifecycle guarantee at attribution + verifiable definition, backed by normative semantics and behavioral conformance fixtures, without promising eternal historical executability.

- ADR-0016 — Governance Evidence Provenance and Derived Analytical Results
  - keeps assertion evidence requirement separate from evidence origin/provenance;
  - keeps G4 narrow and G5-owned evidence semantics deferred to G5;
  - makes Arcogine-derived analytical results, external observations, and later reconciliation results distinguishable without creating a generic verification framework.

## Deliberately not changed

- ADR-0013 remains untouched because its acceptance/revision discussion is still active.
- Gate 5's exact transfer lifecycle/timing/destination/event semantics are not frozen here; the final Gate 5 synthesis should determine whether they belong in ADR-0015, a dedicated Gate 5 ADR, and/or a focused delivery plan.
- No current-state architecture overview claims are changed because these ADRs are Proposed, not Accepted/implemented.
- PR #247 remains the active Governance G4 implementation lane; this PR does not duplicate or modify its implementation.

## Validation

Documentation-only change; no Java/frontend gates required by `AGENTS.md`.
