### PR TITLE
chore: group routine Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,40 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      gradle-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/product/interfaces/web"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      npm-development-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- group Gradle minor/patch updates into one weekly PR
- group npm minor/patch updates by development vs production dependency type
- group GitHub Actions minor/patch updates into one weekly PR
- leave major updates unmatched so they continue as individual PRs
- leave security updates on their existing separate path

## Scope

Configuration-only change to `.github/dependabot.yml`; cadence and open-PR limits are unchanged.

## Validation

No runtime validation required for this config-only change; GitHub will validate the Dependabot configuration when processing it.