### PR TITLE
docs: narrow logs/ scope to ad hoc diagnostics

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Use `./arcogine check` before pushing. Use `./arcogine check --full` when the ch
 
 5. **Open a pull request** against `main` with a clear description of what changed and why.
 
-**Temporary artifacts:** test output, coverage reports, and other transient build/test artifacts should be written to a dedicated `logs/` directory at the repository root (which is gitignored as a whole). This keeps the root directory clean and makes cleanup simple (`rm -rf logs/`).
+**Temporary artifacts:** ad hoc diagnostic reports and one-off session artifacts (that would otherwise litter the root) should go to a dedicated `logs/` directory at the repository root (gitignored as a whole). This keeps the root directory clean. Do not redirect canonical tool outputs — Gradle, npm/Vitest coverage, Playwright reports, and `dist/` continue to use their configured locations.
 
 For independent PR review, re-review, severity/disposition, CI-language, and AI-assisted session-boundary guidance, follow [`docs/development/reviewing.md`](../docs/development/reviewing.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,9 @@ authorities.
 
 ## Temporary artifacts
 
-Test output, coverage reports, logs, and other transient build artifacts must be written to the `logs/` directory at the repository root (not to the root level or scattered across the tree). The `logs/` directory is gitignored as a whole. Keep the root and working directory clean; use `logs/coverage.txt`, `logs/test-output.log`, etc. instead of root-level files.
+Ad hoc diagnostic reports, one-off log captures, and transient session artifacts that would otherwise be written at repository root should go to the `logs/` directory at the repository root. The `logs/` directory is gitignored as a whole. Keep the root and working directory clean; use `logs/coverage.txt`, `logs/test-output.log`, etc. instead of root-level files.
+
+Do not redirect canonical tool-managed outputs: Gradle (`product/**/build/`), npm/Vitest (`product/interfaces/web/coverage/`, `test-results/`), Playwright (`playwright-report/`), and `dist/` continue to write to their configured locations per the canonical build commands.
 
 ## Commit message footer
 


### PR DESCRIPTION
## Summary

Follow-up to #255 after it was merged before the final review remediation landed.

This narrows the `logs/` convention to ad hoc diagnostics, one-off log captures, and transient session artifacts that would otherwise clutter the repository root.

Canonical tool-managed outputs remain unchanged:
- Gradle: `product/**/build/`
- npm/Vitest: `product/interfaces/web/coverage/` and `test-results/`
- Playwright: `playwright-report/`
- canonical distribution: `dist/`

## Changes

- `AGENTS.md`: scope `logs/` to ad hoc/session-created diagnostics and explicitly preserve canonical generated-output locations.
- `.github/CONTRIBUTING.md`: make the same contributor-facing distinction.

## Validation

Documentation-only follow-up; no product or build configuration changes.