### PR TITLE
docs: add Session-close Kaizen shorthand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,23 @@ Common shorthand should be interpreted in repository context:
 PR workflow shorthand has distinct review and remediation meanings:
 
 - `.` = review or re-review the current applicable pull request using the dedicated PR Reviewer contract;
-- `..` = re-resolve the current implementation pull request's lifecycle state and perform the next implementation-owned transition, if one is available.
+- `..` = re-resolve the current implementation pull request's lifecycle state and perform the next implementation-owned transition, if one is available;
+- `.?` = perform the Session-close Kaizen review before ending or deleting the current session.
+
+### Session-close Kaizen
+
+When the user's entire message is `.?`, inspect the current session and live repository for anything learned, decided, repeated, or encountered that should survive deletion of the conversation by changing executable safeguards, standard work, or maintained repository knowledge.
+
+Classify each material candidate as one of:
+
+- **Already encoded** — the repository already captures the lesson or invariant adequately; make no duplicate change.
+- **Bake in** — the lesson is durable and generally reusable; identify the narrowest authoritative repository surface that should encode it.
+- **Follow-up** — the improvement is worthwhile but belongs in separate work rather than being smuggled into the current PR or slice.
+- **Discard** — the observation is situational, transient, or otherwise not worth preserving.
+
+Prefer stronger forms of durable capture in this order when they fit the lesson: executable guard/test, canonical helper/tooling, agent/contributor standard work, maintained documentation, then an ADR only for genuinely architectural or hard-to-reverse decisions. Generalize incidents into semantic rules rather than preserving session or PR coordinates as durable concepts. Prefer improving an existing authoritative artifact over creating a new one.
+
+Do not manufacture a lesson merely to produce an output. Finish every Session-close Kaizen review with an explicit deletion verdict: either the session is safe to delete because nothing unique remains, or name exactly what still needs to be captured first.
 
 Do not replace known repository context with generic GitHub discovery.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Common shorthand should be interpreted in repository context:
 - “check repo state” means inspect the state of this repository;
 - references such as “the issue”, “the PR”, “main”, or a bare issue/PR number refer to this repository unless context explicitly establishes otherwise.
 
-PR workflow shorthand has distinct review and remediation meanings:
+Repository workflow shorthand has distinct meanings:
 
 - `.` = review or re-review the current applicable pull request using the dedicated PR Reviewer contract;
 - `..` = re-resolve the current implementation pull request's lifecycle state and perform the next implementation-owned transition, if one is available;


### PR DESCRIPTION
## Summary

- add `.?` as the Session-close Kaizen shorthand alongside `.` and `..`
- define a compact session-close procedure in `AGENTS.md`
- classify candidate lessons as Already encoded, Bake in, Follow-up, or Discard
- prefer executable safeguards and existing authoritative surfaces over duplicative prose or new documents
- require an explicit safe-to-delete verdict at the end of the review

## Rationale

Session-close review should answer a stronger question than “were there any lessons?”: whether anything learned, decided, repeated, or encountered would be lost if the conversation disappeared, and if so what repository authority should absorb it. Encoding this as `.?` makes that Kaizen Act part of Arcogine’s normal agent workflow without introducing a separate agent or document.

## Validation

Documentation-only change. Verified the final `AGENTS.md` section in branch context and confirmed the net diff is limited to `AGENTS.md`; no runtime validation required per repository policy.