### PR TITLE
fix(governance): validate and repair PR disposition workflow

### DIFF
--- a/.github/scripts/check-actions-workflows.sh
+++ b/.github/scripts/check-actions-workflows.sh
@@ -4,18 +4,17 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 version="1.7.12"
 archive_sha256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+archive="$tmp_dir/actionlint.tar.gz"
 
-if command -v actionlint >/dev/null 2>&1; then
-  actionlint_bin="$(command -v actionlint)"
-else
-  tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' EXIT
-  archive="$tmp_dir/actionlint.tar.gz"
-  curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz" -o "$archive"
-  echo "${archive_sha256}  ${archive}" | sha256sum -c -
-  tar -xzf "$archive" -C "$tmp_dir" actionlint
-  actionlint_bin="$tmp_dir/actionlint"
-fi
+# Always download and verify the exact validator version used by CI. Do not
+# silently accept a runner- or developer-provided actionlint from PATH: parser
+# behavior is part of the disposition-gate regression contract.
+curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz" -o "$archive"
+echo "${archive_sha256}  ${archive}" | sha256sum -c -
+tar -xzf "$archive" -C "$tmp_dir" actionlint
+actionlint_bin="$tmp_dir/actionlint"
 
 cd "$repo_root"
 "$actionlint_bin" -shellcheck= -pyflakes= .github/workflows/*.yml

--- a/.github/scripts/check-actions-workflows.sh
+++ b/.github/scripts/check-actions-workflows.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+version="1.7.12"
+archive_sha256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint_bin="$(command -v actionlint)"
+else
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+  archive="$tmp_dir/actionlint.tar.gz"
+  curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz" -o "$archive"
+  echo "${archive_sha256}  ${archive}" | sha256sum -c -
+  tar -xzf "$archive" -C "$tmp_dir" actionlint
+  actionlint_bin="$tmp_dir/actionlint"
+fi
+
+cd "$repo_root"
+"$actionlint_bin" -shellcheck= -pyflakes= .github/workflows/*.yml

--- a/.github/scripts/check-pr-disposition.test.sh
+++ b/.github/scripts/check-pr-disposition.test.sh
@@ -23,9 +23,6 @@ test_count=0
 pass_count=0
 fail_count=0
 
-# Encode one or more review bodies (each a full multi-line string, passed as
-# a separate argument) into the newline-separated base64 list the evaluator
-# expects.
 encode_bodies() {
   local out=""
   local body
@@ -315,6 +312,12 @@ test_case \
   "$CURRENT" \
   "Reviewed head:t${CURRENT}
 Disposition:t**READY TO MERGE**"
+
+# GitHub can reject an Actions workflow before scheduling any job, which makes
+# evaluator-only tests insufficient. Lint every workflow definition from the
+# always-running disposition test suite so malformed orchestration cannot
+# reach main while the required gate is green.
+bash "$SCRIPT_DIR/check-actions-workflows.sh"
 
 # Summary
 echo ""

--- a/.github/workflows/pr-disposition.yml
+++ b/.github/workflows/pr-disposition.yml
@@ -14,12 +14,7 @@ name: PR Disposition
 # not sufficient on its own: GitHub sources a `pull_request` or
 # `pull_request_review` triggered workflow's *definition* from the pull
 # request's own merge commit, not from `main`. A PR could therefore edit this
-# very file to skip the evaluator and fabricate a passing result. This is not
-# hypothetical -- it was caught live on this branch: `main` did not yet
-# contain this file at all, yet earlier revisions of this workflow (under
-# `pull_request`/`pull_request_review` triggers) were already executing on
-# this PR's own heads, proving the PR was supplying its own workflow
-# definition.
+# very file to skip the evaluator and fabricate a passing result.
 #
 # Three trusted-orchestration triggers, none of which ever checks out or
 # executes PR-supplied code:
@@ -44,13 +39,9 @@ name: PR Disposition
 #     unchanged head. `.github/CODEOWNERS` requires an independent owner to
 #     review any change under `.github/workflows/`, including that
 #     narrowing, before it can merge (see reviewing.md's listener-coverage
-#     mitigation) -- once the ruleset enforces it, this closes the
-#     candidate-controlled part of the gap; the schedule sweep is always
-#     read from the version of this file
-#     on the default branch regardless of any PR, and remains as
-#     defense-in-depth, re-checking every open PR against `main` on a fixed
-#     interval independent of whatever event coverage a candidate PR's own
-#     listener declares.
+#     mitigation). The schedule sweep is always read from the version of
+#     this file on the default branch and remains defense-in-depth,
+#     re-checking every open PR against `main` on a fixed interval.
 #
 # Neither `pull_request_target`, `workflow_run`, nor `schedule` implicitly
 # attaches a check result to the correct PR head SHA the way a
@@ -66,8 +57,7 @@ name: PR Disposition
 # running this evaluator. The same `.github/CODEOWNERS` entry mitigates
 # this: authoring such a workflow is itself a change under
 # `.github/workflows/`, so it requires an owner's independent review and
-# approval first -- see reviewing.md for the full required-activation
-# checklist, including enabling "Require review from Code Owners".
+# approval first.
 on:
   pull_request_target:
     branches: [main]
@@ -82,6 +72,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
   checks: write
 
 jobs:
@@ -138,10 +129,6 @@ jobs:
               TARGETS=$(jq -nc --arg n "$PR_NUMBER" '[{pr_number: $n}]')
               ;;
             schedule)
-              # Trusted backstop: re-evaluate every open PR targeting main,
-              # independent of any PR-controlled event coverage. --repo is
-              # required here: this job has no checkout, so there is no local
-              # git context for gh to auto-detect the repository from.
               TARGETS=$(gh pr list --repo "${{ github.repository }}" --state open --base main --json number --jq 'map({pr_number: (.number | tostring)})')
               ;;
             *)
@@ -169,11 +156,6 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Read as data, not interpolated into the script text -- see the
-          # resolve-targets job above for why. matrix.target.pr_number is
-          # always produced upstream by jq/gh from an actual numeric PR
-          # number, but this job holds `checks: write`, so its inputs are
-          # validated as numeric here rather than trusted by construction.
           TARGET_PR_NUMBER: ${{ matrix.target.pr_number }}
         run: |
           set -euo pipefail
@@ -196,22 +178,6 @@ jobs:
         run: |
           set -euo pipefail
           PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
-
-          # Fetch all reviews (paginated). `gh api` rejects --slurp combined
-          # with --jq in one invocation, so --slurp collects the raw page
-          # arrays here and a separate jq pipe does the rest of the work:
-          #
-          #  1. `add` flattens the page arrays into one ordered array.
-          #  2. Only reviews from a trusted repository authority
-          #     (author_association OWNER/MEMBER/COLLABORATOR) are kept.
-          #     This repository is public: any user with read access can
-          #     submit a review, so an unfiltered pass-through would let an
-          #     unrelated external account mint a canonical READY TO MERGE
-          #     block and satisfy the gate.
-          #  3. Each surviving body is base64-encoded and emitted one per
-          #     line -- a plain newline-separated list of opaque strings, not
-          #     a JSON array, so the evaluator needs no JSON re-parsing or
-          #     ad-hoc object-boundary splitting.
           BODIES=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
             --paginate \
             --slurp \
@@ -222,8 +188,6 @@ jobs:
                 | .[]
               ')
 
-          # Multiline values must use the heredoc form of GITHUB_OUTPUT with a
-          # delimiter unlikely to collide with the (base64-only) payload.
           DELIM="REVIEW_BODIES_$(date +%s%N)_$RANDOM"
           {
             echo "review_bodies_b64<<$DELIM"
@@ -232,10 +196,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository at main (trusted base)
-        # A candidate PR must not be able to modify the evaluator used to
-        # authorize itself, so the evaluator always runs from main, never
-        # from the PR's own (possibly attacker-controlled) checkout. No
-        # PR-supplied ref is ever checked out or executed by this workflow.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
@@ -263,11 +223,6 @@ jobs:
             CONCLUSION="failure"
           fi
 
-          # None of this workflow's triggers implicitly attach a check result
-          # to the correct PR head SHA (pull_request_target's default
-          # GITHUB_SHA is the base commit; workflow_run and schedule have no
-          # commit association at all), so the check is published explicitly
-          # against the resolved head SHA via the Checks API.
           gh api "repos/${{ github.repository }}/check-runs" \
             -f name="disposition" \
             -f head_sha="${{ steps.pr.outputs.head_sha }}" \

--- a/.github/workflows/pr-disposition.yml
+++ b/.github/workflows/pr-disposition.yml
@@ -94,19 +94,12 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Untrusted event fields (PR number, workflow_run.pull_requests,
-          # workflow_run.head_branch) are passed as data via environment
-          # variables rather than interpolated directly into the shell
-          # script text. GitHub explicitly documents ref/branch names and
-          # other `github.event.*` fields as attacker-controllable
-          # script-injection vectors when interpolated as `${{ ... }}` into
-          # an inline `run:` block; reading them through `$NAME` here means
-          # their content is never parsed as shell syntax, regardless of
-          # what characters they contain. This job also has no `checks:
-          # write`/no privileged output, but the same pattern is required in
-          # the privileged check-disposition job below.
+          # Event values are passed as data via environment variables rather
+          # than interpolated directly into shell script text. The workflow-run
+          # association is re-fetched from GitHub's API using the run ID instead
+          # of serializing the nested pull_requests object into an expression.
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_WORKFLOW_RUN_PRS_JSON: ${{ toJson(github.event.workflow_run.pull_requests) }}
+          EVENT_WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           EVENT_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
@@ -116,28 +109,24 @@ jobs:
               TARGETS=$(jq -nc --arg n "$EVENT_PR_NUMBER" '[{pr_number: $n}]')
               ;;
             workflow_run)
-              # Resolve the associated PR from the TRUSTED job's own event
-              # context (github.event.workflow_run.pull_requests), computed by
-              # GitHub itself -- not from anything the untrusted listener run
-              # produced. This is the field GitHub docs describe as populated
-              # for same-repository PRs; for a pull_request_review-triggered
-              # listener run specifically, github.event.workflow_run.head_sha
-              # is the ephemeral refs/pull/<n>/merge commit, NOT a real commit
-              # in the PR's own history, so GET /commits/<sha>/pulls (which
-              # only recognizes actual commits) always returns an empty array
-              # for it -- confirmed live, this previously made PR resolution
-              # fail on every single review-triggered run.
-              PR_NUMBER=$(echo "$EVENT_WORKFLOW_RUN_PRS_JSON" | jq -r '.[0].number // empty')
+              case "$EVENT_WORKFLOW_RUN_ID" in
+                ''|*[!0-9]*)
+                  echo "::error::workflow_run id is not numeric: $EVENT_WORKFLOW_RUN_ID" >&2
+                  exit 1
+                  ;;
+              esac
+
+              # Re-fetch the trusted workflow-run object from GitHub and read
+              # its associated PRs there. For a pull_request_review-triggered
+              # listener run, head_sha is the ephemeral refs/pull/<n>/merge
+              # commit and cannot be resolved through /commits/<sha>/pulls.
+              PR_NUMBER=$(gh api \
+                "repos/${{ github.repository }}/actions/runs/$EVENT_WORKFLOW_RUN_ID" \
+                --jq '.pull_requests[0].number // empty')
 
               if [ -z "$PR_NUMBER" ]; then
-                # Fallback for the case GitHub's docs say pull_requests can be
-                # empty (a fork PR): resolve via the run's own head branch name,
-                # which (unlike head_sha) is the PR's real source branch, not
-                # the synthetic merge ref. Read as data ($EVENT_HEAD_BRANCH),
-                # never interpolated into the script text -- a branch name is
-                # attacker-controlled content and GitHub's script-injection
-                # guidance gives a concrete example of one breaking out of
-                # this exact `NAME="${{ ... }}"` shell-assignment style.
+                # GitHub documents pull_requests as possibly empty for fork
+                # cases. Fall back to the run's real source branch name.
                 PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$EVENT_HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
               fi
 

--- a/docs/development/reviewing.md
+++ b/docs/development/reviewing.md
@@ -344,14 +344,16 @@ The listener's own `pull_request_review.types` list is itself PR-editable conten
 
 Both mitigations depend on the *reviewing* owner identity being genuinely independent of whoever could otherwise self-approve the change (see activation item 2 below); CODEOWNERS enforcement is necessary but not sufficient on its own.
 
-At time of writing, this status check is **not yet required** by the branch protection ruleset on `main` — see the check's own workflow file for the exact context name to add. This bootstrap PR does not need to activate the rule before merging. Because all three workflow files must exist on `main` for `pull_request_target`/`workflow_run`/`schedule` to fire at all, no `disposition` check runs on this bootstrap PR's own head — this is expected, not a defect, and is a stronger form of the same bootstrap boundary as the evaluator script itself. The gate becomes active for the first time on the first PR opened after this one merges. Enforcement activates only once a maintainer completes all of the following, not merely adding the status name:
+The `disposition` check is intended to be required on `main`. Enforcement is considered active only when all of the following are true:
 
-1. Add the exact check-run context (see the workflow file) to the ruleset's required status checks.
-2. Ensure the identity available to coding agents cannot bypass the required disposition and CI checks, and cannot satisfy the `.github/CODEOWNERS` review requirement on itself. A ruleset actor with a "for pull requests only" bypass can still choose to bypass at merge time; if Arcogine's agents operate through that same identity, adding a required check (or a code-owner review requirement naming that same identity) does not constrain them. A separate human-only emergency bypass, reviewed by a distinct human code owner, is acceptable as long as agents cannot exercise it and cannot self-approve as the listed owner.
-3. Enable "require branches to be up to date before merging" (or an equivalent base-freshness safeguard). The gate binds only to the PR head SHA and is not triggered by a push to `main`, so a base-branch advance after a passing disposition/CI check would otherwise leave a stale authorization mergeable even though the reviewed base-to-head transition is no longer current.
-4. Enable "Require review from Code Owners" on the ruleset for `main`, so that `.github/CODEOWNERS`'s entry for `.github/workflows/` is actually enforced. Until this is on, the CODEOWNERS file is documentation only and does not mitigate the candidate-controlled listener-narrowing or check-name-spoofing gaps described above.
+1. The exact `disposition` check-run context is required by the `main` ruleset.
+2. The identity available to coding agents cannot bypass the required disposition and CI checks and cannot satisfy its own `.github/CODEOWNERS` review requirement. A separate human-only emergency bypass is acceptable only when agents cannot exercise it and cannot self-approve as the listed owner.
+3. Required checks enforce base freshness, for example by requiring branches to be up to date before merging. The disposition gate binds to the PR head SHA and is not triggered by a push to `main`, so a base advance must not leave stale review authorization mergeable.
+4. The ruleset requires review from Code Owners, so `.github/CODEOWNERS` actually protects workflow and CODEOWNERS changes against candidate-controlled listener narrowing or same-named check spoofing.
 
-Until all four are true, the workflow existing and passing does not mean the merge invariant is actually enforced.
+If the disposition infrastructure itself is broken such that GitHub cannot publish the `disposition` check, temporarily remove only `disposition` from the required-check list while repairing the trusted workflow. Keep the remaining protections active, including `gate`, base-freshness enforcement, Code Owner review, and the no-bypass posture. After the repair reaches `main`, verify end to end that a canonical current-head review produces a `disposition` check on that PR head and that a subsequent head change invalidates the old authorization. Restore `disposition` as a required status check only after that live verification succeeds.
+
+Until all four activation conditions are true, the workflow existing and passing does not mean the merge invariant is actually enforced.
 
 ## Tests as design evidence
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -76,6 +76,7 @@ All Java commands run through the Gradle wrapper under `product/`. Raising a min
 | Frontend dependency audit | Supported Node.js/npm and installed frontend dependencies | Required to query the npm registry advisory service |
 | Image vulnerability scan | Docker, built images, and Trivy | Needed for Trivy's vulnerability database |
 | Secret scan | Gitleaks | None after the scanner is installed |
+| GitHub Actions workflow validation | Bash, `curl`, `tar`, and `sha256sum` | Required to download the pinned actionlint release from GitHub Releases |
 
 CI and release certification continue to run their required jobs and fail on
 missing tools or findings. Local capability limitations justify omitting only
@@ -184,7 +185,7 @@ The GitHub Actions workflow (`.github/workflows/ci.yml`) runs these jobs, each i
 
 | Job | Command | What it checks |
 |-----|---------|----------------|
-| Classify changes | `git diff --name-only` against the PR base (or the pushed range on `main`) | Buckets the diff into backend/frontend/docker/docs-only surfaces to drive the conditional jobs below |
+| Classify changes | Repository-owned shell/Node validation plus `git diff --name-only` against the PR base (or pushed range on `main`) | Validates classifier logic, developer/preflight tooling, PR lifecycle resolution, repository snapshot tooling, the PR disposition evaluator, and every GitHub Actions workflow definition with pinned actionlint; then buckets the diff into backend/frontend/docker/docs-only surfaces for conditional jobs |
 | Java | `./gradlew compileJava compileTestJava checkstyleMain checkstyleTest test jacocoTestReport jacocoTestCoverageVerification` | Java 21 compatibility, Checkstyle, unit tests, Jacoco coverage gates |
 | Frontend | separate steps: lint, typecheck, `test:coverage`, build, `npm audit --audit-level=high` | Node 22.22.2 floor, lint, typecheck, coverage, build, dependency audit — each step is separately attributable on failure, and the audit step always writes `npm-audit.json` (uploaded as an artifact only on failure) while still failing the job on any HIGH+ finding |
 | Playwright | `npx playwright test` (after `./gradlew :cli:bootJar`) | Browser E2E against the Java API at the Java/Node floors |
@@ -223,6 +224,22 @@ Pass the **file**, not the directory: `node --test infra/dev/` fails with `MODUL
 
 ```bash
 node --test infra/dev/repo-snapshot.test.mjs
+```
+
+### PR disposition and workflow-definition validation
+
+The always-running `classify` job validates both layers of the PR disposition merge gate:
+
+- `.github/scripts/check-pr-disposition.test.sh` exercises the disposition evaluator semantics.
+- `.github/scripts/check-actions-workflows.sh` validates every `.github/workflows/*.yml` definition with the repository-pinned actionlint version.
+
+The workflow-definition check deliberately validates GitHub Actions syntax before merge so a workflow cannot reach `main` in a form that GitHub rejects before scheduling any jobs. The helper always downloads actionlint 1.7.12, verifies the pinned archive SHA-256, and executes that exact binary rather than substituting an arbitrary runner- or developer-provided `actionlint` from `PATH`. It therefore requires `curl`, `tar`, `sha256sum`, and network access to GitHub Releases whenever it runs.
+
+Run the two checks locally with:
+
+```bash
+bash .github/scripts/check-pr-disposition.test.sh
+bash .github/scripts/check-actions-workflows.sh
 ```
 
 ### Scheduled and manual security runs


### PR DESCRIPTION
## Summary

Repairs the repository-level PR disposition gate after live run `34142482940` failed before scheduling any jobs, leaving the `disposition` check absent.

The original root cause was an invalid GitHub Actions expression in `.github/workflows/pr-disposition.yml`: serializing `github.event.workflow_run.pull_requests` with `toJson(...)` caused workflow expression parsing to fail before any job could be scheduled.

## Fix

- replace the fragile nested `toJson(github.event.workflow_run.pull_requests)` expression with the scalar trusted workflow-run ID
- validate that run ID as numeric
- re-fetch the trusted workflow-run object through GitHub's API and read `.pull_requests[0].number`
- grant the resolver the minimal `actions: read` permission needed for that API call
- retain the existing head-branch fallback for cases where GitHub reports no associated PR
- preserve the existing trust boundary: evaluator/orchestration comes from trusted `main`, never PR-controlled code

## Regression guard

Add deterministic GitHub Actions workflow-definition validation for every `.github/workflows/*.yml` definition. The helper always downloads actionlint `1.7.12`, verifies the pinned archive SHA-256, and runs that exact binary; it never substitutes a runner- or developer-provided version from `PATH`.

The guard reproduced the pre-fix failure exactly:

```
.github/workflows/pr-disposition.yml:111:1530: unexpected token "." while parsing variable access, function call, null, bool, int, float or string
```

After the workflow repair, all 24 disposition evaluator tests and workflow lint pass in the always-running classifier path.

## Review remediation

- REV-001: added `actions: read` for the workflow-run API lookup.
- REV-002: made actionlint pinning unconditional and checksum-verified.
- REV-003: reconciled the maintained review/testing guidance with the repaired operational state, including durable activation/recovery semantics and the workflow-validation tool/network dependency.

## Validation

- pre-fix regression guard: reproduced the workflow parser failure
- previous repaired head completed the full CI matrix green
- current documentation-remediation head `4e2250d6c289498314f49d53fc9f5efbf60a2a74` has fresh CI run `34148819533` pending
- repaired heads no longer produce the zero-job invalid `.github/workflows/pr-disposition.yml` run; only ordinary CI is expected before the trusted definition reaches `main`

`disposition` remains temporarily removed from the `Protect main` required-check list while this infrastructure repair is in flight.

## Post-merge activation

Because the trusted disposition workflow definition is loaded from `main`, end-to-end production verification must happen after this PR is merged:

1. submit/use a canonical current-head review on an open PR and verify an actual `disposition` check-run is published on that head
2. verify a subsequent head change invalidates the old authorization
3. only then restore `disposition` to the `Protect main` required-check list
