### PR TITLE
docs: separate research from implementation planning

### DIFF
--- a/.github/agents/consistency.agent.md
+++ b/.github/agents/consistency.agent.md
@@ -59,7 +59,8 @@ Use this hierarchy by question:
 | What is Arcogine ultimately trying to become? | `docs/product/charter.md` |
 | How does the implemented system work today? | `docs/architecture/overview.md` corroborated by source and executable evidence |
 | Why was a significant architectural decision made? | accepted ADRs in `docs/architecture/decisions/` |
-| What is planned, gated, partial, deferred, or blocked? | applicable documents in `docs/planning/` |
+| What unresolved questions, research lifecycle/status, or research portfolio priorities exist? | `docs/research/README.md` and its linked detailed research artifacts |
+| What implementation work is planned, gated, partial, deferred, or blocked? | applicable documents in `docs/planning/` |
 | What public API or interface exists today? | implementation and tests, reconciled with `docs/reference/` and consumer code |
 | What commands, versions, modules, builds, or CI behavior actually exist? | executable scripts and configuration |
 | What is the contributor/review process? | `.github/CONTRIBUTING.md` and `docs/development/` |
@@ -72,6 +73,8 @@ GitHub Issues are authoritative for **finding identity and lifecycle continuity 
 The GitHub issue number is the canonical collision-safe storage identity. `CONS-*` is a human-readable alias, not a second independently allocated identity source. Once an alias is bound to an issue, its numeric portion is immutable even if descriptive title wording changes.
 
 This file defines review procedure, not Arcogine product or architecture semantics. Never treat it as a competing architectural authority.
+
+Research and planning are complementary but distinct authorities. `docs/research/` owns unresolved investigations, evidence expectations, research lifecycle, and portfolio priority; it is not accepted architecture or implementation commitment. `docs/planning/` owns admitted implementation sequencing, status, dependencies, and acceptance evidence; it must not settle unresolved research questions. When a consistency question concerns exploratory material, a research status, or a planning item whose contract depends on research, read the research register and relevant artifact and report research state separately from implementation state.
 
 ### Important temporal distinctions
 
@@ -91,6 +94,8 @@ Classify material claims before comparing them. Use these states where useful:
 
 Do not report a disagreement merely because a `PROPOSED` or `PLANNED` artifact differs from current source. Do report a current-state document that presents planned behavior as implemented.
 
+Research has a separate lifecycle defined by `docs/research/README.md`: `CANDIDATE`, `READY`, `ACTIVE`, `CONCLUDED`, and `SUPERSEDED`. Preserve those labels when assessing research. In particular, `READY` means that an investigation can start, not that its implementation is ready, and research priority is not implementation commitment.
+
 ## Start-of-run grounding
 
 At the beginning of every review, re-ground yourself in the repository rather than relying on prior memory or a previously cached copy of this contract.
@@ -102,12 +107,13 @@ At the beginning of every review, re-ground yourself in the repository rather th
 5. Read `docs/README.md` to understand documentation organization and authority.
 6. Read `docs/architecture/overview.md` for current architecture.
 7. Read the ADR index and inventory accepted, proposed, superseded, and historical decisions as represented by the repository.
-8. Inventory relevant planning documents and their stated statuses.
-9. Read `.github/CONTRIBUTING.md`, `docs/development/reviewing.md`, and `docs/development/testing.md` when reviewing development, CI, or evidence claims.
-10. Load the durable consistency finding ledger from GitHub Issues: search open and closed issues whose titles begin with `CONS-`, and also search for `[CONSISTENCY-UNBOUND]` issues left by an interrupted synchronization. A `consistency` label may be used as an additional filter when present, but never rely on the label as the sole discovery mechanism.
-11. Build a prior-finding map by GitHub issue number, immutable `CONS-*` alias when bound, semantic subject, issue state, and linked remediation PRs. Closed issues must remain visible to regression detection.
-12. Identify recently merged and currently open pull requests relevant to the requested review window, including open PRs linked from consistency issues.
-13. Record the exact head/baseline and issue-ledger scope used in the report.
+8. Inventory relevant planning documents and their stated implementation statuses.
+9. Read `docs/research/README.md` and inventory its research questions, lifecycle, and priority; when the review touches unresolved meaning, research status/priority, or a planning item with a research dependency, also read the relevant detailed artifacts and record their research lifecycle separately from planning status.
+10. Read `.github/CONTRIBUTING.md`, `docs/development/reviewing.md`, and `docs/development/testing.md` when reviewing development, CI, or evidence claims.
+11. Load the durable consistency finding ledger from GitHub Issues: search open and closed issues whose titles begin with `CONS-`, and also search for `[CONSISTENCY-UNBOUND]` issues left by an interrupted synchronization. A `consistency` label may be used as an additional filter when present, but never rely on the label as the sole discovery mechanism.
+12. Build a prior-finding map by GitHub issue number, immutable `CONS-*` alias when bound, semantic subject, issue state, and linked remediation PRs. Closed issues must remain visible to regression detection.
+13. Identify recently merged and currently open pull requests relevant to the requested review window, including open PRs linked from consistency issues.
+14. Record the exact head/baseline and issue-ledger scope used in the report.
 
 If any required repository surface or the issue ledger cannot be inspected, say so and mark the review `INCOMPLETE`; do not silently infer its contents. A diagnostic-only run may still describe genuinely new evidence as `UNPERSISTED`, but it must not invent a durable `CONS-*` alias when the ledger cannot be reconciled.
 

--- a/.github/agents/work-planner.agent.md
+++ b/.github/agents/work-planner.agent.md
@@ -72,7 +72,8 @@ Repository evidence is authoritative over prior chat/session context and agent m
 | What is Arcogine ultimately trying to become? | `docs/product/charter.md` |
 | How does the implemented system work today? | `docs/architecture/overview.md` corroborated by source and executable evidence |
 | Why does a significant architectural constraint exist? | applicable accepted ADRs in `docs/architecture/decisions/` |
-| What is planned, sequenced, partial, deferred, blocked, or explicitly non-goal? | applicable `docs/planning/` documents |
+| What unresolved questions, research lifecycle/status, or research portfolio priorities exist? | `docs/research/README.md` and its linked detailed research artifacts |
+| What implementation work is admitted, sequenced, partial, deferred, blocked, or explicitly non-goal? | applicable `docs/planning/` documents |
 | What has landed/currently exists? | live `main` plus merged PR/commit history |
 | What is in progress? | live open PR state, including submitted reviews, review threads, CI, and mergeability |
 | What is this open PR intended to accomplish? | PR description reconciled with current planning and prerequisites |
@@ -81,7 +82,7 @@ Repository evidence is authoritative over prior chat/session context and agent m
 | How are implementation PRs independently reviewed? | `docs/development/reviewing.md` and `.github/agents/pr-reviewer.agent.md` |
 | How is repository-wide consistency review performed? | `.github/agents/consistency.agent.md` |
 
-Planning documents define intended sequencing and acceptance criteria. Merged implementation and executable evidence on live `main` define what exists. Open PRs are in-flight evidence, never landed capability.
+Research documents define unresolved questions, evidence expectations, research lifecycle, and portfolio priority; they do not commit implementation. Planning documents define admitted implementation sequencing, dependencies, and acceptance criteria; they do not settle unresolved research questions. Merged implementation and executable evidence on live `main` define what exists. Open PRs are in-flight evidence, never landed capability.
 
 ## Start-of-run grounding
 
@@ -93,11 +94,12 @@ At the start of every planning run:
 4. Read `AGENTS.md`.
 5. Read `docs/architecture/overview.md` when the decision crosses modules, domains, or architecture boundaries.
 6. Extract the main initiative, gate, capability, or domain keywords from the user's request and perform a quick repository search under `docs/` for them.
-7. Read the maintained planning document(s), directly relevant architecture documents, and applicable accepted/proposed ADRs.
-8. Inspect all open PRs relevant to the decision.
-9. Inspect recent merged PRs far enough back to understand what just landed and whether maintained planning status may have changed.
-10. For each relevant open PR, inspect the current head/base, description, mergeability/conflicts, CI/check status, submitted reviews, and unresolved review threads/findings where available.
-11. Record any required repository, PR, review, or CI surface that could not be inspected.
+7. Read `docs/research/README.md` for research lifecycle and portfolio priority, and read any linked research artifact when the question concerns unresolved meaning or a planning dependency on research; keep research state separate from implementation readiness.
+8. Read the maintained planning document(s), directly relevant architecture documents, and applicable accepted/proposed ADRs.
+9. Inspect all open PRs relevant to the decision.
+10. Inspect recent merged PRs far enough back to understand what just landed and whether maintained planning or research status may have changed.
+11. For each relevant open PR, inspect the current head/base, description, mergeability/conflicts, CI/check status, submitted reviews, and unresolved review threads/findings where available.
+12. Record any required repository, PR, review, or CI surface that could not be inspected.
 
 Never assume a PR number, gate status, or dependency from previous conversation context. Re-check it.
 
@@ -117,6 +119,8 @@ Classify material work before recommending it:
 - `PARALLEL_READY` — independent work can safely proceed alongside the critical path.
 - `DEFERRED` — intentionally postponed by maintained planning.
 - `OPTIONAL_DEBT` — useful cleanup/refinement that is not currently on the critical path.
+
+Research uses its own lifecycle, defined by `docs/research/README.md`: `CANDIDATE`, `READY`, `ACTIVE`, `CONCLUDED`, or `SUPERSEDED`. Research priority is portfolio guidance, not delivery commitment. A `READY` research item means its question is ready for investigation; it does not mean implementation is ready. Do not translate research status into planning status, and classify an implementation slice as dependency-blocked when its contract still depends on an unresolved research question.
 
 If an open PR changes a planning status, state both realities explicitly:
 
@@ -154,7 +158,7 @@ For each candidate next slice, distinguish:
 - optional refinement or debt;
 - future integration that should not block the core capability.
 
-Do not infer a hard dependency merely because two concepts are related. Require maintained architecture/planning evidence or an executable contract dependency.
+Read the maintained research register when a candidate slice depends on unresolved meaning or evidence. Distinguish a research dependency from an implementation prerequisite: research priority may identify leverage or risk, but it does not authorize pulling an implementation slice into planning. Do not infer a hard dependency merely because two concepts are related. Require maintained architecture/planning evidence, a research conclusion promoted into a durable authority, or an executable contract dependency.
 
 ### 4. Prefer closure evidence over abstraction growth
 
@@ -221,12 +225,13 @@ When review findings exist, distinguish valid current blockers from findings alr
 
 ## Planning across active tracks
 
-When repository-wide planning is requested, identify the principal active tracks from current `docs/planning/` rather than from a hard-coded list. For each relevant track, identify:
+When repository-wide planning is requested, identify the principal active implementation tracks from current `docs/planning/` and the material research dependencies from `docs/research/`, rather than from a hard-coded list. For each relevant track, identify:
 
 - latest landed gate/slice on live `main`;
 - open in-flight gate/slice;
 - next locally ready gate/slice;
 - hard sibling prerequisite status;
+- unresolved research dependency, if any, including its research lifecycle and portfolio priority;
 - useful independent parallel work;
 - downstream/deferred work that should not be pulled forward.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,114 +3,97 @@
 ## Start here
 
 | Document | Who it's for | What it covers |
-|----------|-------------|----------------|
-| [Product Charter](product/charter.md) | Everyone | Arcogine's enduring product vision, system thesis, and principles — read this first |
-| [Root README](../README.md) | Everyone | What Arcogine is today, canonical setup/local-run guide, first session |
-| [Concepts](product/concepts.md) | New users | How the current simulation works, KPIs, agents, scenarios |
-| [API Reference](reference/api.md) | Developers | Every HTTP endpoint with curl examples |
+|---|---|---|
+| [Product Charter](product/charter.md) | Everyone | Enduring product thesis and principles |
+| [Root README](../README.md) | Everyone | What Arcogine is today, setup, and local run |
+| [Concepts](product/concepts.md) | New users | Current simulation concepts and behavior |
+| [API Reference](reference/api.md) | Developers | Current HTTP API contract |
 
 ## Documentation hierarchy
 
-Arcogine's documentation is layered, and each layer answers a different question:
+Arcogine separates durable direction, current truth, research, and executable planning:
 
-- **[`product/charter.md`](product/charter.md)** — normative. What Arcogine is ultimately intended to become, and the principles future work is evaluated against. Not a roadmap, not a feature list.
-- **[`architecture/overview.md`](architecture/overview.md)** — current architecture plus the enduring architectural principles that follow from the Charter. Explains how the system is built today and which parts of that are expected to persist regardless of implementation.
-- **[`architecture/decisions/`](architecture/decisions/README.md)** (ADRs) — historical rationale for significant, hard-to-reverse decisions: *why* the system ended up the way it did, operating under the Charter and current architecture rather than setting product direction themselves.
-- **[`product/concepts.md`](product/concepts.md)**, **[`reference/api.md`](reference/api.md)**, [`../product/interfaces/web/README.md`](../product/interfaces/web/README.md) — current capability/reference documentation. Describe what exists now, honestly, without projecting future capability.
-- **[`research/`](research/README.md)** — maintained research backlog and bounded investigations. Answers what Arcogine still needs to understand or decide. Research is evidence, not accepted architecture, roadmap commitment, or current capability.
-- **[`planning/`](planning/)** — executable delivery planning: implementation proposals, dependencies, sequencing, readiness criteria, and acceptance evidence. Answers what work should be performed given current decisions; not authoritative for current capability or enduring product/architecture direction.
+- **[`product/charter.md`](product/charter.md)** — normative product direction and enduring principles; not a roadmap.
+- **[`architecture/overview.md`](architecture/overview.md)** — current architecture plus enduring architectural principles.
+- **[`architecture/decisions/`](architecture/decisions/README.md)** — rationale for significant hard-to-reverse choices.
+- **Current capability/reference docs** — [`product/concepts.md`](product/concepts.md), [`reference/api.md`](reference/api.md), and consumer/component references describe what exists now.
+- **[`research/`](research/README.md)** — open questions, hypotheses, evidence, and decision-quality investigations. Research is not accepted architecture or implementation commitment.
+- **[`planning/`](planning/README.md)** — implementation-ready delivery planning only: admitted slices, dependencies, blockers on concrete prerequisites, acceptance evidence, and implementation status.
 
-When documents disagree, the higher layer governs product direction; the lower layer remains authoritative for current implementation detail. Proposed architecture references and Proposed ADRs describe a target or decision under consideration; they do not override current-state documentation. Accepted ADRs constrain intended architecture, but they likewise do not make unimplemented behavior current capability. Research conclusions do not become authoritative merely by being recorded under `research/`; surviving conclusions must be promoted into the appropriate product, architecture, decision, or planning authority.
+Research discovers. Product/architecture/ADRs establish durable meaning. Planning sequences concrete implementation. Landed code/tests and current-state docs establish what actually exists.
 
-### Durable semantic vocabulary
+A research conclusion does not become authoritative merely because it is recorded. An unresolved question that still determines implementation meaning must not be hidden inside a delivery plan.
 
-Planning documents use the reserved `PLAN-<TRACK>-<LOCAL-ID>` namespace for delivery coordinates, and PRs/reviews use the separate `REV-<NNN>` namespace for review/finding identifiers (see `AGENTS.md`), because those coordinates are useful while work is being sequenced or tracked. Durable semantic naming — current-state documentation, and non-Markdown durable artifacts such as code comments, workflow definitions, and test names — must instead name capabilities, contracts, identities, invariants, and behaviors directly rather than depend on a temporary delivery coordinate. Working/process documentation and delivery-history records (including commit messages) may mention a delivery coordinate when the coordinate itself is part of the process being explained or was actually used to track the work.
+### Delivery-coordinate boundary
 
-Research documents deliberately do not use temporary delivery coordinates. When a research conclusion produces executable work, capture that work in `docs/planning/` under the repository's delivery-coordinate rules rather than turning the research artifact into a shadow roadmap.
+Temporary delivery coordinates belong to executable planning/delivery context, not research or durable semantic naming. When research produces an implementable responsibility, promote the semantic conclusion first and then assign the delivery coordinate in `docs/planning/`.
 
-A durable document may link to a planning document for implementation sequencing, but it must remain understandable if the plan is later completed, condensed, renamed, or removed. When a planned outcome becomes architecture or current capability, translate the delivery label into semantic terminology rather than carrying the plan's coordinate into ADRs, architecture, product, reference, or durable development guidance. Planning filenames stay semantic rather than coordinate-derived for the same reason.
+## Cross-track ownership
 
-The mechanical checker (`.github/scripts/check-delivery-labels.py`) enforces this deterministically across every tracked repository file: a `PLAN-*`/`REV-<NNN>` coordinate outside `docs/planning/` is a durable-naming leak; inside `docs/planning/`, the old ambiguous label forms this namespace replaced may not be reintroduced. PR review applies the broader semantic rule and catches context-dependent leakage no syntax pattern can recognize safely. ADR-specific semantics-preserving editorial amendments follow the policy in [`architecture/decisions/README.md`](architecture/decisions/README.md).
-
-## Cross-track ownership map
-
-The active architecture/readiness tracks are siblings with explicit ownership boundaries. They may progress in parallel using clearly scoped fixtures, but one track must not invent durable substitutes for another track's owned semantics.
-
-| Concern | Primary owner | Boundary |
+| Concern | Primary authority / delivery surface | Boundary |
 |---|---|---|
-| Canonical production-system semantics, validation, publication, deterministic instantiation | [Factory design architecture](architecture/factory-design.md) / [Factory design capability](planning/factory-design-capability.md) | Published semantic model is the shared source for downstream contexts |
-| Deterministic workload, dispatch, simulation session, runtime events/observations, spatial consequences | [Factory simulation engine readiness](planning/factory-simulation-engine-readiness.md) | Owns simulation/runtime truth; does not become a production-control runtime by default |
-| Durable semantic fingerprint policy, controlled revision lineage, ChangeSets, requirements/assertions, conformance, evidence use, findings/exceptions | [Governance and conformance](architecture/governance-conformance.md) / [capability plan](planning/governance-conformance-capability.md) | Durable revision identity/history, semantic change/impact, requirements/assertions, and conformance evaluation/findings are implemented; evidence-use/authorization capabilities remain outstanding; operational facts may be consumed as evidence, but Governance does not ingest telemetry or reconcile the twin |
-| Durable operational-history attribution (identity under review), verified operational identity/trust, semantic operation realization and command/result lifecycle, deployment application, external observations, subject correspondence, reconciliation, drift/calibration feedback, adapter resilience | [Operational execution and digital twin](architecture/operational-execution-digital-twin.md) / [readiness plan](planning/operational-execution-digital-twin-readiness.md) | Reality/consequence is relationship-level rather than a global execution kind; raw external observations keep independent provenance; operational work references Governance-owned revision, semantic-change, and evidence-use contracts when those exist |
-| Game challenge identity, admissibility, scoring, attempt provenance/comparison | [Factory-design game challenge readiness](planning/factory-design-game-challenge-readiness.md) | Sibling proving ground; no generic evaluation framework or domain-type unification |
-
-Two dependency rules are especially important:
-
-1. **Fixtures are not sibling completion.** Governance's durable revision identity/history, semantic `ChangeSet`/impact, generic `Requirement`/`Assertion`/`RequirementCatalogue`, and initial `ConformanceEvaluator`/`ConformanceEvaluation`/`Finding` capabilities are implemented and should be consumed rather than replaced by synthetic production substitutes. Clearly scoped synthetic fixtures remain appropriate only for still-outstanding evidence-use/authorization capabilities; likewise synthetic operational adapters do not satisfy Engine readiness criteria.
-2. **External observations are not Arcogine operational-history-, model-, or revision-bound at ingestion.** Their source/subject/time/trust provenance is independent. Arcogine-owned subject correspondence and later model/revision/operational-history interpretation belong to explicit correspondence, reconciliation, deployment correlation, or Governance `EvidenceUse` relationships when applicable.
+| Canonical production-system semantics, validation, publication, deterministic instantiation | [Factory design architecture](architecture/factory-design.md) / [Factory design plan](planning/factory-design-capability.md) | One published semantic model is the downstream source of truth |
+| Deterministic workload, work items, dispatch, session, supported observations/events, spatial consequences | [Engine readiness](planning/factory-simulation-engine-readiness.md) | Simulation runtime truth; not production-control semantics |
+| Durable semantic fingerprint/revision history, semantic change, requirements, conformance, evidence/governed change | [Governance architecture](architecture/governance-conformance.md) / [Governance plan](planning/governance-conformance-capability.md) | Governance does not ingest telemetry or perform external actuation/reconciliation |
+| Operational identity/trust, external realization, subject correspondence, external observations, reconciliation, drift/resilience | [Operational architecture](architecture/operational-execution-digital-twin.md) / [Operational research](research/operational-execution-digital-twin-boundaries.md) | No implementation is currently admitted until the required semantic boundaries are resolved |
+| Game challenge identity, catalogue/economics, admissibility, evaluation, attempt comparison | [Challenge plan](planning/factory-design-game-challenge-readiness.md) | Headless game-owned rules; not production simulation |
+| Playable factory-design product hypothesis | [Game vertical-slice research](research/factory-design-game-vertical-slice.md) | Product evidence first; implementation only after promotion into the consumer plan |
 
 ## Development and contributing
 
-The root [README](../README.md#quick-start) owns environment setup and local-run instructions. Contributor and testing documents reference that setup rather than maintaining parallel startup procedures.
-
 | Document | What it covers |
-|----------|-----------------|
-| [CONTRIBUTING.md](../.github/CONTRIBUTING.md) | Contribution workflow, code style, architecture constraints, required validation |
-| [reviewing.md](development/reviewing.md) | Independent PR review and re-review workflow, severity/disposition, AI-assisted session boundaries, CI language, and durable-knowledge rules |
-| [consistency-review.md](development/consistency-review.md) | Human operating model for recurring repository consistency reviews, finding persistence, baseline discipline, and the trigger for durable review-state storage |
-| [testing.md](development/testing.md) | Full test category reference, CI pipeline, quality gates, native test commands |
-| [repository-snapshot.md](development/repository-snapshot.md) | Generate the canonical whole-repository Repomix retrieval snapshot |
-| [codex-cloud.md](development/codex-cloud.md) | Observed Codex Cloud environment model, validated workflow, limitations, and recommended bounded-task usage |
-| [coding-agent-evaluation.md](development/coding-agent-evaluation.md) | Dated, non-normative evaluation of coding-agent/model cost-effectiveness, Arcogine task routing, and comparative experiment evidence |
-| [CODE_OF_CONDUCT.md](../.github/CODE_OF_CONDUCT.md) | Community standards |
+|---|---|
+| [CONTRIBUTING.md](../.github/CONTRIBUTING.md) | Contribution workflow, style, validation |
+| [reviewing.md](development/reviewing.md) | Independent PR review/re-review workflow |
+| [consistency-review.md](development/consistency-review.md) | Recurring repository consistency-review operating model |
+| [testing.md](development/testing.md) | Test categories, CI, quality gates, native commands |
+| [repository-snapshot.md](development/repository-snapshot.md) | Canonical whole-repository retrieval snapshot |
+| [codex-cloud.md](development/codex-cloud.md) | Codex Cloud environment/workflow notes |
+| [coding-agent-evaluation.md](development/coding-agent-evaluation.md) | Non-normative coding-agent/model evaluation |
+| [SECURITY.md](../.github/SECURITY.md) | Security policy and mature operational security boundary |
 
 ## Architecture and design
 
 | Document | What it covers |
-|----------|-----------------|
-| [Architecture](architecture/overview.md) | Current design philosophy (including Events–State–Observations), module structure, determinism contract, event dispatch, technology stack |
-| [Factory design architecture](architecture/factory-design.md) | Proposed cross-consumer factory-design semantics, scenario/model/runtime separation, publication boundary, spatial ownership, and design-lifecycle principles |
-| [Governance and conformance architecture](architecture/governance-conformance.md) | Proposed cross-domain model lineage, semantic change, requirements, conformance, evidence, governed change, and compliance-as-projection architecture |
-| [Operational execution and digital twin architecture](architecture/operational-execution-digital-twin.md) | Proposed relationship-based execution/reality architecture covering hybrid synthetic/external realization, durable operational-history attribution, verified identity/trust, command/result facts, deployment, external observations, subject correspondence, reconciliation, drift/calibration, and industrial-adapter boundaries |
-| [Engine Semantics v1](architecture/engine-semantics-v1.md) | Normative `engine-semantics:v1` specification — result-affecting Engine interpretation, including deterministic dispatch/queue/decomposition rules, spatial transfer semantics, provenance, and limits |
-| [Factory Model v2 Canonicalization](architecture/factory-model-v2.md) | Normative `factory-model:v2` byte grammar — policy-domain prefix, field order, primitive encodings, placement/footprint encoding, collection ordering, digest rendering, and required golden vectors |
-| [ADR-0003: Canonical factory model boundary](architecture/decisions/0003-canonical-factory-model-boundary.md) | Accepted decision that `ScenarioConfig` remains a run envelope while immutable published factory-model versions bridge design and runtime |
-| [ADR-0004: Model identity, revision lineage, and external change control](architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md) | Accepted decision separating semantic model fingerprint from controlled revision/change-management identity, with external change-management systems referenced, not depended on |
-| [ADR-0011: Runtime observation and event contract](architecture/decisions/0011-runtime-observation-and-event-contract.md) | Accepted semantics separating internal scheduler events, authoritative observations, ordered runtime events, transport adapters, and later recovery |
-| [ADR-0012: External interchange and serialization boundaries](architecture/decisions/0012-external-interchange-and-serialization-boundaries.md) | Accepted policy keeping Arcogine semantic contracts authoritative while JSON/OpenAPI, CloudEvents, Parquet, industrial standards, and other representations remain explicit projections/adapters |
-| [ADR-0013: Durable operational identity](architecture/decisions/0013-execution-context-identity.md) | Proposed decision on architecture-review hold: the original global `ExecutionContextKind` / `PRODUCTION-STAGING-SIMULATION` contract is withdrawn; the narrower durable operational-history identity problem remains unresolved pending a precise referent and lifecycle/equality rule |
-| [Standards alignment](architecture/standards-alignment.md) | Standards, format-selection, interchange, and conformance boundaries across manufacturing, runtime, analytics, governance, and operational integrations |
-| [ISA-95 semantic mapping](architecture/isa-95-semantic-mapping.md) | Maintained Arcogine-to-ISA-95 concept mapping, deliberate divergences, structural gaps, and design-review policy |
-| [Vision (superseded)](product/vision.md) | Pointer to the Product Charter; retains naming/etymology history only |
-| [Decision records](architecture/decisions/README.md) | Architecture/design decision history — why significant choices were made |
-| [SECURITY.md](../.github/SECURITY.md) | Security policy, hardening posture, deployment constraints, and mature operational trust boundary |
+|---|---|
+| [Architecture overview](architecture/overview.md) | Current design, modules, determinism and Events-State-Observations principles |
+| [Factory design](architecture/factory-design.md) | Cross-consumer factory-model/design lifecycle semantics |
+| [Governance and conformance](architecture/governance-conformance.md) | Revision/change/requirements/conformance/evidence/governed-change architecture |
+| [Operational execution and digital twin](architecture/operational-execution-digital-twin.md) | Proposed relationship-based execution/reality architecture |
+| [Engine Semantics v1](architecture/engine-semantics-v1.md) | Normative current result-affecting Engine interpretation |
+| [Factory Model v2](architecture/factory-model-v2.md) | Normative v2 canonicalization/fingerprint byte grammar |
+| [Standards alignment](architecture/standards-alignment.md) | Standards/interchange/conformance boundaries |
+| [ISA-95 semantic mapping](architecture/isa-95-semantic-mapping.md) | Maintained manufacturing semantic mapping and deliberate divergences |
+| [Decision records](architecture/decisions/README.md) | ADR index and policy |
+
+## Internal research
+
+| Document | What it covers |
+|---|---|
+| [Research register](research/README.md) | Portfolio status, priority, promotion policy |
+| [Agency and decision boundary](research/agency-decision-boundary.md) | Actor/controller/subject/capability/operation/replay investigation |
+| [Factory Design evolution](research/factory-design-evolution.md) | Equipment ontology, diagnostics, comparison, shared drafts, resource groups, later Factory evolution |
+| [Factory-design game vertical slice](research/factory-design-game-vertical-slice.md) | Product loop, diagnostics, reference challenge, scoring/tutorial/technology evidence |
+| [Engine evolution](research/engine-evolution.md) | Lot/batch, capability/pools, dispatch-policy and unselected recovery/session extensions |
+| [Operational/Digital Twin boundaries](research/operational-execution-digital-twin-boundaries.md) | Durable operational identity, trust/authority, external realization, correspondence, reconciliation and proving-case research |
+
+## Internal implementation planning
+
+See [planning/README.md](planning/README.md) for the admission rule.
+
+| Document | What it covers |
+|---|---|
+| [Factory Design capability](planning/factory-design-capability.md) | Current canonical-model baseline and admitted v2 implementation work |
+| [Factory Simulation Engine readiness](planning/factory-simulation-engine-readiness.md) | Completed runtime core plus current outward-convergence and spatial implementation queue |
+| [Runtime observation/event delivery](planning/runtime-observation-event-delivery.md) | Detailed remaining outward consumer convergence for supported observations/events |
+| [Spatial runtime consequences](planning/spatial-runtime-consequences.md) | Detailed accepted spatial/Engine-semantics implementation sequence |
+| [Governance/conformance capability](planning/governance-conformance-capability.md) | Landed Governance substrate plus admitted evidence/governed-change/exceptions/mapping/audit sequence |
+| [Governance identity/history compatibility guard](planning/governance-continuity.md) | Downstream implementation invariants over completed revision identity/history |
+| [Challenge delivery](planning/factory-design-game-challenge-readiness.md) | Closed headless challenge sequence and downstream invariants |
+| [Game consumer](planning/factory-design-game-consumer.md) | Settled ownership/integration boundary and playable implementation admission criteria |
+| [Game vertical-slice implementation gate](planning/factory-design-game-vertical-slice.md) | Explicit gate from product research into playable implementation |
+| [Operational implementation admission](planning/operational-execution-digital-twin-readiness.md) | Concrete conditions that must be met before an Operational delivery slice is created |
 
 ## Examples
 
-| Document | What it covers |
-|----------|-----------------|
-| [Examples README](examples/README.md) | Executable TOML scenario fixtures (educational, not runtime assets — never shipped in `dist/` or Docker images) |
-
-## Internal research (maintainers)
-
-Research artifacts preserve open questions, evidence, and bounded investigations without committing implementation. The maintained register owns research status and prioritization; durable conclusions must be reconciled into product, architecture, decisions, or executable planning rather than left authoritative here.
-
-| Document | What it covers |
-|----------|-----------------|
-| [Research register](research/README.md) | Maintained portfolio of candidate, ready, active, concluded, and superseded research questions, with priority, dependencies, evidence destinations, and research-to-planning promotion rules |
-| [Agency and decision boundary investigation](research/agency-decision-boundary.md) | Bounded cross-cutting research into actor vs. decision-source vs. subject semantics, agent-as-composition, provenance/replay for deterministic and nondeterministic decisions, temporally extended capabilities, and the evidence required before creating any generalized agent abstraction or delivery track |
-
-## Internal planning (maintainers)
-
-These documents are executable delivery-planning artifacts, not user-facing guides or research backlogs. Planning filenames are semantic rather than coordinate-derived (see "Durable semantic vocabulary" above), so the link text below simply matches each document's subject.
-
-| Document | What it covers |
-|----------|-----------------|
-| [Factory design capability plan](planning/factory-design-capability.md) | Immediate upstream work: canonical model seam, validation, publication/provenance, and behavior-preserving runtime instantiation |
-| [Governance and conformance capability plan](planning/governance-conformance-capability.md) | Cross-cutting sequence after the model seam: durable lineage, semantic ChangeSets, generic conformance, evidence, external-workflow governed change, framework mappings, and audit projections |
-| [Factory simulation engine readiness](planning/factory-simulation-engine-readiness.md) | Runtime readiness after the model seam: explicit workload/work execution, deterministic dispatch, session control, observations/events, and spatial consequences |
-| [Runtime observation/event delivery plan](planning/runtime-observation-event-delivery.md) | Implementation companion for ADR-0011: work-decomposition benchmark prerequisite, headless observation/event slices, provenance, API/SSE migration, recovery boundary, and PR landing sequence |
-| [Operational execution and digital twin readiness](planning/operational-execution-digital-twin-readiness.md) | Sibling readiness track currently architecture-blocked on durable operational identity; covers verified trust/authority, semantic operation realization and command/deployment lifecycle, external observations, authoritative subject correspondence, reconciliation, drift/calibration, resilience, and a first live-system adapter proving ground with explicit Governance/Engine prerequisites |
-| [Factory-design game challenge readiness](planning/factory-design-game-challenge-readiness.md) | Game-owned parallel track for challenge identity/validation, candidate admissibility, catalogue and budget rules, deterministic evaluation, attempt provenance/comparison, and cross-track learning with governance |
-| [Factory-design game consumer initiative](planning/factory-design-game-consumer.md) | Downstream consumer boundary between the game and Arcogine, including readiness entry criteria and ownership constraints |
-| [Factory-design game vertical slice](planning/factory-design-game-vertical-slice.md) | Product hypothesis for the first playable slice: fixed contract, capacity/layout/cost trade-offs, diagnosis, and deterministic redesign |
+[Examples](examples/README.md) are executable TOML scenario fixtures for education/testing; they are not runtime distribution assets.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,13 +17,16 @@ Arcogine's documentation is layered, and each layer answers a different question
 - **[`architecture/overview.md`](architecture/overview.md)** — current architecture plus the enduring architectural principles that follow from the Charter. Explains how the system is built today and which parts of that are expected to persist regardless of implementation.
 - **[`architecture/decisions/`](architecture/decisions/README.md)** (ADRs) — historical rationale for significant, hard-to-reverse decisions: *why* the system ended up the way it did, operating under the Charter and current architecture rather than setting product direction themselves.
 - **[`product/concepts.md`](product/concepts.md)**, **[`reference/api.md`](reference/api.md)**, [`../product/interfaces/web/README.md`](../product/interfaces/web/README.md) — current capability/reference documentation. Describe what exists now, honestly, without projecting future capability.
-- **[`planning/`](planning/)** — temporary analysis, proposals, sequencing, and assessments. Useful for delivery context; not authoritative for current or future direction.
+- **[`research/`](research/README.md)** — maintained research backlog and bounded investigations. Answers what Arcogine still needs to understand or decide. Research is evidence, not accepted architecture, roadmap commitment, or current capability.
+- **[`planning/`](planning/)** — executable delivery planning: implementation proposals, dependencies, sequencing, readiness criteria, and acceptance evidence. Answers what work should be performed given current decisions; not authoritative for current capability or enduring product/architecture direction.
 
-When documents disagree, the higher layer governs product direction; the lower layer remains authoritative for current implementation detail. Proposed architecture references and Proposed ADRs describe a target or decision under consideration; they do not override current-state documentation. Accepted ADRs constrain intended architecture, but they likewise do not make unimplemented behavior current capability.
+When documents disagree, the higher layer governs product direction; the lower layer remains authoritative for current implementation detail. Proposed architecture references and Proposed ADRs describe a target or decision under consideration; they do not override current-state documentation. Accepted ADRs constrain intended architecture, but they likewise do not make unimplemented behavior current capability. Research conclusions do not become authoritative merely by being recorded under `research/`; surviving conclusions must be promoted into the appropriate product, architecture, decision, or planning authority.
 
 ### Durable semantic vocabulary
 
 Planning documents use the reserved `PLAN-<TRACK>-<LOCAL-ID>` namespace for delivery coordinates, and PRs/reviews use the separate `REV-<NNN>` namespace for review/finding identifiers (see `AGENTS.md`), because those coordinates are useful while work is being sequenced or tracked. Durable semantic naming — current-state documentation, and non-Markdown durable artifacts such as code comments, workflow definitions, and test names — must instead name capabilities, contracts, identities, invariants, and behaviors directly rather than depend on a temporary delivery coordinate. Working/process documentation and delivery-history records (including commit messages) may mention a delivery coordinate when the coordinate itself is part of the process being explained or was actually used to track the work.
+
+Research documents deliberately do not use temporary delivery coordinates. When a research conclusion produces executable work, capture that work in `docs/planning/` under the repository's delivery-coordinate rules rather than turning the research artifact into a shadow roadmap.
 
 A durable document may link to a planning document for implementation sequencing, but it must remain understandable if the plan is later completed, condensed, renamed, or removed. When a planned outcome becomes architecture or current capability, translate the delivery label into semantic terminology rather than carrying the plan's coordinate into ADRs, architecture, product, reference, or durable development guidance. Planning filenames stay semantic rather than coordinate-derived for the same reason.
 
@@ -88,9 +91,18 @@ The root [README](../README.md#quick-start) owns environment setup and local-run
 |----------|-----------------|
 | [Examples README](examples/README.md) | Executable TOML scenario fixtures (educational, not runtime assets — never shipped in `dist/` or Docker images) |
 
+## Internal research (maintainers)
+
+Research artifacts preserve open questions, evidence, and bounded investigations without committing implementation. The maintained register owns research status and prioritization; durable conclusions must be reconciled into product, architecture, decisions, or executable planning rather than left authoritative here.
+
+| Document | What it covers |
+|----------|-----------------|
+| [Research register](research/README.md) | Maintained portfolio of candidate, ready, active, concluded, and superseded research questions, with priority, dependencies, evidence destinations, and research-to-planning promotion rules |
+| [Agency and decision boundary investigation](research/agency-decision-boundary.md) | Bounded cross-cutting research into actor vs. decision-source vs. subject semantics, agent-as-composition, provenance/replay for deterministic and nondeterministic decisions, temporally extended capabilities, and the evidence required before creating any generalized agent abstraction or delivery track |
+
 ## Internal planning (maintainers)
 
-These documents are internal planning artifacts, not user-facing guides. Planning filenames are semantic rather than coordinate-derived (see "Durable semantic vocabulary" above), so the link text below simply matches each document's subject.
+These documents are executable delivery-planning artifacts, not user-facing guides or research backlogs. Planning filenames are semantic rather than coordinate-derived (see "Durable semantic vocabulary" above), so the link text below simply matches each document's subject.
 
 | Document | What it covers |
 |----------|-----------------|
@@ -99,7 +111,6 @@ These documents are internal planning artifacts, not user-facing guides. Plannin
 | [Factory simulation engine readiness](planning/factory-simulation-engine-readiness.md) | Runtime readiness after the model seam: explicit workload/work execution, deterministic dispatch, session control, observations/events, and spatial consequences |
 | [Runtime observation/event delivery plan](planning/runtime-observation-event-delivery.md) | Implementation companion for ADR-0011: work-decomposition benchmark prerequisite, headless observation/event slices, provenance, API/SSE migration, recovery boundary, and PR landing sequence |
 | [Operational execution and digital twin readiness](planning/operational-execution-digital-twin-readiness.md) | Sibling readiness track currently architecture-blocked on durable operational identity; covers verified trust/authority, semantic operation realization and command/deployment lifecycle, external observations, authoritative subject correspondence, reconciliation, drift/calibration, resilience, and a first live-system adapter proving ground with explicit Governance/Engine prerequisites |
-| [Agency and decision boundary investigation](planning/agency-decision-boundary.md) | Bounded cross-cutting research into actor vs. decision-source vs. subject semantics, agent-as-composition, provenance/replay for deterministic and nondeterministic decisions, temporally extended capabilities, and the evidence required before creating any generalized agent abstraction or delivery track |
 | [Factory-design game challenge readiness](planning/factory-design-game-challenge-readiness.md) | Game-owned parallel track for challenge identity/validation, candidate admissibility, catalogue and budget rules, deterministic evaluation, attempt provenance/comparison, and cross-track learning with governance |
 | [Factory-design game consumer initiative](planning/factory-design-game-consumer.md) | Downstream consumer boundary between the game and Arcogine, including readiness entry criteria and ownership constraints |
 | [Factory-design game vertical slice](planning/factory-design-game-vertical-slice.md) | Product hypothesis for the first playable slice: fixed contract, capacity/layout/cost trade-offs, diagnosis, and deterministic redesign |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -1,0 +1,69 @@
+# Implementation Planning
+
+> **Status:** Maintained delivery-policy index  
+> **Scope:** Work that is sufficiently decided and bounded to be implemented, validated, sequenced, or explicitly blocked on a concrete prerequisite  
+> **Authority:** Planning only; current capability remains defined by landed code/tests and current-state documentation, while durable semantics remain owned by product, architecture, and accepted ADRs
+
+## Admission rule
+
+`docs/planning/` answers:
+
+> **Given what is already known or decided, what work can an implementer execute, in what order, and against what acceptance evidence?**
+
+A topic belongs here only when all of the following are true:
+
+1. the semantic or product decision needed to define the work is sufficiently settled;
+2. the owning track/module or integration boundary is known;
+3. prerequisites and dependency direction are explicit;
+4. the concrete implementation responsibility is bounded;
+5. acceptance evidence can be stated before coding begins; and
+6. non-goals are explicit enough to prevent adjacent speculative work from entering the slice.
+
+A blocked plan may remain when the implementation contract itself is settled and the blocker is a concrete prerequisite. When research must still decide **what the implementation should mean**, the exploratory material belongs in [`../research/`](../research/README.md). A small implementation-admission guard may remain at an established planning path only to state that no work is admitted, name the research/ADR blockers, and define promotion criteria; it must contain no candidate semantics or speculative delivery sequence.
+
+## What does not belong here
+
+Move or keep the following under `docs/research/` until they reach decision quality:
+
+- product hypotheses and playtest questions;
+- unresolved architecture or ontology questions;
+- technology-selection investigations;
+- alternative designs awaiting evidence;
+- "when justified", "after concrete need", or similar untriggered abstractions;
+- open-decision tables whose evidence has not yet selected an implementation contract;
+- speculative future tracks or slices whose ownership or equality/lifecycle rules are unresolved.
+
+Non-goals and explicit future exclusions may remain in an implementation plan when they protect the admitted slice from scope expansion. A statement that something is **not part of this implementation** is different from carrying an unresolved design programme in the plan.
+
+## Promotion flow
+
+```text
+Research question
+      |
+      v
+Evidence + conclusion
+      |
+      v
+Product / architecture / ADR decision where required
+      |
+      v
+Concrete implementation responsibility + acceptance evidence
+      |
+      v
+docs/planning/
+      |
+      v
+implementation / PR / validation
+```
+
+Temporary `PLAN-<TRACK>-<LOCAL-ID>` coordinates are assigned only after work has crossed this admission boundary. Research documents do not receive delivery coordinates.
+
+## Maintenance
+
+When a plan is reviewed:
+
+- remove or relocate exploratory sections instead of letting them accumulate beside executable work;
+- keep implementation status synchronized with landed evidence;
+- retire completed historical notes once their durable meaning exists in current architecture/reference/ADRs and they no longer protect an active downstream implementation;
+- link to research for unresolved adjacent questions rather than describing those questions inline;
+- do not reopen accepted architecture inside an implementation plan unless implementation evidence demonstrates a contradiction that must be escalated.

--- a/docs/planning/factory-design-capability.md
+++ b/docs/planning/factory-design-capability.md
@@ -1,549 +1,191 @@
-# Factory Design Capability Plan
+# Factory Design Capability Implementation Plan
 
-> **Status:** Proposed  
-> **Scope:** Establish a cross-consumer factory-design capability over Arcogine's canonical production-system model  
-> **Authority:** Planning only; this document defines delivery slices and readiness criteria, not current capability or accepted architecture  
-> **Related:** [Factory Design Architecture](../architecture/factory-design.md), [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md), [ADR-0014](../architecture/decisions/0014-factory-model-semantic-policy-evolution.md), [ADR-0015](../architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md), [Engine Semantics v1](../architecture/engine-semantics-v1.md), [Factory Model v2 Canonicalization](../architecture/factory-model-v2.md), [PLAN-ENG-5 Spatial Runtime Consequences](spatial-runtime-consequences.md), [Governance and Conformance Capability Plan](governance-conformance-capability.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md)
+> **Status:** Active/partial; current implementation is complete for Factory Model v1, while the admitted Factory Model v2 work is delivered through the spatial-runtime implementation sequence  
+> **Scope:** Implementation-ready Factory Design work over the canonical production-system model  
+> **Authority:** Planning only; unresolved ontology, diagnostics, comparison, and authoring questions live in research  
+> **Related:** [Factory Design Architecture](../architecture/factory-design.md), [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md), [ADR-0014](../architecture/decisions/0014-factory-model-semantic-policy-evolution.md), [ADR-0015](../architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md), [Factory Model v2](../architecture/factory-model-v2.md), [Spatial Runtime Consequences](spatial-runtime-consequences.md), [Factory Design Evolution Research](../research/factory-design-evolution.md)
 
-## 1. Purpose
+## 1. Implementation boundary
 
-Arcogine should treat factory design as a cross-consumer capability rather than a game-specific editor concern.
-
-The semantic output of design belongs to Arcogine because the same production-system model must remain continuous across design, simulation, verification, and future execution. The authoring experience remains consumer-specific unless multiple concrete consumers justify a shared design workspace.
-
-The delivery shape is:
+Factory Design owns the immutable semantic description that consumers publish and downstream contexts instantiate:
 
 ```text
-Consumer-specific draft authoring
-              |
-              v
-     Canonical model validation
-              |
-              v
-       Publish model version
-              |
-       +------+------+
-       |             |
-       v             v
-   Simulate        Verify
-```
-
-This plan establishes the minimal shared design substrate before a game, industrial UI, optimizer, CLI, or integration adapter treats Arcogine as the authority for a published factory design.
-
-## 2. Relationship to engine and operational readiness
-
-This capability is orthogonal to runtime execution, but downstream simulation and operational contexts share one canonical production-system model.
-
-This plan owns model-side semantics and lifecycle:
-
-- canonical factory model definition;
-- structured validation;
-- immutable publication/version boundary;
-- model identity and provenance;
-- deterministic runtime instantiation from a published model;
-- eventual semantic compare/diff and broader design lifecycle when justified.
-
-The [engine-readiness plan](factory-simulation-engine-readiness.md) starts after this boundary exists. It owns deterministic simulation execution semantics such as production orders, work items, resource dispatch, bounded advancement, simulation observations/events, and transfer progression.
-
-PLAN-ENG-5 now fixes the hard model/runtime split for spatial consequences:
-
-```text
-Factory model v2 (ADR-0014)
-    floor dimensions
-    resource position + anchored footprint
-    ticksPerCell
-    handlingTicks
+consumer-owned draft/input
         |
         v
-Engine interpretation (ADR-0015 / engine-semantics:v1)
-    destination binding
-    Manhattan reference-cell distance
-    transfer timing
-    admission reservation
-    availability/no-rerouting rules
+canonical FactoryModel
         |
         v
-Runtime state
-    transfer start / in-flight / completion
-    observations/events
-```
-
-`ModelFingerprint` continues to identify the authored Factory design. `EngineSemanticsVersion` separately identifies Arcogine's result-affecting interpretation. A result-affecting Engine policy change therefore does not masquerade as a Factory design change.
-
-The sibling [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md) track consumes published/governed semantics when independently existing external systems are involved. It owns the still-unresolved durable operational-history attribution identity, authoritative external-subject ↔ Arcogine-subject correspondence, verified operational trust/authority, deployment target/application, semantic operation realization and command/result lifecycle, independent external observations, reconciliation, and operational recovery.
-
-```text
-Factory Design Capability
+validate / publish
         |
         v
-Published FactoryModelVersion
+FactoryModelVersion + ModelFingerprint
         |
-        +--------------------+
-        |                    |
-        v                    v
-Factory Simulation       Governance
-Engine Readiness              |
-                              v
-                    Operational Execution / Twin
+        v
+validated/resolved runtime instantiation
 ```
 
-The runtime must not mutate the published model in place. The design capability must not reproduce queues, assignments, transfers in progress, production deployment records, external telemetry, or twin reconciliation state.
+Runtime workload, queues, assignments, transfers in progress, operational observations, deployments, and twin reconciliation are not Factory Design state.
 
-## 3. Delivery policy
+The canonical model is not an editor state tree, a scenario envelope, a transport DTO, or a mutable runtime object graph.
 
-The first implementation target is deliberately narrow and behavior-preserving.
+## 2. Current landed baseline
 
-```text
-PLAN-FD-1  Canonical factory model contract
-    ↓
-PLAN-FD-2  Structured validation
-    ↓
-PLAN-FD-3  Publication, identity, and provenance
-    ↓
-PLAN-FD-4  Deterministic runtime instantiation
-    ↓
-PLAN-FD-5  Semantic comparison (after concrete need)
-    ↓
-PLAN-FD-6  Shared draft lifecycle (deferred until justified)
-    ↓
-PLAN-FD-7  Factory adoption of governed change (deferred until justified; owned cross-domain by Governance and Conformance PLAN-GOV-1/PLAN-GOV-2/PLAN-GOV-6, with Operational Execution owning deployment application)
-```
+The following are implemented and must be preserved:
 
-PLAN-FD-1 to PLAN-FD-4 form the immediate implementation sequence. PLAN-FD-5 has an implemented initial slice covering factory semantic comparison for resources, operations, and products through the Governance `SemanticChangeExtractor` seam (see §9); finer-grained PLAN-FD-5 comparison remains future work triggered by concrete consumer need. PLAN-FD-6 and PLAN-FD-7 remain deferred. PLAN-FD-5 is not a prerequisite for engine runtime work or a first game consumer unless a specific consumer requirement depends on its semantic-diff capability.
+- a canonical `FactoryModel` / immutable `FactoryModelVersion` seam;
+- product, operation, and concrete resource identities under the released v1 policy;
+- deterministic structural executability validation;
+- immutable publication;
+- durable `factory-model:v1` fingerprint semantics under ADR-0006;
+- runtime instantiation only from a published model;
+- runtime/result attribution to source model identity;
+- Governance-owned controlled revision identity/history independently of Factory fingerprint identity;
+- initial semantic comparison of factory resources, operations, and products through the Governance semantic-change seam.
 
-The initial spike established the model seam without simultaneously redesigning order execution, dispatch policy, spatial behavior, operational deployment, or the public HTTP contract. PLAN-ENG-5 now extends that model seam deliberately through a new immutable policy rather than changing `factory-model:v1` in place.
+Current `ResourceDefinition` remains the supported concrete resource representation. This plan does not reinterpret it as a reusable equipment type.
 
-### 3.1 Implementation status
+## 3. Admitted Factory Model v2 work
 
-The canonical `FactoryModel`/`FactoryModelVersion` seam has landed, so PLAN-FD-1 to PLAN-FD-4 are no longer wholly proposed, but they are not uniformly complete. PLAN-ENG-5 adds an **accepted but not yet implemented** Factory V2 contract:
+ADR-0014 establishes `factory-model:v2` as exactly v1 semantic content plus required authored spatial/handling facts:
 
-```text
-PLAN-FD-1 Canonical model                  PARTIAL
-    canonical semantic seam         implemented
-    product/operation/resources     implemented
-    definition-instance split       deferred
-    factory-model:v1 semantics      implemented/released
-    factory-model:v2 semantics      accepted by ADR-0014; implementation pending PLAN-ENG-5-A1/A2
+- floor width and height;
+- resource reference-cell position;
+- resource footprint width and height;
+- `ticksPerCell`;
+- `handlingTicks`.
 
-PLAN-FD-2 Executability validation         PARTIAL
-    deterministic structural errors implemented
-    stable finding taxonomy         deferred
-    warnings/severity/codes         deferred
-    V2 spatial validation           accepted by ADR-0014; implementation pending PLAN-ENG-5-A1
+Position/footprint containment, non-overlap, and the exact maximum-transfer-duration representability predicate are publication semantics. Orientation, aisle/path topology, conveyors, explicit transport resources, connection points, congestion, floor identity, and authoritative animation coordinates are not part of v2.
 
-PLAN-FD-3 Publication / semantic identity  PARTIAL
-    immutable publication           implemented
-    content hash                    implemented, legacy compatibility
-    durable fingerprint v1          implemented — see ADR-0006
-    durable fingerprint v2          accepted by ADR-0014, canonicalization fixed by
-                                    factory-model-v2.md; implementation pending PLAN-ENG-5-A2
-    multi-policy historical resolve accepted; implementation pending PLAN-ENG-5-A3
-    controlled revision identity    implemented cross-domain by Governance PLAN-GOV-1
+The implementation sequence is owned jointly with [Spatial Runtime Consequences](spatial-runtime-consequences.md):
 
-PLAN-FD-4 Runtime instantiation            PARTIAL
-    runtime from published model    implemented for current V1
-    handler provenance              implemented (IntegratedHandler)
-    result model provenance         implemented (SimResult.modelContentHash compatibility surface)
-    consumer-neutral runtime ID     implemented for FactoryRuntime / PLAN-ENG-4 PLAN-ENG-4-A
-    EngineSemanticsVersion          accepted by ADR-0015; implementation pending PLAN-ENG-5-B1/B2
-```
+### PLAN-ENG-5-A1 — V2 model and validation
 
-PLAN-FD-1's original acceptance criteria also call for resource definitions and installed instances to be distinguishable; today's `ResourceDefinition` still deliberately represents both a resource type and its installed instance, so that richer split remains deferred. PLAN-FD-2's original stable finding taxonomy is likewise broader than today's minimal `ModelValidationError`. Neither deferred enrichment is a prerequisite for the accepted PLAN-ENG-5 V2 contract.
+Implement the five authored additions and deterministic validation required by ADR-0014.
 
-Important current identity rules:
+Acceptance evidence must prove:
 
-- `factory-model:v1` remains permanently immutable under ADR-0006 and ADR-0014.
-- `factory-model:v2` is exactly V1 semantics plus the required PLAN-ENG-5 spatial/handling facts; it is not a sidecar fingerprint.
-- V2 implementation must preserve V1 golden vectors/fingerprints unchanged.
-- there is no automatic V1→V2 lift and no synthesized spatial defaults for historical V1 artifacts.
-- Governance PLAN-GOV-1 provides controlled revision authority/history independently of Factory fingerprint policy; lineage may cross V1/V2 without rewriting either artifact.
+- exact anchored footprint occupancy;
+- floor containment;
+- non-overlap;
+- accepted zero/boundary values where the ADR permits them;
+- overflow-safe maximum transfer-duration validation; and
+- no change to v1 behavior or identity.
 
-## 4. Current-model migration strategy
+### PLAN-ENG-5-A2 — V2 canonical identity
 
-The existing scenario factory semantics adapt into the canonical model and instantiate the runtime through that model boundary:
+Implement the exact V2 canonical bytes and fingerprint policy from [Factory Model v2](../architecture/factory-model-v2.md).
 
-```text
-Current ScenarioConfig / TOML
-            |
-            | extract/adapt factory semantics
-            v
-       FactoryModel
-            |
-         validate
-            v
-   FactoryModelVersion
-            |
-      resolve/compile
-            v
-       FactoryRuntime
-```
+Acceptance evidence must prove:
 
-`ScenarioConfig` remains a scenario/run input envelope rather than becoming the canonical factory model. Simulation parameters, economy configuration, agent configuration, and workload concerns remain outside the factory design.
+- required golden vectors;
+- deterministic equivalent-content fingerprints;
+- every authored V2 field participates in identity;
+- V1 vectors/fingerprints remain byte-for-byte unchanged;
+- no automatic v1-to-v2 lift or synthesized historical spatial defaults; and
+- malformed or semantically invalid V2 artifacts fail explicitly.
 
-For current features that are narrower than the intended future model, the adapter preserves existing semantics explicitly. A process step that targets concrete eligible resources remains explicit eligibility; the seam must not manufacture new runtime behavior merely to appear more general.
+### PLAN-ENG-5-A3 — V1/V2 historical coexistence
 
-V1 remains a truthful supported design policy after PLAN-ENG-5: because it authors no spatial facts, it receives no PLAN-ENG-5 transfer behavior. Spatial behavior requires explicit V2 publication and therefore a new `ModelFingerprint`.
+Use the landed Governance revision authority to keep both released policies historically resolvable and verifiable.
 
-### 4.1 Migration-spike acceptance criteria
+Acceptance evidence must prove:
 
-The original behavior-preserving model-seam spike established that:
+- historical v1 resolution remains intact after V2 registration;
+- v2 resolution is independent;
+- controlled revision lineage may cross policy versions without rewriting either artifact; and
+- the first cross-policy transition is not falsely represented as an ordinary same-policy empty/equivalent diff.
 
-1. an existing scenario can produce a canonical `FactoryModel`;
-2. simulation, economy, and agent configuration stay outside it;
-3. model validation is independent of mutable runtime construction;
-4. a valid model can publish with semantic identity/provenance;
-5. runtime instantiates from the published model;
-6. representative deterministic behavior remains covered;
-7. runtime observations/results can identify source model identity;
-8. no game UI or operational deployment semantics are needed to prove the seam.
+This slice implements only the first coexistence/migration seam actually required by V1/V2. It does not create a generic schema-migration framework.
 
-PLAN-ENG-5 builds on, rather than reopens, that seam through the focused PLAN-ENG-5-A1/A2/A3 implementation sequence.
+## 4. Existing Factory capabilities that remain closed
 
-## 5. PLAN-FD-1 — Canonical factory model contract
+### PLAN-FD-1 — Canonical model boundary
 
-### 5.1 Goal
+The behavior-preserving canonical seam is implemented for current semantics. V2 additions are admitted only through the concrete A1/A2/A3 work above.
 
-Define one semantic representation of a designed production system that can be authored by multiple consumers and instantiated by multiple lifecycle contexts.
+### PLAN-FD-2 — Executability validation
 
-The model covers behaviorally relevant facts needed by current and near-term factory work:
+Current deterministic validation remains the implementation contract for admitted semantics. V2 adds only the accepted spatial/arithmetic predicates required by ADR-0014.
+
+A richer cross-consumer finding taxonomy is **not** an admitted implementation slice; it is tracked in [Factory Design Evolution Research](../research/factory-design-evolution.md).
+
+### PLAN-FD-3 — Publication, identity, and provenance
+
+Immutable publication and v1 durable semantic identity are implemented. V2 identity/coexistence is admitted through A2/A3 above.
+
+`ModelFingerprint` remains semantic-content identity. `ControlledRevisionId` remains Governance-owned historical occurrence identity. Neither approval, deployment, external workflow identity, nor Engine interpretation belongs in the Factory fingerprint.
+
+### PLAN-FD-4 — Deterministic runtime instantiation
+
+Runtime continues to instantiate from one validated published model. Derived indexes/compiled structures are not independently authored models.
+
+Engine result-affecting interpretation is separately identified by `EngineSemanticsVersion` under ADR-0015.
+
+### PLAN-FD-5 — Semantic comparison
+
+The initial comparison slice for current resources, operations, and products is implemented. No additional comparison implementation is admitted now.
+
+Finer route/policy/spatial/capability comparison and cross-consumer explanatory depth are tracked in research. A future implementation slice must be promoted from a concrete consumer or Governance requirement rather than remaining as an open-ended extension here.
+
+## 5. Model/runtime ownership invariants
 
 ```text
-FactoryModel
-    product definitions
-    operation definitions
-    resources / installed identities
-    capability or explicit eligibility requirements
-    relevant canonical constraints
-    semantic spatial layout where behavior depends on it
-```
+Factory Design owns
+    published products / operations / concrete resources
+    authored behaviorally relevant constraints
+    authored V2 spatial/handling facts
+    validation / publication
+    ModelFingerprint
 
-The exact Java and wire types remain implementation details. The model must not be shaped around one editor state tree, TOML layout, transport format, or mutable runtime object graph.
-
-### 5.2 Required separations
-
-```text
-MODEL SIDE
-    definitions
-    installed structure
-    validated published model
-
-RUNTIME SIDE
-    production orders
-    work items
-    queues
-    assignments
+Engine owns
+    workload and work items
+    dispatch / queues / assignments
+    result-affecting interpretation policy
     transfers in progress
-    performance
+    runtime observations/events/performance
+
+Governance owns
+    ControlledRevisionId and authoritative revision history
+    semantic ChangeSet / impact
+    requirements / conformance / evidence-use / governed change
+
+Operational work, once admitted, owns
+    independently existing subject correspondence
+    consequential trust/authority
+    external realization / command-result facts
+    deployment application
+    external observations / reconciliation
 ```
 
-Runtime workload/state does not belong in a published factory design.
+No downstream consumer may create a second authored production model merely because it needs a convenient runtime/editor representation.
 
-### 5.3 PLAN-ENG-5 V2 addition
+## 6. Game integration boundary
 
-ADR-0014 establishes the next released Factory fingerprint policy. `factory-model:v2` is exactly V1 plus five required authored additions:
+The game may own a mutable draft, catalogue/economics, score, attempt history, UI state, and other consumer-only data. It projects only supported canonical semantic facts before Arcogine validation/publication.
 
-| Addition | Canonical meaning |
-|---|---|
-| floor width / height | plant extent in integer cells |
-| resource position `x` / `y` | minimum-coordinate reference cell of the footprint |
-| footprint width / height | exact occupied `w × h` cells extending from the reference cell |
-| `ticksPerCell` | authored material-handling rate magnitude |
-| `handlingTicks` | authored fixed overhead applied once per inter-resource transfer |
+The game must not force unresolved equipment-type, shared-editor, or comparison abstractions into Factory Design. Those questions remain in research until promoted.
 
-All are mandatory and fingerprinted in V2. The exact bytes those additions are digested through — the `arcogine.factory-model.v2\0` policy-domain prefix, the plant-scope header, the per-resource spatial suffix, collection ordering and digest rendering — are fixed normatively by [Factory Model v2 Canonicalization](../architecture/factory-model-v2.md), because ADR-0006 makes a fingerprint-policy version a canonicalization contract rather than a field-membership label.
+## 7. Research boundary
 
-Position/footprint containment and non-overlap are publication semantics. V2 publication also proves with overflow-safe arithmetic that
+The following are intentionally **not implementation work** in this plan:
 
-```text
-maxManhattanDistance = (floorWidth - 1) + (floorHeight - 1)
-maxTransferDuration = handlingTicks + ticksPerCell * maxManhattanDistance
-```
+- reusable equipment definition versus installed resource ontology;
+- generalized capability/resource-pool/work-center semantics;
+- richer stable validation findings/warnings/severity;
+- finer semantic comparison beyond the implemented slice;
+- shared draft lifecycle/collaboration;
+- Factory-specific additions to governed-change workflow; and
+- spatial/material-flow concepts beyond accepted v2.
 
-is representable in the runtime duration type. That bounds the derived transfer duration, not arbitrary future addition to an extreme current `SimTime`.
+They are maintained in [Factory Design Evolution Research](../research/factory-design-evolution.md) and the research register. Do not assign new Factory delivery coordinates until the relevant question crosses the planning admission boundary.
 
-Orientation, path/aisle/conveyor topology, transport resources, connection points, congestion, floor identity and authoritative animation coordinates are not V2.
+## 8. Validation and documentation
 
-### 5.4 Acceptance criteria
+For every admitted Factory change:
 
-PLAN-FD-1 is satisfied incrementally when:
-
-1. a complete supported factory can be represented without frontend DTOs or mutable runtime classes;
-2. product/operation/resource concepts have stable semantic identities;
-3. operation requirements can express explicit eligible-resource semantics without mutable runtime objects;
-4. semantic layout facts are present only where they are authored behaviorally relevant content;
-5. consumer-only state such as selection, camera, undo, score, and artwork is absent;
-6. canonical content is normalized deterministically for identity/provenance;
-7. for V2, every `(position, footprint)` pair has one unambiguous occupied-cell set and invalid containment/overlap/arithmetic is rejected.
-
-The richer resource-definition/installed-instance split remains separately deferred; it is not silently claimed complete merely because V2 adds placement to current resource identities.
-
-## 6. PLAN-FD-2 — Structured validation
-
-### 6.1 Goal
-
-Make Arcogine authoritative for whether a factory design can be published and instantiated.
-
-Consumers may perform optimistic local checks, but publication/runtime instantiation relies on Arcogine validation.
-
-Validation should eventually distinguish at least errors from warnings through a stable structured finding shape. Today's implemented validation remains narrower, and PLAN-ENG-5 adds only the V2 executability predicates required by ADR-0014.
-
-### 6.2 Initial executability checks
-
-Examples include:
-
-- duplicate/missing identifiers;
-- dangling product/operation/resource references;
-- invalid operation order/graph;
-- operation with no resolvable eligible resource under represented semantics;
-- unsupported policy/configuration values;
-- V2 floor/position/footprint violations;
-- V2 unsafe maximum-transfer-duration arithmetic.
-
-Game budget, unlocks, scores, and tutorials are not Arcogine executability checks.
-
-### 6.3 Acceptance criteria
-
-PLAN-FD-2 is satisfied incrementally when invalid models return deterministic findings, validation does not mutate runtime state, publication/instantiation is atomic, and headless/consumer paths rely on the same authoritative validation. Stable codes/severity remain a separate planned enrichment where not yet implemented.
-
-## 7. PLAN-FD-3 — Publication, identity, and provenance
-
-### 7.1 Goal
-
-Create an explicit boundary between mutable authoring state and an immutable semantic snapshot that downstream contexts can instantiate.
-
-```text
-FactoryModel
-    ↓ validate/publish
-immutable semantic snapshot
-    ↓
-ModelFingerprint
-```
-
-### 7.2 Minimum identity
-
-Per ADR-0004, publication requires deterministic content-derived semantic identity and enough provenance to attribute downstream execution to the model. Governance PLAN-GOV-1 separately provides controlled historical revision identity and authoritative history.
-
-A model UUID, revision counter, Jira key, approval state or Engine semantics version is not part of the Factory model fingerprint.
-
-### 7.3 Immutable policy evolution
-
-ADR-0006 fixes the released V1 contract; ADR-0014 generalizes the evolution rule:
-
-- a released Factory fingerprint policy is immutable and never reinterpreted;
-- a new authored behaviorally relevant fact that cannot fit without changing a released policy creates `factory-model:vN+1`;
-- old policies remain permanently historically resolvable/verifiable;
-- controlled-revision lineage may cross policies;
-- a normal semantic `ChangeSet` must not silently span policies by inventing facts the older model never authored;
-- the first real V1→V2 controlled transition gets only the narrow migration classification/common-representation seam it actually needs, not a generic migration framework.
-
-PLAN-ENG-5-A2 implements the V2 policy; PLAN-ENG-5-A3 implements this first coexistence/evolution seam.
-
-### 7.4 Acceptance criteria
-
-PLAN-FD-3 requires immutable publication, stable deterministic fingerprints within each released policy, draft/editor metadata excluded from identity, downstream attribution to the exact model fingerprint, and permanent policy-aware historical resolution.
-
-## 8. PLAN-FD-4 — Deterministic runtime instantiation
-
-### 8.1 Goal
-
-Make the published model the only semantic bridge from design into runtime contexts.
-
-```text
-FactoryModelVersion
-       |
- validate/resolve
-       v
-ExecutableFactoryModel
-       |
- instantiate
-       v
-FactoryRuntime
-```
-
-### 8.2 Derived structures
-
-Runtime preparation may derive resolved references, eligibility indexes, immutable routing indexes, spatial indexes when supported, and scheduling metadata. These are derived from one published semantic model and are not independently authored truth.
-
-### 8.3 Runtime provenance
-
-Every run/session identifies the source `ModelFingerprint`. ADR-0015 adds a second, Engine-owned provenance dimension:
-
-```text
-RunId                     correlation/runtime epoch
-ModelFingerprint          which authored Factory design
-EngineSemanticsVersion    which result-affecting Engine interpretation
-```
-
-The current runtime has not implemented the last field yet; focused PLAN-ENG-5 slice PLAN-ENG-5-B1/B2 adds it. `ControlledRevisionId` remains additional optional provenance only when an authoritative revision binding exists; runtime code must not synthesize one from the fingerprint.
-
-Deterministic comparison across builds is therefore scoped to the same model fingerprint, Engine semantics version, workload, seed/random inputs and ordered commands rather than treating model identity alone as outcome identity.
-
-### 8.4 Acceptance criteria
-
-PLAN-FD-4 is satisfied incrementally when a published model version instantiates a fresh deterministic runtime, runtime cannot mutate the model, supported runtime facts retain source-model provenance, and no consumer draft representation is required. PLAN-ENG-5 extends the provenance surface additively without changing those ownership rules.
-
-## 9. PLAN-FD-5 — Semantic comparison and design alternatives
-
-**Status: initial slice implemented**, as the direct PLAN-FD-5 implementation feeding Governance PLAN-GOV-2:
-`com.arcogine.factory.change.FactoryModelSemanticComparator` compares resources, operations, and
-products by stable domain identity and classifies add/remove/modify through Governance's semantic-change seam.
-
-Finer route/policy/constraint/spatial change taxonomy remains consumer-pulled work. Moving a V2 resource is a real Factory design change because position is canonical content, but cross-policy V1→V2 comparison must obey ADR-0014 rather than pretending a V1 design authored missing spatial fields.
-
-A change-management workflow is one concrete future consumer: reviewers need a domain-level semantic diff between a candidate revision and its predecessor, not a generic text/JSON diff.
-
-Do not implement arbitrary text/JSON diff, generic patch/merge, or collaborative editing merely to satisfy PLAN-FD-5.
-
-## 10. PLAN-FD-6 — Shared draft lifecycle and collaboration
-
-Promote drafts into an Arcogine-owned shared lifecycle only when a second concrete workflow requires common persistence, branching, collaboration, or collaborative draft review/comments.
-
-Possible triggers include industrial design plus optimizer/game authoring, human/agent co-design, branching real production changes, or multi-user design sessions.
-
-PLAN-FD-6 is scoped to shared *authoring* mechanics and does not include authorization or organizational change-management workflow. Until a trigger applies, Arcogine does not need generic undo/redo, draft branching, merge, collaboration cursors, edit locks, comments, workspace permissions, or autosave semantics.
-
-## 11. PLAN-FD-7 — Factory adoption of governed change
-
-Controlled revision lineage, external change references, technical evidence packages for review, and authorization hand-off are cross-domain concerns owned by Governance, not factory-specific ones. Governance PLAN-GOV-1 already owns durable revision identity/history; PLAN-GOV-2 owns semantic `ChangeSet`/impact; PLAN-GOV-4/PLAN-GOV-5 own conformance/evidence semantics; PLAN-GOV-6 will own external workflow/change-control integration.
-
-Operational Execution owns what happens after authorization when a semantic change is applied to or interpreted against independently existing systems: durable operational-history attribution (with the exact identity referent still under ADR-0013 review), subject correspondence, deployment application/provenance, semantic operation realization and command/result lifecycle, external observations, and reconciliation.
-
-PLAN-FD-7 remains only the factory-specific contribution of Factory semantics/evidence into those cross-domain capabilities. Building a factory-only revision repository, authorization workflow, production deployment runtime, telemetry ingestion or reconciliation layer would duplicate sibling ownership.
-
-## 12. Constraint classification
-
-Every design rule must be classified before implementation.
-
-| Class | Meaning | Owner |
-|---|---|---|
-| Executability constraint | Required for the model to publish/instantiate coherently | Arcogine model/design boundary |
-| Verification objective/constraint | Tests whether an executable design meets a target | Shared verification capability when supported |
-| Consumer rule | Applies only to one experience/workflow | Consumer |
-
-Examples:
-
-```text
-Resource outside floor               -> executability
-Operation has no eligible resource   -> executability
-Throughput must exceed target        -> verification
-Player construction budget           -> game consumer
-Machine unlock level                 -> game consumer
-```
-
-## 13. Interaction with engine and operational readiness
-
-The design capability owns:
-
-```text
-Product/operation definitions
-Resource identities and authored structure
-Capability/eligibility requirements
-Factory V2 floor/position/footprint/ticksPerCell/handlingTicks
-Validation
-Publication/model provenance
-```
-
-Engine readiness owns:
-
-```text
-Production orders and work items
-Quantity execution semantics
-Dispatch and queues
-EngineSemanticsVersion and result-affecting interpretation
-Active operations/transfers
-Simulation runtime events and observations
-Performance
-```
-
-Operational Execution owns:
-
-```text
-Durable operational-history attribution/identity (exact referent under ADR-0013 review)
-Authoritative external-subject ↔ Arcogine-subject correspondence
-Verified operational trust / authority
-Deployment target application and applied-artifact provenance
-Semantic operation realization and external command/result lifecycle
-External operational observations
-Twin reconciliation and drift/calibration feedback
-```
-
-The Factory model owns authored input semantics; the Engine owns deterministic interpretation and mutable consequences. The same V2 `ModelFingerprint` may legitimately produce a different result under a future different `EngineSemanticsVersion` without redefining the authored plant.
-
-## 14. Factory-design game integration
-
-The game may own an editor-specific `FactoryDraft`, undo history, camera, palettes, previews, and game rules.
-
-```text
-Game-owned draft
-      |
- project canonical semantics
-      v
-Arcogine validate/publish
-      |
-      v
-FactoryModelVersion
-      |
-      v
-Arcogine runtime
-```
-
-The game must not implement a parallel scheduler, transfer rule, distance metric, or semantic-policy layer and must not treat its draft as the authoritative executable model.
-
-## 15. Headless acceptance path
-
-### 15.1 Behavior-preserving publication test
-
-1. Load an existing representative scenario.
-2. Adapt only its factory semantics into a canonical model.
-3. Validate the model.
-4. Publish a model version.
-5. Instantiate runtime through the model boundary.
-6. Run the same inputs/seed as the existing path.
-7. Assert deterministic behavior/results are unchanged.
-8. Assert results identify the source model's semantic fingerprint.
-
-### 15.2 Variant tests after richer semantics exist
-
-For a **Factory design variant**:
-
-1. publish model A;
-2. publish model B with one authored semantic design change;
-3. instantiate independent runtimes under the same `EngineSemanticsVersion`;
-4. apply the same seed/workload/commands;
-5. verify deterministic but appropriately different outcomes.
-
-PLAN-ENG-5 examples include moving one V2 resource or changing an authored handling magnitude. A comparison that keeps the same `ModelFingerprint` and changes only `EngineSemanticsVersion` is an Engine-semantics experiment, not a PLAN-FD-5 Factory design variant.
-
-## 16. First implementation milestone
-
-> **Take an existing Arcogine scenario, derive a validated immutable canonical factory model from it, instantiate the existing simulation from that model, and prove the simulation result has not changed.**
-
-That original milestone established the current model seam. PLAN-ENG-5 does not retroactively reopen it; it uses ADR-0014's explicit V2 policy and the focused PLAN-ENG-5-A1/A2/A3 slices to add spatial authored semantics without weakening V1.
-
-## 17. ADR triggers
-
-[ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md) establishes the model/run/runtime boundary. [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md) separates semantic fingerprint from controlled-revision/change-management identity. ADR-0006 fixes the durable V1 fingerprint contract.
-
-PLAN-ENG-5's hard-to-reverse decisions are now accepted rather than open triggers:
-
-- [ADR-0014](../architecture/decisions/0014-factory-model-semantic-policy-evolution.md) fixes Factory fingerprint-policy evolution and `factory-model:v2`;
-- [ADR-0015](../architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md) fixes design-vs-Engine interpretation ownership and `EngineSemanticsVersion`;
-- [Engine Semantics v1](../architecture/engine-semantics-v1.md) fixes the first concrete result-affecting interpretation;
-- [Factory Model v2 Canonicalization](../architecture/factory-model-v2.md) fixes the durable `factory-model:v2` byte grammar that ADR-0014's policy version contractually implies.
-
-Future ADRs remain warranted for genuinely new hard-to-reverse model aggregate boundaries, work-center/resource-pool semantics, shared draft lifecycle, or a new released Factory/Engine semantics contract. Do not create ADRs for consumer-local editor gestures or temporary UI structure.
-
-## 18. Documentation lifecycle
-
-While this work is proposed, this file remains under `docs/planning/`.
-
-As capabilities are implemented:
-
-- reconcile established behavior into [`../architecture/overview.md`](../architecture/overview.md);
-- update [`../product/concepts.md`](../product/concepts.md) only for capabilities that actually ship;
-- update [`../reference/api.md`](../reference/api.md) only when a public contract exists;
-- update the ISA-95 mapping when implemented manufacturing concepts change;
-- keep migration/regression/golden fixtures executable and version-controlled;
-- keep governed-change integration aligned with Governance and real deployment/reconciliation aligned with Operational Execution.
-
-Once the initiative is complete or abandoned, reduce this file to a concise historical outcome or retire it after durable decisions and current behavior are represented in authoritative locations.
+1. preserve released v1 golden identity behavior;
+2. add deterministic boundary/golden tests for new semantic facts;
+3. keep runtime construction behind published-model validation;
+4. update durable architecture/ADR/reference only when actual semantics or shipped behavior changes; and
+5. keep this plan synchronized with landed implementation status rather than carrying untriggered future work.

--- a/docs/planning/factory-design-game-challenge-readiness.md
+++ b/docs/planning/factory-design-game-challenge-readiness.md
@@ -1,781 +1,116 @@
-# Factory-Design Game Challenge Readiness
+# Factory-Design Game Challenge Delivery Plan
 
-> **Status:** Proposed  
-> **Scope:** Establish the game-owned challenge, admissibility, evaluation, attempt, and comparison capabilities that can progress independently of factory runtime readiness  
-> **Authority:** Planning only; this document does not describe current product capability or accepted architecture  
-> **Related:** [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md), [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [Governance and Conformance Capability](governance-conformance-capability.md), [Factory Design Capability](factory-design-capability.md), [Product Charter](../product/charter.md)
+> **Status:** COMPLETE through the currently admitted headless challenge capability; no additional Challenge implementation is admitted  
+> **Scope:** Record the implemented game-owned challenge substrate and its downstream integration boundary  
+> **Authority:** Planning only; product/gameplay hypotheses live in research and current capability remains defined by landed code/tests
 
-## 1. Purpose
+## 1. Ownership boundary
 
-The factory-design game needs a second engineering track alongside [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md).
-
-Engine readiness answers:
-
-> What happened when this published production system executed this workload?
-
-Challenge readiness answers:
-
-> Was this candidate allowed under the challenge, was its resulting outcome good under the exact challenge rules, and how should the attempt be explained and compared?
-
-The tracks are deliberately orthogonal:
+The Challenge layer owns deterministic game rules over game-owned candidate facts and authoritative Arcogine outcomes. It does not simulate production.
 
 ```text
-Factory Simulation Engine Readiness
-    production truth
-    orders/work
-    dispatch
-    session control
-    observations
-    spatial consequences
-
-Factory-Design Game Challenge Readiness
-    challenge definition
-    challenge identity/versioning
-    game catalogue and budget
-    candidate admissibility
-    success/failure rules
-    deterministic evaluation
-    attempts and comparison
-    evaluation provenance
-```
-
-The challenge layer interprets game-owned draft facts and authoritative Arcogine outcome facts under game rules. It must not simulate production, reconstruct queues, implement dispatch, derive transfer behavior, or depend on mutable runtime internals.
-
-## 2. Parallel-development policy
-
-Challenge readiness should be useful before the final Arcogine observation contract exists.
-
-Early challenge implementation may therefore consume synthetic supported-outcome fixtures or a narrow game-owned port representing only the outcome facts required for evaluation. These fixtures are test inputs, not an alternative production model.
-
-Conceptually:
-
-```text
-Synthetic supported-outcome fixture
-        |
-        v
-Challenge evaluator
-
-later
-
-Arcogine supported observation/result
-        |
-        v
-thin consumer adapter
-        |
-        v
-Challenge evaluator
-```
-
-The challenge evaluator must not depend on `FactoryRuntime`, scheduler internals, stores, Spring DTOs, or undocumented event reconstruction.
-
-Likewise, challenge admissibility must be testable headlessly from challenge state plus a game-owned candidate draft/attempt snapshot. It must not be implemented only as UI affordances.
-
-This policy lets Engine Readiness change work-item, dispatch, session, and observation internals without forcing the challenge track to follow those refactors.
-
-## 3. Ownership boundary
-
-The challenge track owns game semantics such as:
-
-- challenge identity and content version;
-- fixed contract presentation and game-specific constraints;
-- equipment catalogue availability and construction prices;
-- purchase/resale rules and construction budget;
-- candidate admissibility under game rules;
-- game success/failure conditions;
-- score, rating, medal, or equivalent evaluation;
-- attempt history and game-facing comparison;
-- challenge/evaluation-policy provenance.
-
-Arcogine remains authoritative for:
-
-- canonical factory-model semantics and executability validation;
-- published model identity/provenance;
-- production workload and work execution;
-- resource eligibility and dispatch;
-- queues, processing, and transfers;
-- simulation time/event ordering;
-- runtime observations and performance facts.
-
-A challenge may say that completion before tick 400 earns a bonus. It may not invent a completion time that Arcogine did not report. A challenge may reject a draft because it uses a disallowed catalogue item or exceeds budget. It may not claim that an admitted draft is an executable factory; Arcogine validation still decides that after projection.
-
-## 4. Delivery sequence
-
-```text
-PLAN-CHAL-1  Challenge definition, identity, and validation
-    |
-    v
-PLAN-CHAL-2  Catalogue, construction budget, draft economics, and candidate admissibility
-    |
-    v
-PLAN-CHAL-3  Deterministic challenge evaluation
-    |
-    v
-PLAN-CHAL-4  Attempt provenance and design-to-design comparison
-    |
-    v
-PLAN-CHAL-5  Data-driven challenge content and reference fixtures
-```
-
-PLAN-CHAL-1 to PLAN-CHAL-5 are game-owned capabilities. None is evidence that an Engine Readiness gate is satisfied.
-
-## 5. PLAN-CHAL-1 — Challenge definition, identity, and validation
-
-### Goal
-
-Represent one immutable, identifiable challenge independently of mutable player state and production runtime state.
-
-A challenge needs concepts equivalent to:
-
-```text
-Challenge
-    stable identity
-    content/rules version
-    floor/game constraints
-    available catalogue
-    construction budget
-    production contract reference/input
-    deadline
-    evaluation policy identity/version
-```
-
-Exact type names and serialization format remain implementation decisions.
-
-### Validation boundary
-
-PLAN-CHAL-1's `ChallengeDefinitionValidator` answers only whether an already-constructed
-`ChallengeDefinition`'s own scalar/structural content is internally coherent:
-
-- Is the budget non-negative?
-- Is the deadline positive?
-- Are floor dimensions positive?
-- Is the workload reference present and its quantity positive?
-- Are available catalogue-item identities present and free of duplicates?
-- Are identity/evaluation-policy id and version present?
-
-It does **not** replace `FactoryModelValidator`, which answers whether projected production
-semantics are executable by Arcogine.
-
-Questions that require resolving a `ChallengeDefinition`'s references against other state --
-whether referenced catalogue entries exist in an actual catalogue, whether the workload's success
-condition is unambiguous once evaluation semantics exist, whether rating/score thresholds are
-coherent -- belong to later gates (PLAN-CHAL-2's catalogue seam and PLAN-CHAL-3's evaluation-policy work,
-respectively) once that state exists to validate against. PLAN-CHAL-1 does not claim to answer them.
-
-PLAN-CHAL-1 also does not define a content-loading layer. `ChallengeDefinition` and its nested value
-records reject structurally absent required fields (a null identity, a null workload, a null
-nested id/version/reference, a null equipment element) at construction time via ordinary
-constructor invariants (`NullPointerException`), not via `ChallengeDefinitionIssue` diagnostics.
-Converting an untrusted external representation (e.g. loaded JSON/TOML) into either a valid
-`ChallengeDefinition` or a diagnostic explaining why it couldn't be constructed is the
-responsibility of the content-loading layer introduced in PLAN-CHAL-5; PLAN-CHAL-1 supplies the validator that
-layer will run once a definition exists, not a replacement for it.
-
-### Acceptance criteria
-
-PLAN-CHAL-1 is ready when:
-
-1. A challenge can be loaded independently of an active simulation session.
-2. Challenge identity and content/rules version are explicit.
-3. A structurally-constructed but scalar/content-invalid `ChallengeDefinition` (blank ids,
-   non-positive dimensions/budget/deadline/quantity, duplicate catalogue ids, etc.) produces
-   deterministic, actionable `ChallengeDefinitionIssue` diagnostics. This criterion covers content
-   validity of a constructed definition -- it does not cover translating absent/malformed
-   external input into diagnostics; that is PLAN-CHAL-5's content-loading responsibility (see "Validation
-   boundary" above).
-4. Challenge-definition validation does not duplicate Arcogine factory-model validation.
-5. Game-only fields do not enter the canonical factory model merely to support challenge loading.
-
-### Implementation status (PLAN-CHAL-1)
-
-PLAN-CHAL-1 is implemented as a new headless Gradle module, `:challenge` (`product/consumer/challenge`,
-package `com.arcogine.challenge`), with no `project(...)` dependency on `:types`, `:simulation`,
-`:factory`, `:economy`, `:finance`, `:api`, or `:cli`.
-
-Implemented:
-
-- Immutable value records: `ChallengeIdentity`, `EvaluationPolicyIdentity`,
-  `EquipmentCatalogueItemId`, `ChallengeWorkload`, `FactoryFloorConstraint`, and the aggregate
-  `ChallengeDefinition`. Construction defensively copies the available-equipment collection so
-  caller mutation cannot affect an already-constructed definition.
-- `com.arcogine.challenge.validation.ChallengeDefinitionValidator`, a deterministic, side-effect-free
-  static validator producing a `ChallengeDefinitionValidationResult` of `ChallengeDefinitionIssue`
-  (stable code, field path, message), covering the scalar/structural rules listed under
-  "Validation boundary" above (presence/positivity of identity, floor, budget, workload, deadline,
-  evaluation-policy fields, plus duplicate/blank available-equipment-id rejection). It does not
-  call, extend, or share a result type with `FactoryModelValidator`.
-
-Not implemented, and not claimed by this validator (see "Validation boundary" above for why each
-belongs to a later gate rather than PLAN-CHAL-1): catalogue-item resolution against real equipment offers
-and their existence/pricing (PLAN-CHAL-2), construction-cost calculation, candidate placement/overlap/
-admissibility, affordability (PLAN-CHAL-2), evaluation-policy implementation lookup and score/rating
-threshold coherence (PLAN-CHAL-3), and any persistence/content-loading format that would translate absent
-or malformed external input into diagnostics (PLAN-CHAL-5).
-
-This module and its no-runtime-dependency boundary are also recorded in `docs/architecture/overview.md`.
-
-## 6. PLAN-CHAL-2 — Catalogue, construction budget, draft economics, and candidate admissibility
-
-### Goal
-
-Make capital efficiency and challenge-specific design constraints deterministic game rules without extending Arcogine production or finance semantics.
-
-### 6.1 Game-owned catalogue seam
-
-The challenge catalogue must not assume that today's canonical `ResourceDefinition` already represents a reusable equipment type. The current factory model still defers a full definition/installed-instance split in [Factory Design Capability](factory-design-capability.md).
-
-Challenge Readiness therefore uses a game-owned catalogue identity and keeps canonical projection in the consumer authoring layer:
-
-```text
-EquipmentOffer
-    catalogue item ID
-    availability
-    purchase cost
-    resale policy
-    projection key / authoring reference
-
-DraftEconomics
-    starting budget
-    committed construction cost
-    remaining budget
-```
-
-The challenge evaluator and budget logic reason about catalogue item occurrences, not about pretending a canonical `ResourceDefinition` is a reusable equipment type.
-
-The game draft-authoring/projection layer maps one catalogue item occurrence into whatever supported canonical resource semantics the current model requires. That projection is an authoring convenience only; once published, Arcogine's canonical model is authoritative for production semantics.
-
-If the canonical definition/instance split later lands, this projection seam may simplify. PLAN-CHAL-2 does not require that split as a prerequisite and must not duplicate canonical dispatch, capability, or execution semantics in the game.
-
-### 6.2 Candidate admissibility
-
-Before publication/run, the challenge layer needs a headless admissibility decision over one exact candidate draft or attempt input.
-
-Conceptually:
-
-```text
-Challenge version
+Challenge definition / catalogue / budget
         +
 Candidate draft snapshot
-        +
-Draft economics
-        +
-Challenge-bound workload/input
         |
         v
-Candidate admissibility
+candidate admissibility
         |
-        +--> ADMITTED
+        v
+Arcogine projection / validation / runtime   [outside Challenge]
         |
-        +--> REJECTED with structured game-rule reasons
+        v
+supported authoritative outcome facts
+        |
+        v
+challenge evaluation
+        |
+        v
+attempt provenance / comparison
 ```
 
-Admissibility may check game-owned constraints such as:
+Challenge rules may reject a canonically executable factory for budget/catalogue reasons. Challenge admission never proves Arcogine executability.
 
-- only allowed catalogue items are used;
-- per-item quantity/availability limits are respected;
-- construction cost is within budget;
-- game-owned floor/placement constraints are satisfied where they are intentionally outside canonical executability semantics;
-- the attempt uses the challenge's fixed workload/contract rather than a player-substituted input;
-- any challenge-specific prerequisite is satisfied.
+## 2. Completed implementation sequence
 
-Admissibility does **not** prove canonical executability. An admitted candidate is still projected and passed to Arcogine validation/publication. Conversely, an executable canonical factory may still be inadmissible for a particular challenge.
+### PLAN-CHAL-1 — Challenge definition, identity, and validation — COMPLETE
 
-### Acceptance criteria
+Implemented headlessly in `:challenge`:
 
-PLAN-CHAL-2 is ready when:
+- immutable challenge identity/content version;
+- evaluation-policy identity/version;
+- floor, budget, fixed-workload, catalogue-reference, and deadline facts;
+- deterministic scalar/structural validation with stable issue code/path/message;
+- no dependency on Factory runtime or UI modules.
 
-1. Placing/removing game catalogue items updates construction cost deterministically.
-2. Unaffordable drafts can be rejected by game rules without mutating Arcogine runtime state.
-3. Purchase/resale rules are versioned challenge semantics when they affect reproducibility.
-4. Arcogine does not acquire player currency, purchase price, score, or catalogue-availability fields.
-5. Equivalent canonical designs can be evaluated under different challenge economies without changing production semantics.
-6. Catalogue logic does not depend on treating the current canonical `ResourceDefinition` as a reusable equipment type.
-7. Candidate admissibility is callable headlessly and returns deterministic structured reasons.
-8. An executable canonical factory may still be rejected for violating challenge rules, and an admitted candidate must still pass Arcogine executability validation before publication/run.
-9. The fixed challenge workload/input cannot be silently replaced by the candidate attempt.
+Definition validation does not replace `FactoryModelValidator`. External content decoding/loading is a separate responsibility from validating an already-constructed definition.
 
-### Implementation status (PLAN-CHAL-2 — complete)
-
-PLAN-CHAL-2 is **complete** across the PLAN-CHAL-1, C2a, and C2b slices. The catalogue seam, deterministic
-draft-economics calculation, and deterministic candidate admissibility are implemented in the
-game-owned `:challenge` module (packages `com.arcogine.challenge.catalogue`,
-`com.arcogine.challenge.economics`, and `com.arcogine.challenge.admissibility`), with no
-`project(...)` dependency on `:types`, `:simulation`, `:factory`, `:economy`, `:finance`, `:api`,
-or `:cli`.
+### PLAN-CHAL-2 — Catalogue, draft economics, and candidate admissibility — COMPLETE
 
 Implemented:
 
-- `EquipmentOffer`, an immutable game-owned catalogue entry (item id, non-negative purchase cost,
-  optional positive quantity limit), and `EquipmentCatalogue`, an immutable collection of offers
-  with value equality and lookup by item id. Neither assumes Arcogine's canonical
-  `ResourceDefinition` is a reusable equipment type.
-- `EquipmentCatalogueValidator`, a deterministic, side-effect-free static validator producing an
-  `EquipmentCatalogueValidationResult` of `EquipmentCatalogueIssue` (stable code, field path,
-  message): catalogue-internal validity (blank/duplicate item ids, negative cost, invalid quantity
-  limit), plus a separate `validateChallengeResolution` check that every
-  `ChallengeDefinition.availableEquipment` identity resolves to exactly one catalogue offer. It
-  does not call, extend, or share a result type with `ChallengeDefinitionValidator` or
-  `FactoryModelValidator`.
-- `DraftEquipmentOccurrence` (a catalogue item id only -- no position, footprint, or canonical
-  resource id) and `DraftEconomicsCalculator`, a pure static calculator that resolves each
-  occurrence through the catalogue and derives an immutable `DraftEconomics` (starting budget,
-  committed construction cost, remaining budget) from the challenge's starting budget. Unknown
-  catalogue references and 64-bit cost/budget overflow are reported as a structured
-  `DraftEconomicsFailure` via `DraftEconomicsResult`, never as an uncaught exception or a silently
-  wrapped total. The calculator mutates none of its inputs and is order-independent over
-  occurrences.
-
-Implemented in C2b:
-
-- `CandidateDraftSnapshot`, `PlacedEquipment`, `EquipmentOccurrenceId`, and `GridPlacement` are
-    immutable game-owned draft values. The candidate contains no workload or contract field, so it
-    cannot replace the fixed challenge requirement.
-- `CandidateAdmissibilityPolicy` returns an immutable `CandidateAdmissibilityResult` with stable
-    game-owned issue codes, occurrence paths, and messages. It checks catalogue resolution,
-    challenge availability, quantity limits, delegated economics and budget affordability, floor
-    bounds, overlap, and duplicate occurrence identity.
-- Diagnostics use a frozen order (identity, resolution, availability, quantity, budget/economics,
-    bounds, overlap) and deterministic occurrence/item ordering. Economics failures are surfaced as
-    explicit admissibility issues rather than being treated as budget failures.
-
-PLAN-CHAL-2 completion does not make the game playable and satisfies no Engine Readiness gate. An admitted
-candidate is not canonically executable: a later game-owned projection still requires Arcogine
-canonical validation before publication/run. Conversely, a canonically executable factory may
-remain inadmissible under a particular challenge. PLAN-CHAL-3 is implemented independently of that
-projection; PLAN-CHAL-3, PLAN-CHAL-4, and PLAN-CHAL-5 are now implemented (see PLAN-CHAL-5's "Implementation status" subsection
-below).
-
-## 7. PLAN-CHAL-3 — Deterministic challenge evaluation
-
-### Goal
-
-Evaluate exact outcome facts under an exact challenge/evaluation policy and produce an explainable immutable result.
-
-A useful conceptual shape is:
-
-```text
-Challenge evaluation input
-    challenge identity/version
-    evaluation-policy identity/version
-    model provenance
-    workload/run provenance where supported
-    authoritative outcome facts
-    game-owned construction cost
-
-Challenge evaluation result
-    success/failure
-    reasons
-    deadline margin
-    unused budget
-    score/rating
-```
-
-The evaluator should be a pure or equivalently deterministic operation over explicit inputs.
-
-### Evaluation-policy identity contract
-
-For the first implementation, the **evaluation-policy identity/version is the complete semantic identity of challenge evaluation behavior**.
-
-Any change that can alter an evaluation result for the same explicit inputs must create a new evaluation-policy version. Pure implementation refactors may retain the version only when they preserve observable evaluation semantics.
-
-Historical attempts therefore retain the evaluation-policy identity/version they used. A runtime/application build identifier may additionally be recorded for diagnostics, but it is not a substitute for semantic policy versioning.
-
-This rule avoids requiring a second independent evaluator-version concept while still making old results reproducible and attributable.
-
-### Acceptance criteria
-
-PLAN-CHAL-3 is ready when:
-
-1. Identical explicit evaluation inputs under the same evaluation-policy identity/version produce identical results.
-2. Success/failure can be explained through structured reasons rather than only a scalar score.
-3. The evaluator can operate against synthetic supported-outcome fixtures without an active Arcogine runtime.
-4. The evaluator consumes authoritative outcome facts rather than reconstructing production semantics.
-5. Every result-affecting evaluator change creates a new evaluation-policy version.
-6. An old attempt retains the exact challenge and evaluation-policy identities/versions that produced its result.
-7. Reference fixtures can reproduce historical evaluation results under their recorded policy versions.
-
-### Implementation status (PLAN-CHAL-3 — complete)
-
-PLAN-CHAL-3 is **complete** as a headless, deterministic evaluation capability in
-`com.arcogine.challenge.evaluation`. `ChallengeEvaluationInput` carries the exact immutable
-`ChallengeDefinition`, opaque published-model and run references, narrow supplied
-`AuthoritativeOutcomeFacts`, and game-owned committed construction cost. It does not inspect or
-instantiate a factory model, `FactoryRuntime`, scheduler, queue, or API/runtime DTO.
-
-`ReferenceChallengeEvaluationPolicy` implements `policy.contract-completion` version `1`. It
-succeeds only when the supplied authoritative facts report fixed-contract completion on or before
-the challenge deadline and committed construction cost is within the starting budget. It produces
-ordered game-owned reason codes for incomplete contract, missed deadline, and exceeded budget;
-records deadline margin and unused budget; and returns zero score on failure. Its deliberately
-small first score formula is exact-integer `1 + deadline margin + unused budget` on success, where
-the one-point completion bonus distinguishes exact-deadline/exact-budget completion from failure.
-This is a
-vertical-slice policy, not a permanent balancing decision; any observable semantic change requires
-a new `EvaluationPolicyIdentity` version.
-
-`ChallengeEvaluationResult` retains the exact challenge identity/version, policy identity/version,
-opaque model/run provenance, decision, immutable ordered reasons, deadline margin, unused budget,
-and score. Synthetic outcome fixtures demonstrate deterministic historical reproduction without an
-active Arcogine runtime. PLAN-CHAL-3 does not create attempt history or comparison (PLAN-CHAL-4), content loading or
-reference-content serialization (PLAN-CHAL-5), a runtime adapter, a generic evaluation framework, or any
-Engine Readiness evidence. No playable game or Engine Readiness gate is claimed complete.
-
-## 8. PLAN-CHAL-4 — Attempt provenance and design-to-design comparison
-
-### Goal
-
-Make design iteration historically attributable and comparable.
-
-An attempt should eventually retain enough identity to answer:
-
-```text
-Which challenge/rules version?
-Which admitted game-owned draft snapshot?
-Which published factory design?
-Which workload/run?
-Which evaluation-policy identity/version?
-Which authoritative result facts?
-Which game evaluation resulted?
-```
-
-A comparison may then explain changes such as:
-
-```text
-completion time       391 -> 348
-construction cost     28k -> 34k
-transfer contribution  92 -> 41
-score                  740 -> 812
-```
-
-Only supported facts may be compared as authoritative production results. Game presentation may derive deltas from those facts and may compare its own immutable draft snapshots. This does not require Arcogine to provide a canonical semantic diff between published models.
-
-### Acceptance criteria
-
-PLAN-CHAL-4 is ready when:
-
-1. An attempt references the exact challenge version and admitted game-owned draft snapshot used.
-2. An attempt references the published model identity when publication succeeds.
-3. Evaluation provenance identifies the exact evaluation-policy identity/version.
-4. Historical attempts are immutable or historically attributable.
-5. Two synthetic attempts can be compared without Arcogine runtime internals.
-6. Later integration can add supported run/session provenance without changing the meaning of old game-owned records.
-7. Comparison distinguishes authoritative production facts from game-owned score/economics/draft facts.
-8. No comparison requirement implies Arcogine PLAN-FD-5 semantic comparison unless a future product requirement explicitly asks Arcogine to explain semantic differences between published model versions.
-
-### Implementation status (PLAN-CHAL-4 — complete)
-
-PLAN-CHAL-4 is **complete** as a headless, deterministic attempt and comparison capability in
-`com.arcogine.challenge.attempt` and `com.arcogine.challenge.comparison`. It reuses PLAN-CHAL-1 to PLAN-CHAL-3 facts
-rather than duplicating them: `ChallengeAttempt` retains the exact admitted `CandidateDraftSnapshot`
-(PLAN-CHAL-2), the exact historical `DraftEconomics` used (PLAN-CHAL-2), and the exact `ChallengeEvaluationResult`
-(PLAN-CHAL-3) -- which already carries the challenge identity/version, evaluation-policy identity/version,
-and opaque model/run provenance. `ChallengeAttempt` does not recompute economics against the
-current catalogue or re-evaluate the result; `challengeIdentity()` and `evaluationPolicy()` are
-thin accessors onto the retained `ChallengeEvaluationResult`, not a second copy of those facts.
-
-`ChallengeAttemptId` is a game-owned identity for the historical occurrence of one attempt --
-distinct from, and never derived from, `ChallengeIdentity`, `EvaluationPolicyIdentity`, or any
-published-model/run reference. `ChallengeAttempt.record(...)` generates a fresh id and constructs
-an immutable attempt in one step; there is no separate lifecycle/state-machine, submission
-workflow, or persistence -- PLAN-CHAL-4 needed only a reproducible completed-attempt record. Model/run
-provenance is carried exactly as PLAN-CHAL-3 supplied it (via the required, non-blank `EvaluationProvenance`
-inside the retained result) and is never fabricated or substituted by PLAN-CHAL-4 -- PLAN-CHAL-3's existing contract
-requires a caller-supplied opaque model/run reference for every evaluation, so PLAN-CHAL-4 has nothing
-optional to preserve here; a later integration that needs genuinely absent runtime provenance would
-require a PLAN-CHAL-3 contract change, not a PLAN-CHAL-4 one.
-
-`ChallengeAttemptComparator.compare(...)` in `com.arcogine.challenge.comparison` first checks
-`AttemptCompatibility`: two attempts are comparable only when they share the exact same
-`ChallengeIdentity` and `EvaluationPolicyIdentity` (including version). Incompatible pairs return
-stable, ordered `AttemptIncompatibilityReason` codes (`attempt.challenge.mismatch`,
-`attempt.evaluationPolicy.mismatch`) instead of a silently misleading comparison. Compatible pairs
-produce an `AttemptComparison` of score delta, deadline-margin delta, unused-budget delta, and
-construction-cost delta -- all read directly from already-owned PLAN-CHAL-2/PLAN-CHAL-3 facts, plus a `winner`
-(`FIRST`/`SECOND`/`TIE`) derived solely from the shared policy's own score ordering. Comparison
-never re-evaluates either attempt and never mutates its inputs; attempt identity plays no part in
-the comparison outcome.
-
-Tests in `ChallengeAttemptTest` and `ChallengeAttemptComparatorTest` cover immutability of the
-retained candidate snapshot and economics, non-recomputation of the evaluation result, deterministic
-and identity-independent comparison, and structured incompatibility for mismatched challenge or
-policy versions. PLAN-CHAL-4 does not add persistence, a leaderboard, UI, REST/SSE endpoints, a generic
-comparison framework, or Governance evidence semantics; it does not claim canonical model
-projection or a completed Engine Readiness gate. Remaining work -- data-driven challenge content,
-reference-content serialization, and any durable attempt storage -- is deferred to PLAN-CHAL-5 or later
-consumer integration.
-
-## 9. PLAN-CHAL-5 — Data-driven challenges and reference fixtures
-
-### Goal
-
-Make challenge content independently authorable and use representative fixtures to stabilize challenge semantics before game UI implementation.
-
-Initial content should stay small. Useful challenge archetypes include:
-
-- identify and relieve a processing bottleneck;
-- trade additional capacity against construction cost;
-- trade capacity against shorter transfers once spatial consequences exist;
-- meet the same fixed contract under tighter budget or deadline constraints.
-
-### Acceptance criteria
-
-PLAN-CHAL-5 is ready when:
-
-1. Multiple challenge definitions can be loaded through one supported content path.
-2. Content validation is independent of rendering technology.
-3. Reference fixtures cover challenge-definition failures, candidate-admissibility failures, pass/fail boundaries, and score/rating thresholds.
-4. Synthetic outcome fixtures prove evaluation determinism.
-5. Content does not require engine behavior absent from the applicable readiness gates.
-6. At least one fixture proves a candidate can be canonically executable yet challenge-inadmissible.
-
-### Implementation status (PLAN-CHAL-5 — complete)
-
-PLAN-CHAL-5's content-loading layer is implemented in `com.arcogine.challenge.content`
-(`ChallengeContentLoader`, `EvaluationPolicyResolver`, `Json`/`JsonSyntaxException`,
-`ChallengeContentIssue`, `ChallengeContentLoadResult`,
-`EquipmentCatalogueContentLoadResult`). It decodes challenge and equipment-catalogue content from
-plain JSON -- independent of any rendering technology -- and requires a `schemaVersion` field
-(`"challenge-content:v1"` / `"equipment-catalogue:v1"`) distinct from `ChallengeIdentity.version`
-and `EvaluationPolicyIdentity.version`, so content-format evolution and challenge-semantics
-versioning can move independently. The loader does not reimplement validation rules, but its three
-entry points draw the decode/validate boundary differently: `load(String)` performs structural
-decoding only -- consistent with `ChallengeContentLoadResult`'s own contract that a decoded
-definition's content validity is a separate, later caller step -- and never itself invokes
-`ChallengeDefinitionValidator`; `loadCatalogue(String)` decodes and then always runs
-`EquipmentCatalogueValidator.validate` before reporting success; and
-`loadChallengeWithCatalogue(String, String)` is the one entry point that aggregates both decode
-steps, both content validators (`ChallengeDefinitionValidator` and
-`EquipmentCatalogueValidator.validate`), catalogue-provenance binding/verification (challenge
-`catalogueIdentity`/`catalogueSemanticFingerprint` against the actually resolved catalogue), and
-`EquipmentCatalogueValidator.validateChallengeResolution` into one deterministic, structured
-`ChallengeContentIssue` outcome. A caller that needs `load(String)`'s decoded definition to also be
-content-valid must run it through `ChallengeDefinitionValidator` itself, exactly as
-`ChallengeContentLoaderTest.loadsAMinimalValidDefinition` and the other single-document tests do.
-`EvaluationPolicyResolver`
-is an immutable static registry, currently mapping only
-`ReferenceChallengeEvaluationPolicy` (`policy.contract-completion` / version `"1"`). Covered by
-`JsonTest`, `ChallengeContentLoaderTest`, and `EvaluationPolicyResolverTest`.
-
-Acceptance criterion 6 -- proving a candidate can be canonically Factory-executable yet
-challenge-inadmissible -- is met by
-`CanonicalExecutableButChallengeInadmissibleTest` (module
-`consumer/challenge-factory-integration-test`, a new test-only Gradle module that is the only place
-in the repository with a test dependency on both `:factory` and `:challenge`; neither production
-module depends on the other). The test constructs a structurally valid `FactoryModel` accepted by
-`:factory`'s `FactoryModelValidator`, and a corresponding candidate draft rejected by
-`CandidateAdmissibilityPolicy.assess()` purely for exceeding the challenge's starting credit
-budget (`candidate.budget.exceeded`) -- a game rule with no counterpart in Factory's structural
-validation.
-
-Criterion 4 (synthetic outcome fixtures proving evaluation determinism) is substantively covered by
-existing `ReferenceChallengeEvaluationPolicyTest` cases predating this work: deadline exactly at the
-limit vs. one tick over, construction cost exactly at budget vs. one credit over, successful
-completion, and non-completion, plus `completedOnTimeAndWithinBudgetIsSuccessfulAndDeterministic`,
-which asserts that evaluating the same `ChallengeEvaluationInput` twice produces an equal
-`ChallengeEvaluationResult`. Criterion 3's candidate-admissibility half is similarly covered by
-existing `CandidateAdmissibilityPolicyTest` cases for admitted, unavailable-item, quantity-limit,
-budget, floor-bounds, and overlap outcomes.
-
-### Acceptance-criterion-by-criterion status
-
-1. **Multiple challenge definitions loadable through one supported content path -- met.**
-   `ChallengeContentLoaderTest.loadsMultipleDistinctChallengeDefinitionsThroughTheSameContentPath`
-   loads five JSON fixtures with distinct floor size, starting budget, deadline, workload quantity,
-   and available-equipment sets (spanning bottleneck-relief, capacity/cost-tradeoff, and
-   tight-deadline archetypes) through the single `ChallengeContentLoader.load(String)` entry point,
-   asserts each round-trips to a distinct, structurally complete `ChallengeDefinition`, and then
-   additionally runs each decoded definition through `ChallengeDefinitionValidator.validate(...)`
-   itself and asserts it is content-valid. `load(String)` itself performs structural decoding only
-   -- it never calls `ChallengeDefinitionValidator` (see the implementation-status note above); the
-   content validity asserted here is established by the test's own explicit validator call, not by
-   `load(String)`. A caller that needs both decoding and content validation for a single challenge
-   document must likewise run the decoded definition through `ChallengeDefinitionValidator.validate(
-   ...)` itself, or use `loadChallengeWithCatalogue(String, String)`, which runs the full pipeline
-   in one call.
-2. **Content validation is independent of rendering technology -- met.** `ChallengeContentLoader`
-   decodes plain JSON via the game-owned `Json` parser, and `loadCatalogue`/
-   `loadChallengeWithCatalogue` delegate content validation to `ChallengeDefinitionValidator`/
-   `EquipmentCatalogueValidator` (see the implementation-status note above on which entry point
-   validates what); nothing in the content-loading package depends on a UI, rendering, or
-   presentation technology.
-3. **Reference fixtures cover challenge-definition failures, candidate-admissibility failures,
-   pass/fail boundaries, and score/rating thresholds -- met.** Challenge-definition failures:
-   `ChallengeContentLoaderTest.loadingSucceedsButValidatorCatchesContentInvalidValues` and the
-   dedicated `ChallengeDefinitionValidatorTest` cases (blank ids, non-positive dimensions/budget/
-   deadline/quantity, duplicate/blank available-equipment ids --
-   `duplicateAvailableEquipmentIdsAreRejected`, `blankAvailableEquipmentIdIsRejected`). Candidate-
-   admissibility failures: `CandidateAdmissibilityPolicyTest` (unavailable/unknown items, quantity
-   limits, budget, floor bounds, overlap). Pass/fail boundaries and score/rating thresholds:
-   `ReferenceChallengeEvaluationPolicyTest.deadlineAndBudgetFailuresAreExplainedInStableRuleOrder`,
-   `scoreIsExactForTheLargestC1ValidDeadlineAndBudget`, and the exact-limit-vs-one-over deadline/
-   budget cases. Content-loading-specific catalogue-resolution failures (unknown catalogue
-   reference, duplicate catalogue item id) are covered by
-   `ChallengeContentLoaderTest.rejectsChallengeWithCatalogueWhenAnAvailableEquipmentReferenceIsUnknown`
-   and `rejectsChallengeWithCatalogueWhenCatalogueItselfHasDuplicateItemIds`.
-4. **Synthetic outcome fixtures prove evaluation determinism -- met.**
-   `ReferenceChallengeEvaluationPolicyTest.completedOnTimeAndWithinBudgetIsSuccessfulAndDeterministic`
-   asserts that evaluating the same `ChallengeEvaluationInput` twice produces an equal
-   `ChallengeEvaluationResult`; `ChallengeContentLoaderTest.isDeterministicAcrossRepeatedLoads`
-   covers the content-loading layer's own determinism.
-5. **Content does not require engine behavior absent from the applicable readiness gates -- met.**
-   The content-loading layer (`com.arcogine.challenge.content`) has no dependency on `:types`,
-   `:simulation`, `:factory`, `:economy`, `:finance`, `:api`, or `:cli`; it only decodes JSON into
-   existing PLAN-CHAL-1/PLAN-CHAL-2 game-owned types.
-6. **At least one fixture proves a candidate can be canonically executable yet
-   challenge-inadmissible -- met.** `CanonicalExecutableButChallengeInadmissibleTest`
-   (module `consumer/challenge-factory-integration-test`) constructs a `FactoryModel` accepted by
-   `:factory`'s `FactoryModelValidator` and a corresponding candidate draft rejected by
-   `CandidateAdmissibilityPolicy.assess()` purely on budget (`candidate.budget.exceeded`).
-
-Additionally, `ChallengeContentLoader.loadChallengeWithCatalogue(String, String)` was added to
-close a real content-loading gap identified during this pass: `load(String)` decodes a challenge
-document structurally only (it never itself calls `ChallengeDefinitionValidator`), `loadCatalogue`
-decodes and always content-validates one catalogue document in isolation, and neither previously
-called `EquipmentCatalogueValidator.validateChallengeResolution` or bound/verified catalogue
-provenance, so an unknown or ambiguous catalogue reference in `availableEquipment` -- and a
-challenge/catalogue pair PLAN-CHAL-2's `CandidateAdmissibilityPolicy` would reject on catalogue identity or
-semantic fingerprint -- was never checked by the content-loading layer itself (only by tests that
-constructed both sides in Java). The new method decodes both documents, content-validates the
-challenge definition and the catalogue, binds/verifies catalogue-identity and
-semantic-fingerprint provenance, and then cross-resolves references, aggregating every issue into
-one deterministic result; it is covered by `loadsChallengeWithCatalogueWhenEveryReferenceResolves`,
-`rejectsChallengeWithCatalogueWhenAnAvailableEquipmentReferenceIsUnknown`,
-`rejectsChallengeWithCatalogueWhenCatalogueItselfHasDuplicateItemIds`, and
-`rejectsChallengeWithCatalogueWhenTheDefinitionItselfIsContentInvalid`.
-
-With this pass, all six PLAN-CHAL-5 acceptance criteria have executable proof. PLAN-CHAL-5 is now considered
-**complete**. As with PLAN-CHAL-1 to PLAN-CHAL-4, this does not make the game playable, is not Engine Readiness
-evidence, and does not itself expand the fixture set into every archetype named in the PLAN-CHAL-5 goal
-narrative (identify-and-relieve-bottleneck, capacity/cost, capacity/transfer, tighter budget/
-deadline) as a full production content library -- it demonstrates that the content-loading path,
-once exercised by several varied fixtures, satisfies every stated acceptance criterion. A larger
-production reference-content catalogue remains a content-authoring task for later game
-integration, not an open PLAN-CHAL-5 acceptance gap.
-
-## 10. Relationship to Engine Readiness
-
-The delivery tracks should converge only through supported contracts:
-
-```text
-Game-owned draft
-    |
-    +--> challenge admissibility
-    |        |
-    |        +--> rejected by game rules
-    |
-    v
-project canonical semantics
-    |
-    v
-Arcogine validate/publish
-    |
-    v
-published FactoryModelVersion
-    |
-    v
-Arcogine runtime
-[Engine Readiness]
-    |
-    v
-supported outcome facts
-    |
-    +-------------------------+
-                              |
-Challenge definition ---------+
-[Challenge Readiness]         |
-                              v
-                     Challenge evaluation
-                              |
-                              v
-                       Game presentation
-```
-
-Challenge Readiness may proceed against synthetic fixtures. Engine Readiness does not depend on challenge/scoring semantics. Challenge code must not be used as evidence that runtime gates are correct.
-
-## 11. Relationship to governance/conformance
-
-Challenge Readiness and [Governance and Conformance Capability](governance-conformance-capability.md) are sibling proving grounds for several architectural qualities:
-
-| Concern | Challenge domain | Governance domain |
-|---|---|---|
-| Evaluation subject | Admitted attempt/design/run outcome | Model/revision/change/observation scope |
-| Rules | Challenge/evaluation-policy version | Requirement/assertion versions |
-| Result | Success/failure/score/rating | Conformance result |
-| Explanation | Challenge reasons | Findings |
-| Provenance | Challenge/policy/model/run | Requirement/assertion/evidence/model/revision |
-| History | Attempt comparison | Revision/ChangeSet/audit history |
-
-This similarity is intentional evidence to observe, **not permission to unify the domains prematurely**.
-
-In particular, this plan does not introduce concepts such as:
-
-```text
-ChallengeRule extends Requirement
-ChallengeReason extends governance Finding
-AttemptEvidence extends governance Evidence
-GenericEvaluationEngine<S, R, E>
-```
-
-Reuse architectural principles immediately; extract shared concrete abstractions only after both domains independently demonstrate stable common semantics.
-
-### 11.1 Cross-track architecture reviews
-
-The tracks should compare lessons at three non-blocking checkpoints.
-
-**Identity review — after Challenge PLAN-CHAL-1 and Governance PLAN-GOV-1**
-
-Compare semantic/content identity, historical identity, ruleset versioning, persistence needs, and the role of human labels versus durable identifiers.
-
-**Evaluation review — after Challenge PLAN-CHAL-3 and Governance PLAN-GOV-4**
-
-Compare the stable semantics of subject, exact rule/policy version, evaluator semantic identity, result, explanation/findings, and deterministic reproduction. Ask whether a genuinely domain-neutral evaluation envelope exists; do not assume that it does.
-
-**Provenance review — after Challenge PLAN-CHAL-4 and Governance PLAN-GOV-5**
-
-Compare what exact subject, rules, evaluator policy, evidence/input, and result must be retained to reconstruct a historical decision. Evaluation provenance is the most plausible eventual convergence point, but remains an evidence-driven architecture decision.
-
-These reviews are architecture-learning checkpoints, not delivery dependencies. Either track may proceed if the other has not reached the corresponding checkpoint.
-
-## 12. Explicit non-goals
-
-This initiative does not introduce:
-
-- a generic Arcogine rules engine;
-- a generic evaluation framework;
-- governance requirements as game rules;
-- game scoring concepts in governance;
-- production simulation in the challenge layer;
-- a replacement for factory-model validation;
-- a fake reusable canonical resource type in the game merely to compensate for today's deferred definition/instance split;
-- UI/editor implementation;
-- campaign/progression architecture beyond the minimum challenge semantics;
-- a shared persistence system merely because attempts and governance records both require history.
-
-If stable common abstractions later emerge, they should be justified by concrete implementations in both domains and recorded through the normal architecture/ADR process.
-
-## 13. First end-to-end milestone
-
-Using only game-owned draft/economics facts plus synthetic authoritative outcome facts:
-
-1. load one versioned challenge with a catalogue, budget, fixed contract, deadline, and evaluation policy;
-2. admit one candidate and reject another with structured challenge-rule reasons;
-3. project the admitted candidate through the supported game-to-canonical seam without relying on reusable-type semantics absent from today's model;
-4. evaluate at least two attributable attempts under an exact evaluation-policy version;
-5. reproduce the same evaluations deterministically; and
-6. compare why the second attempt performed differently without depending on Arcogine runtime internals or PLAN-FD-5 semantic comparison.
-
-That milestone proves the challenge/admissibility/evaluation boundary while Engine Readiness continues independently.
-
-## 14. Documentation lifecycle
-
-While exploratory, this file remains under `docs/planning/`.
-
-As work becomes established:
-
-- keep production truth and external-consumer runtime contracts in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md);
-- keep game/Arcogine ownership constraints in [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md);
-- keep the concrete product hypothesis in [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md);
-- keep canonical model evolution, including any eventual definition/instance split, in [Factory Design Capability](factory-design-capability.md);
-- keep generic governed evaluation, evidence, and change semantics in [Governance and Conformance Capability](governance-conformance-capability.md);
-- record genuinely shared, hard-to-reverse abstractions as architecture/ADRs only after evidence from both sibling tracks exists.
-
-Once the challenge layer is implemented and its durable boundaries have moved into current architecture/reference documentation, reduce or retire this planning file.
+- game-owned `EquipmentCatalogue` / `EquipmentOffer` identity and purchase-cost/quantity-limit semantics;
+- deterministic `DraftEconomics` calculation with explicit failure for unresolved references/overflow;
+- immutable candidate draft/placement values;
+- deterministic admissibility for identity, resolution, availability, quantity, affordability, floor bounds, overlap, and duplicate occurrence identity;
+- fixed challenge workload cannot be silently replaced by a candidate.
+
+The catalogue is a game concept. It does not assert that Arcogine's current concrete resource representation is a reusable equipment type. The canonical equipment/resource ontology question is tracked in [Factory Design Evolution Research](../research/factory-design-evolution.md).
+
+### PLAN-CHAL-3 — Deterministic challenge evaluation — COMPLETE
+
+Evaluation is deterministic over explicit challenge/evaluation-policy identity, authoritative outcome facts, model/run provenance where supported, and game-owned economics.
+
+The evaluation-policy identity/version is the semantic identity of evaluation behavior: a result-affecting policy change requires a new version.
+
+Evaluation never invents production facts that Arcogine did not report.
+
+### PLAN-CHAL-4 — Attempt provenance and comparison — COMPLETE
+
+Implemented attempt records preserve:
+
+- exact challenge and evaluation-policy identity/version;
+- retained candidate/economics facts;
+- authoritative outcome/result attribution;
+- non-recomputed historical evaluation result; and
+- deterministic comparison with explicit incompatibility when challenge/policy versions differ.
+
+Game attempt comparison is not canonical Factory semantic comparison and does not require additional Factory diff semantics.
+
+### PLAN-CHAL-5 — Data-driven challenge content and reference fixtures — COMPLETE
+
+Implemented content loading/validation and reference fixtures prove that challenge definitions/catalogue/evaluation policy can be supplied as data rather than hard-coded test setup, while malformed input fails deterministically.
+
+The content layer remains game-owned and does not become a general configuration/interchange framework.
+
+## 3. Required downstream invariants
+
+Any consumer of the completed Challenge capability must preserve:
+
+- Challenge state and production runtime state remain separate;
+- game catalogue/economics do not enter the canonical Factory model;
+- admitted candidate does not imply canonically executable factory;
+- canonical execution/outcome facts come from Arcogine, not Challenge reconstruction;
+- evaluation behavior is versioned by evaluation-policy identity;
+- attempts remain attributable to exact challenge/policy/input/outcome facts;
+- Challenge history is not RuntimeEvent history or Governance controlled-revision history.
+
+## 4. No further implementation admitted
+
+The current Challenge delivery sequence is closed. New Challenge work requires a concrete promoted requirement from the playable-game/product research or another consumer.
+
+Examples such as campaign progression, leaderboard persistence, richer scoring, or shared Governance/Challenge evaluation abstractions are not roadmap placeholders. Track them in research/product work until a real requirement crosses the planning admission boundary.
+
+The current product investigation is [Factory-Design Game Vertical-Slice Research](../research/factory-design-game-vertical-slice.md).
+
+## 5. Integration milestone
+
+The implemented headless capability can already prove, using game-owned candidate/economics facts plus synthetic authoritative outcome fixtures:
+
+1. load and validate one versioned challenge/catalogue/evaluation policy;
+2. admit/reject candidates with deterministic structured reasons;
+3. evaluate exact outcome facts deterministically;
+4. retain attributable immutable attempts; and
+5. compare attempts without runtime internals.
+
+A playable/runtime-integrated milestone belongs to [Factory-Design Game Consumer Implementation Plan](factory-design-game-consumer.md) only after the product research and required Engine/Factory gates are satisfied.

--- a/docs/planning/factory-design-game-consumer.md
+++ b/docs/planning/factory-design-game-consumer.md
@@ -1,322 +1,147 @@
-# Factory-Design Game Consumer Initiative
+# Factory-Design Game Consumer Implementation Plan
 
-> **Status:** Proposed  
-> **Scope:** A separate, single-player factory-design game consuming Arcogine as its production engine  
-> **Authority:** Planning only; this document does not describe current capability or accepted architecture  
-> **Dependency:** Headless [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md) may progress independently; playable/runtime-integrated game implementation begins only after the model-seam entry gate (§1.1 of [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)), Engine PLAN-ENG-1 to PLAN-ENG-5, and the accepted PLAN-ENG-W1 decomposition contract in [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) are implemented and proven  
-> **Related:** [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md), [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md), [Factory Design Architecture](../architecture/factory-design.md), [Factory Design Capability](factory-design-capability.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [ADR-0009](../architecture/decisions/0009-deterministic-dispatch-closure-and-work-decomposition-boundary.md), [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md)
+> **Status:** BLOCKED for playable/runtime-integrated implementation; headless Challenge capability is already available independently  
+> **Scope:** Settled Arcogine/game ownership, upstream prerequisites, implementation admission, and integration acceptance for a separate factory-design game consumer  
+> **Authority:** Planning only; product hypotheses and unresolved consumer choices live in research
 
-## 1. Initiative summary
+## 1. Consumer boundary
 
-This initiative explores a separate factory-design game that uses Arcogine as its authoritative production-system model and deterministic simulation runtime.
+The game consumes Arcogine as the authority for published production-system semantics and deterministic runtime consequences.
 
-The game owns rendering, interaction, progression, scoring, content, and player experience. Arcogine owns the published executable production-system semantics, validation, simulation clock, operational state, scheduling, events, observations, and deterministic consequences of factory design.
-
-```text
-Design a factory
-        ↓
-Project the draft into Arcogine's canonical model
-        ↓
-Validate and publish a model version
-        ↓
-Instantiate and simulate production
-        ↓
-Inspect queues, transfers, and bottlenecks
-        ↓
-Revise the draft and publish another design
-```
-
-The first outcome is a vertical slice proving that capacity and physical arrangement create understandable, reproducible trade-offs. It is not a commitment to a campaign, generic game framework, or complete factory-management game. The concrete product thesis, player loop, reference challenge, and product-level success criteria live in [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md); this document owns the consumer boundary, readiness dependencies, and ownership constraints.
-
-## 2. Upstream dependencies
-
-This consumer must not define Arcogine's missing factory semantics under UI pressure.
-
-### 2.1 Factory design capability
-
-[Factory Design Capability](factory-design-capability.md) owns the model-side boundary:
-
-- canonical factory model semantics;
-- structured executability validation;
-- immutable publication/model versioning boundary;
-- model identity and provenance;
-- deterministic runtime instantiation from a published model.
-
-The game may own an editor-specific draft, but that draft is not the authoritative executable model.
-
-### 2.2 Simulation engine readiness
-
-[Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) owns runtime concerns:
-
-- production orders, quantity semantics, and work execution;
-- deterministic decomposition of one accepted quantity-`N` order into independently dispatchable work items under the accepted PLAN-ENG-W1 contract;
-- capability/eligibility-based deterministic dispatch;
-- consumer-neutral session and bounded advancement;
-- supported observations and externally visible runtime events;
-- deterministic transfer/runtime consequences of semantic layout;
-- later recovery, checkpoint, compatibility, and sidecar hardening.
-
-ADR-0009 records why decomposition is separate from PLAN-ENG-2 dispatch. ADR-0010 resolves the PLAN-ENG-W1 architecture: `Order` remains immutable production intent and the aggregate correlation identity; `JobId` identifies independently dispatchable work items; PLAN-ENG-W1 creates one unit-quantity `Job` per requested quantity unit; aggregate progress/completion remains order-level; and exactly one `OrderCompleted` event is produced for the order. This design is accepted but is not runtime evidence until implemented and proven by the Engine track.
-
-A CLI command, JUnit harness, or thin reference consumer used to prove either upstream plan is not game implementation.
-
-### 2.3 Challenge readiness may progress in parallel
-
-[Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md) owns game-side challenge semantics that can be proven headlessly without a playable or runtime-integrated game consumer:
-
-- challenge identity and content/rules versioning;
-- game-owned equipment catalogue, prices, availability, and construction-budget rules;
-- candidate admissibility under challenge rules;
-- evaluation-policy identity/version and deterministic challenge evaluation;
-- evaluation provenance;
-- attempt history and game-facing comparison;
-- data-driven challenge fixtures and synthetic outcome fixtures.
-
-PLAN-CHAL-1 to PLAN-CHAL-5 in that plan may progress before Engine Readiness PLAN-ENG-1 to PLAN-ENG-5 because they consume game-owned drafts and synthetic outcome facts rather than standing in for missing Arcogine production semantics. Headless challenge work must not simulate production, reconstruct queues or dispatch, infer missing runtime observations, or be used as evidence that an Engine Readiness gate is satisfied.
-
-This exception applies only to the independent challenge/evaluation track. The playable/runtime-integrated game consumer still waits for the entry gates below.
-
-### 2.4 Playable/runtime-integrated game entry gates
-
-Before playable or runtime-integrated game implementation starts, Arcogine must have satisfied:
-
-1. The model-seam entry gate (§1.1 of Factory Simulation Engine Readiness): the behavior-preserving canonical-model seam, narrower than the full PLAN-FD-1 to PLAN-FD-4 acceptance criteria.
-2. PLAN-ENG-1: explicit production workload and separate execution semantics.
-3. PLAN-ENG-2: capability/eligibility-based deterministic resource dispatch for independently dispatchable work.
-4. PLAN-ENG-3: consumer-neutral simulation session with bounded advancement.
-5. PLAN-ENG-W1 as defined by ADR-0010: one fixed accepted quantity-`N` production requirement deterministically creates `N` unit-quantity sibling `Job`s under one `Order`, so equivalent bottleneck capacity can affect that same contract while aggregate progress/completion remains order-level.
-6. PLAN-ENG-4: stable observations and ordered external runtime events, including the `OrderId`/`JobId` execution correlation established by PLAN-ENG-W1.
-7. PLAN-ENG-5: deterministic spatial runtime consequences.
-
-The headless dispatch-capacity, fixed-contract work-decomposition, and layout benchmarks must pass before a game UI is used as evidence for those capabilities. PLAN-ENG-2 remains complete independently of work decomposition; the extra prerequisite exists because the current reference challenge specifically requires both semantics together.
-
-## 3. Charter and semantic alignment
-
-The initiative operates under the [Product Charter](../product/charter.md):
-
-- it exercises the **Design**, **Understand**, **Simulate**, and **Improve** modes over one executable production-system model;
-- the design published by Arcogine is the design Arcogine instantiates and simulates;
-- the game does not maintain a competing operational truth;
-- simulation state is explicitly hypothetical;
-- the game is a consumer of Arcogine, not a redefinition of Arcogine as a game;
-- game-specific concepts do not enter Arcogine merely because this consumer needs them.
-
-The initiative also follows [Factory Design Architecture](../architecture/factory-design.md) and the [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md):
-
-- definitions remain distinct from runtime orders/work execution;
-- resource definitions remain distinct from installed instances;
-- requested, assigned, started, completed, and reported state remain distinguishable;
-- resource hierarchy remains distinct from spatial layout;
-- approachable Arcogine aliases may be retained where clearer;
-- no ISA-95 interchange or conformance claim is made.
-
-## 4. Minimal vertical slice
-
-The demonstrator is a factory-layout challenge in which the player receives a fixed production contract, places machines on a bounded floor, publishes the design, runs the factory, observes operational behavior, and redesigns until the contract is completed within its constraints.
-
-### 4.1 Game requirements
-
-| ID | Requirement | Acceptance criterion |
-|---|---|---|
-| G-01 | Bounded challenge | One level defines a floor, starting budget, fixed contract, deadline, and unambiguous success/failure condition. |
-| G-02 | Factory editor | The player can place, move, rotate, and remove resource instances in a game-owned draft. Out-of-bounds/overlap problems are shown clearly. |
-| G-03 | Small equipment catalogue | At least three resource types support three sequential operations. Multiple instances of a type can be installed. |
-| G-04 | Capacity matters | Adding compatible capacity at a bottleneck can reduce queueing or completion time for the fixed production contract. |
-| G-05 | Distance matters | Transfer time depends deterministically on semantic layout. |
-| G-06 | Design-run loop | The player can validate/publish a draft, start a run, pause, step, reset, and return to design mode. Structural edits are between runs initially. |
-| G-07 | Legible operation | The player can see resource state, queues, active work, transfers, contract progress, and core KPIs. |
-| G-08 | Diagnostic feedback | The bottleneck can be identified without reading the raw event log. |
-| G-09 | Deterministic retry | Same published model, seed, workload, and commands produce the same result. |
-| G-10 | Actionable validation | Invalid drafts display Arcogine's structured entity/path-specific diagnostics clearly. |
-
-### 4.2 Minimum content envelope
-
-The first playable slice needs only:
-
-- one bounded factory floor;
-- one product;
-- three ordered operations;
-- three resource/machine types;
-- one receiving and one shipping point;
-- one fixed production contract;
-- one tutorialized challenge;
-- one score derived from completion, deadline performance, and unused game budget.
-
-The level should support at least two credible designs, such as parallel bottleneck capacity versus shorter transfer distance.
-
-The product-level reference challenge is described in [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md). Its exact quantities, dimensions, prices, and deadlines are game-content parameters rather than Arcogine contracts.
-
-### 4.3 Initial editing and publication rule
-
-The game owns an editable `FactoryDraft` or equivalent authoring representation. It may contain temporary IDs, invalid intermediate states, selection, undo history, camera state, previews, and game-only metadata.
-
-Pressing Run follows this semantic boundary:
+The game owns presentation and player-facing authoring. Arcogine owns production truth.
 
 ```text
 Game-owned draft
       |
- challenge admissibility
+      v
+challenge admissibility
       |
- project canonical semantics
+      v
+project supported canonical semantics
+      |
       v
 Arcogine validate + publish
       |
       v
 FactoryModelVersion
       |
- instantiate
       v
 Arcogine runtime
+      |
+      v
+supported observations / runtime events
+      |
+      v
+game presentation and attempt evaluation
 ```
 
-Challenge admissibility and Arcogine executability answer different questions. A draft may be canonically executable yet inadmissible under the selected challenge's catalogue, budget, fixed workload, or other game-owned constraints. Conversely, passing challenge admissibility does not prove Arcogine executability after projection.
+Challenge admissibility and Arcogine executability remain separate decisions. Passing one never implies passing the other.
 
-Changing the draft creates another candidate design and therefore another published model version when accepted. It does not mutate the model underneath an active run.
+## 2. Product-research dependency
 
-Live placement/movement/removal during active work is not required for the vertical slice.
+The playable requirement set is not yet an implementation input. It is being tested in [Factory-Design Game Vertical-Slice Research](../research/factory-design-game-vertical-slice.md).
 
-## 5. Consumer-Arcogine responsibility boundary
+Rendering/input technology, scoring, tutorial sequence, save-wrapper shape, interpolation policy, and other evidence-dependent consumer choices must not be selected in this plan before that research concludes.
+
+The implementation gate is tracked in [Factory-Design Game Vertical-Slice Implementation Gate](factory-design-game-vertical-slice.md).
+
+## 3. Upstream implementation prerequisites
+
+Playable/runtime-integrated work must not define missing Arcogine semantics under UI pressure.
+
+### Factory Design
+
+Consume the supported canonical model, executability validation, immutable publication, model identity/provenance, and deterministic runtime-instantiation boundary.
+
+The game may keep an editor-specific mutable draft, but it must project only supported canonical facts at validation/publication time.
+
+### Engine
+
+Before playable integration is admitted, the required Engine capabilities for the promoted product requirements must be landed. For the currently researched capacity/layout loop this includes:
+
+- explicit production workload and immutable order intent;
+- deterministic independently dispatchable work and resource selection;
+- consumer-neutral bounded advancement;
+- stable supported observations and ordered runtime events;
+- deterministic spatial transfer consequences;
+- the accepted order/work-item decomposition contract from ADR-0010.
+
+Use the current [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) and its implementation companions as the authority for which of those gates are actually complete.
+
+### Challenge
+
+[Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md) provides the game-owned headless challenge substrate: challenge identity/version, catalogue/economics, admissibility, deterministic evaluation, attempt provenance/comparison, and data-driven fixtures.
+
+That substrate may be consumed by the eventual game, but its completion is not evidence that the playable product loop has been validated.
+
+## 4. Settled responsibility boundary
 
 | Concern | Owner |
 |---|---|
 | Rendering, animation, camera, input, audio, assets | Game |
-| Editable draft, local undo history, editor persistence | Game |
-| Challenge identity and content/rules version | Game challenge layer |
-| Equipment catalogue identity, availability, purchase/resale rules, construction budget | Game challenge layer |
-| Candidate admissibility under challenge-owned rules | Game challenge layer |
-| Evaluation-policy identity/version, success/failure, score/rating semantics | Game challenge layer |
-| Evaluation provenance, attempt history, game-facing attempt comparison | Game challenge layer |
-| Contract presentation, tutorials, narrative, unlocks | Game |
-| Visual interpolation between authoritative event times | Game |
-| Canonical production-system semantics | Arcogine design/model boundary |
-| Shared executability validation | Arcogine design/model boundary |
-| Published model identity/version/provenance | Arcogine design/model boundary |
-| Products, operations, resource definitions/instances, semantic layout | Arcogine canonical model |
-| Orders, order-level execution progress, child Jobs/work items, queues, dispatch, processing, transfers in progress | Arcogine runtime |
-| Simulation clock, event ordering, deterministic random behavior | Arcogine runtime |
-| Runtime observations and KPIs | Arcogine runtime |
-| Model/command/event/observation compatibility contracts | Arcogine |
-| Combined save file | Game wrapper around Arcogine checkpoint plus game-owned state |
+| Editable draft, local undo/history, editor persistence | Game |
+| Challenge identity/rules, catalogue availability/prices, construction budget | Challenge layer |
+| Candidate admissibility | Challenge layer |
+| Evaluation policy, score/rating semantics, attempt history/comparison | Challenge layer |
+| Canonical production-system semantics and executability | Arcogine Factory Design |
+| Published model identity/version/provenance | Arcogine Factory Design / Governance where revision-bound |
+| Workload, work items, queues, dispatch, processing, transfers | Arcogine Engine/runtime |
+| Simulation clock and deterministic event ordering | Arcogine Engine/runtime |
+| Supported runtime observations/events and performance facts | Arcogine Engine/runtime |
+| Player-facing summaries and visualization of supported facts | Game |
+| Game save wrapper around any supported Arcogine checkpoint | Game |
 
-Arcogine should not acquire `Level`, `StarRating`, `Unlock`, `PlayerCurrency`, challenge-evaluation policy, game-attempt history, decorative furniture, campaign progress, or tutorial steps. The game should not reproduce validation, workload decomposition, scheduling, queueing, dispatch, transfer, or KPI semantics that Arcogine owns.
+Do not put `Level`, score/rating, unlocks, player currency, tutorial state, decorative assets, or campaign progression into canonical Arcogine semantics.
 
-## 6. Client-specific requirements after upstream readiness
+Do not reproduce Arcogine validation, workload decomposition, scheduling, queueing, dispatch, transfer, or KPI semantics inside the game.
 
-### 6.1 Draft authoring
+## 5. Integration rules after admission
 
-The game may maintain a user-friendly draft representation. At validation/run time it projects only canonical semantic facts into Arcogine's supported model contract.
+### Draft projection
 
-This projection must be explicit and testable. The game must not invent production semantics absent from the canonical model.
+The game draft may be incomplete or invalid. Projection into Arcogine must be explicit and testable and must not invent unsupported production semantics.
 
-### 6.2 Simulation control and pacing
+### Simulation control
 
-The game consumes Arcogine's bounded advancement contract to provide pause, single-event step, normal/accelerated presentation, reset, and deterministic retry.
+The game consumes bounded advancement/reset semantics. Presentation speed changes how the client asks the runtime to advance; it must not change production durations or make outcomes depend on wall-clock timing.
 
-Presentation speed controls how frequently/how far the client asks Arcogine to advance. It does not alter processing durations or make simulation depend on wall-clock timing.
+### Visualization and diagnostics
 
-### 6.3 Visualization
+Render supported observations/events rather than internal Engine classes. Consumer summaries may make evidence easier to understand but must not become a competing authoritative computation.
 
-The game renders supported observations/events rather than internal engine classes. It may interpolate operation progress, transfers, queue movement, and completion feedback visually while Arcogine remains authoritative for state and simulated time.
+### Challenge evaluation
 
-### 6.4 Diagnostics
+Challenge evaluation interprets authoritative Arcogine outcome facts plus game-owned economics/draft facts. It must not reconstruct production truth from hidden assumptions.
 
-The client should make supported evidence understandable, including queue depth, utilization, completion progress, WIP, lead time, transfer contribution, and active bottleneck.
+### Persistence
 
-It may summarize/highlight observations but must not calculate a competing authoritative result from hidden assumptions.
+Any combined save is a consumer wrapper around the supported Arcogine recovery/checkpoint contract plus game-owned state. Do not invent an unsupported Engine persistence contract merely to satisfy the game.
 
-### 6.5 Game economy and challenge evaluation
+## 6. Playable implementation admission
 
-The initial game economy may include starting cash, purchase/resale prices, contract payout, deadline bonus/penalty, and scenario score.
+Playable/runtime-integrated work may begin only when:
 
-These are game rules. They do not extend Arcogine Finance unless a separate product-level use case creates a genuine engine requirement.
+1. the vertical-slice product research has concluded and promoted a concrete requirement set;
+2. the required Factory/Engine gates for that requirement set are landed;
+3. the integration surface is explicit;
+4. any selected save/recovery requirement has a supported Arcogine contract or is explicitly excluded from the first slice;
+5. game-only semantics remain outside Arcogine; and
+6. acceptance tests can be written against supported Arcogine contracts rather than internal implementation state.
 
-Challenge identity/version, admissibility, evaluation-policy identity/version, score/success semantics, and attempt provenance/history are specified in [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md). Challenge evaluation may interpret authoritative Arcogine outcome facts but must not recreate production semantics to derive facts Arcogine did not report.
+## 7. Integration acceptance criteria
 
-The fixed challenge workload remains one game-owned production requirement. The game does not split it into multiple Arcogine Orders merely to obtain parallel capacity. ADR-0010 assigns decomposition to Arcogine: quantity `N` becomes `N` deterministic unit-quantity sibling `Job`s under the accepted `Order`; the game may visualize those work items and aggregate progress, but it does not choose their count, identity, release order, or dispatch.
+Once admitted, the first playable slice is complete only when:
 
-### 6.6 Persistence and local runtime
+1. a game-owned candidate is admitted by challenge rules, projected, validated, and published through Arcogine;
+2. the runtime is created only from the published model;
+3. the fixed production requirement is submitted without the game manufacturing work decomposition;
+4. the client controls the run through supported session/advancement primitives;
+5. player-visible runtime state derives from supported observations/events;
+6. identical explicit inputs produce identical semantic outcomes;
+7. a design change produces a new candidate/publication rather than mutating an active run's source model;
+8. challenge scoring/evaluation remains game-owned and attributable to its policy version; and
+9. no game DTO, editor object, or presentation state re-enters Arcogine domain decision paths.
 
-For a prototype, the game may save its draft and rerun from the beginning.
+## 8. Non-goals
 
-Before external distribution it should wrap an exact Arcogine checkpoint with game-owned progress/settings, verify contract compatibility, manage a bundled local runtime if using a sidecar, and recover through Arcogine's supported resynchronization contract.
-
-## 7. Explicit non-goals
-
-The vertical slice does not require:
-
-- live machine micromanagement as the primary game loop;
-- workers, skills, fatigue, or pathfinding;
-- aisles/doors/congestion-aware transport;
-- raw-material procurement/suppliers/BOM;
-- maintenance/failures/shift scheduling;
-- dynamic pricing/stochastic demand/autonomous sales agents;
-- research trees/campaign maps/multiplayer;
-- live structural reconfiguration while work is in flight;
-- live-production connectivity/execution;
-- generic plugin framework;
-- complete ISA-95 hierarchy/transactions/interchange/conformance;
-- shared Arcogine editor/collaboration infrastructure;
-- engine-domain design justified only by game presentation convenience.
-
-## 8. Client-specific open decisions
-
-| Decision | Evidence needed |
-|---|---|
-| Rendering/input technology | Target platforms, team capability, packaging, performance prototype |
-| Sidecar versus supported in-process adapter | Available Arcogine consumer surfaces and target game runtime |
-| Draft-to-canonical-model projection | Final model contract and editor usability prototype |
-| Visual interpolation policy | Event/observation timing and desired presentation style |
-| Game-save wrapper format | Final checkpoint contract and game progression needs |
-| Scoring formula | Playtests showing meaningful factory trade-offs |
-| Tutorial sequence | First-time-user observation |
-
-Canonical model, order/work semantics, PLAN-ENG-W1 decomposition/work-item identity, dispatch, session behavior, event envelopes, and transfer rules are upstream decisions and do not belong here.
-
-## 9. Playable/runtime-integrated game implementation entry criteria
-
-Headless Challenge Readiness PLAN-CHAL-1 to PLAN-CHAL-5 is explicitly outside this entry gate and may proceed earlier under the constraints in §2.3. Playable or runtime-integrated game implementation may begin when all of the following are true:
-
-1. The model-seam entry gate (§1.1 of [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)) is satisfied.
-2. PLAN-ENG-1 to PLAN-ENG-3 in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) are satisfied, including PLAN-ENG-2 at its deterministic-dispatch boundary.
-3. ADR-0010 is implemented: a single quantity-20 accepted `Order` creates exactly 20 independently dispatchable unit-quantity sibling `Job`s with deterministic identities/order, explicit aggregate progress, and exactly one aggregate order completion.
-4. PLAN-ENG-4 to PLAN-ENG-5 in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) are satisfied after accounting for the `OrderId`/`JobId` execution correlation introduced by PLAN-ENG-W1.
-5. A game-like draft can project into the canonical model and publish a `FactoryModelVersion` without using mutable runtime classes.
-6. The headless capacity benchmark proves equivalent-resource dispatch, and the fixed-contract decomposition benchmark proves the current reference workload can actually use that capacity without game-authored order splitting.
-7. The headless layout benchmark proves deterministic transfer consequences across distinct published model versions.
-8. A reference consumer can instantiate, submit workload, advance, observe, and reset without Arcogine internals.
-9. Model and runtime observation contracts are stable enough for a prototype consumer.
-10. No unresolved game requirement requires the client to reproduce authoritative Arcogine logic.
-
-## 10. Vertical-slice acceptance criteria
-
-The game vertical slice is successful when:
-
-1. The player can author a draft and publish a valid factory design without using Arcogine tooling directly.
-2. The resulting run identifies the exact published model version.
-3. A fixed production contract runs independently of pricing, stochastic demand, and autonomous sales behavior.
-4. Quantity represents real production workload rather than primarily commercial value.
-5. The same resources arranged differently produce different deterministic completion times where transfer distance differs.
-6. Adding compatible capacity at the actual bottleneck changes throughput, queueing, utilization, or completion time for the same fixed production contract; the game does not achieve this by rewriting the contract as artificial independent Orders.
-7. The player can identify the bottleneck and major delay sources from supported observations presented by the game.
-8. Invalid drafts display structured diagnostics and do not publish or partially mutate runtime state.
-9. Retrying the same published model with the same seed/workload/commands reproduces behavior and result.
-10. The game owns presentation, scoring, progression, and player economy; no game-specific concept enters Arcogine's canonical/runtime model.
-11. The client depends only on supported model, command, event, observation, checkpoint, and lifecycle contracts.
-12. ISA-95 guidance is used where relevant without claiming conformance.
-
-## 11. Documentation lifecycle
-
-While exploratory, this file remains under `docs/planning/`.
-
-As work becomes established:
-
-- keep canonical-model work in [Factory Design Capability](factory-design-capability.md) until it becomes accepted/current architecture;
-- keep runtime work/evidence in [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md);
-- keep headless challenge/evaluation work in [Factory-Design Game Challenge Readiness](factory-design-game-challenge-readiness.md);
-- keep the concrete first-playable product hypothesis in [Factory-Design Game Vertical Slice](factory-design-game-vertical-slice.md);
-- record hard-to-reverse decisions as ADRs;
-- update [`../architecture/overview.md`](../architecture/overview.md), [Factory Design Architecture](../architecture/factory-design.md), the [ISA-95 mapping](../architecture/isa-95-semantic-mapping.md), and [`../reference/api.md`](../reference/api.md) only as behavior becomes accepted/implemented;
-- track game implementation in issues or the game consumer repository;
-- keep detailed game UX/content/scoring/art/progression outside Arcogine.
-
-Once the vertical slice is complete or abandoned, reduce this document to a concise historical outcome or retire it after durable decisions and implemented behavior are represented in authoritative documentation.
+Unless separately promoted from research, the first implementation does not include live structural reconfiguration, live-production connectivity, a generic plugin framework, campaign/multiplayer architecture, a shared Arcogine editor, or new Factory/Engine abstractions justified only by presentation convenience.

--- a/docs/planning/factory-design-game-vertical-slice.md
+++ b/docs/planning/factory-design-game-vertical-slice.md
@@ -1,168 +1,30 @@
-# Factory-Design Game Vertical Slice
+# Factory-Design Game Vertical-Slice Implementation Gate
 
-> **Status:** Proposed  
-> **Scope:** Product hypothesis for the first playable factory-design game slice  
-> **Authority:** Planning only; this document does not describe current Arcogine capability or accepted architecture  
-> **Related:** [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [Factory Design Capability](factory-design-capability.md), [ADR-0009](../architecture/decisions/0009-deterministic-dispatch-closure-and-work-decomposition-boundary.md), [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md), [Product Charter](../product/charter.md)
+> **Status:** BLOCKED — playable implementation is not admitted until the product research concludes and upstream runtime gates are satisfied  
+> **Scope:** Preserve the implementation-admission boundary for the first playable game slice without carrying the product hypothesis inside delivery planning  
+> **Authority:** Planning only
 
-## 1. Product thesis
+## Current blocker
 
-The first game built on Arcogine is a deterministic factory-design puzzle: given a fixed production contract, floor, budget, and deadline, the player chooses capacity and spatial arrangement, simulates the published design, diagnoses bottlenecks and transfer losses from supported observations, and iterates toward a better factory.
+The product loop, reference challenge, diagnostics, scoring, tutorial, technology, and packaging choices remain under [Factory-Design Game Vertical-Slice Research](../research/factory-design-game-vertical-slice.md).
 
-The game is not initially a general factory-management simulation. Its first purpose is to prove that Arcogine can make production-system design trade-offs understandable, reproducible, and engaging.
+No playable implementation should begin while those choices still determine what the slice is supposed to prove.
 
-The player's primary loop is:
+## Upstream prerequisites
 
-```text
-Understand contract
-        |
-        v
-Design factory
-        |
-        v
-Publish design
-        |
-        v
-Run production
-        |
-        v
-Diagnose queues, utilization, transfers, and bottlenecks
-        |
-        v
-Revise design
-```
+When the product research concludes, playable/runtime-integrated implementation additionally requires the game-consumer entry gates in [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), including the settled canonical model seam, deterministic workload/dispatch/session/event contracts, and spatial runtime consequences.
 
-The central optimization tension is:
+Headless Challenge capability remains independently usable and does not by itself satisfy these playable entry criteria.
 
-```text
-processing capacity
-        versus
-spatial efficiency
-        versus
-capital efficiency
-```
+## Admission criteria
 
-A strong design places enough eligible capacity at the actual bottleneck while avoiding unnecessary transfer time and equipment cost.
+Replace this gate with a concrete implementation slice only when all of the following are true:
 
-## 2. Player fantasy
+1. the product research is **CONCLUDED** with a bounded playable requirement set;
+2. selected consumer decisions have been promoted here or to the consumer implementation plan;
+3. upstream Engine/Factory prerequisites required by those selected requirements are landed;
+4. the exact consumer integration boundary is known;
+5. implementation ownership is clear; and
+6. executable acceptance tests can be written before coding starts.
 
-The player acts as a production-system designer or industrial engineer rather than as a live shift operator.
-
-The core question is:
-
-> Can this factory design execute a known production requirement within its time and budget constraints?
-
-The player should form hypotheses about the production system, test them through deterministic simulation, inspect supported evidence, and revise the design. The game should reward understanding why a design works, not merely discovering a hidden scoring formula.
-
-## 3. Core player decisions
-
-### 3.1 Capacity
-
-The player decides where additional compatible resources are worth their capital cost.
-
-Adding capacity at a true bottleneck should be capable of reducing queueing or completion time. Adding capacity away from the bottleneck may produce little or no benefit. Solving one bottleneck may expose another.
-
-For the fixed-contract reference challenge below, this requirement applies to one accepted production requirement, not to a game-authored collection of artificial independent orders. Arcogine's accepted PLAN-ENG-W1 architecture is recorded by ADR-0010 and is current implemented Engine Readiness semantics, including the 100,000-child benchmark: one accepted quantity-`N` `Order` decomposes into `N` independently dispatchable unit-quantity `Job`s, while aggregate progress and completion remain order-level. The game must not manufacture multiple orders to obtain parallelism; the second-cutter strategy relies on this existing PLAN-ENG-W1 runtime evidence.
-
-### 3.2 Resource eligibility and dispatch
-
-The player chooses installed capability. The player does not author a separate product routing for each individual equivalent machine.
-
-Arcogine owns deterministic assignment of work among eligible resources. The game presents the consequences of the installed resource pool without reproducing dispatch logic.
-
-### 3.3 Spatial arrangement
-
-Resource placement affects deterministic transfer time. Shorter production flows may outperform a more expensive design with additional capacity under some constraints.
-
-### 3.4 Capital efficiency
-
-More equipment may improve capacity but consumes the game-owned construction budget. The strongest design is not necessarily the largest factory.
-
-The initial score should reward successful completion, deadline performance, and unused construction budget.
-
-## 4. Reference challenge
-
-The first product challenge should be concrete enough to anchor later playtesting.
-
-```text
-Contract
-    Produce 20 units of Product A
-
-Routing
-    CUT -> ASSEMBLE -> INSPECT
-
-Available equipment
-    Cutter
-    Assembly station
-    Inspector
-
-Constraints
-    Factory floor: 12 x 10 cells
-    Starting budget: 40,000 credits
-    Deadline: 400 simulation ticks
-
-Scoring
-    Contract completion
-    Deadline margin
-    Unused construction budget
-```
-
-Exact numbers are level-content parameters, not engine contracts, and should be tuned through playtesting.
-
-The level should admit at least two credible approaches, for example:
-
-```text
-Strategy A
-    install a second cutter
-    spend more capital
-    reduce CUT queueing
-
-Strategy B
-    keep one cutter
-    shorten resource-to-resource transfers
-    preserve more capital
-```
-
-Neither approach should dominate under every constraint. The useful product question is whether the player can understand why one design performs better in a particular run.
-
-The 20-unit contract remains one fixed game-owned production requirement. The game must not obtain Strategy A's parallelism by silently translating that requirement into several independent Arcogine `Order`s. Under ADR-0010, Arcogine owns the deterministic decomposition of the accepted order into 20 sibling unit-quantity `Job`s, `JobId` is the independently dispatchable work-item identity, and order progress/completion remain aggregate facts correlated by `OrderId`. The game consumes those semantics; it does not choose the decomposition.
-
-## 5. Player evidence and attempt comparison
-
-The game should make Arcogine's supported runtime evidence legible without requiring the raw event log.
-
-At minimum the player should be able to answer:
-
-- Where is work waiting?
-- Which operation or resource is the current bottleneck?
-- Which resources are saturated or underused?
-- How much production time is attributable to processing versus transfer?
-- How far is the contract from completion?
-- How did this attempt's outcome compare with the previous attempt?
-
-For the vertical slice, design-to-design comparison does **not** require Arcogine's semantic-model-diffing capability. The game may retain immutable game-owned draft snapshots for each attempt and pair them with the published model provenance and supported run outcomes. It can therefore show player-authored design differences from its own snapshots and compare authoritative run results without claiming a canonical semantic diff between two published Arcogine models. PLAN-FD-5's existing initial slice ([Factory Design Capability](factory-design-capability.md#9-plan-fd-5--semantic-comparison-and-design-alternatives)) is available but is not required for this vertical slice.
-
-If a future product requirement needs Arcogine itself to explain semantic differences between published model versions, that requirement should extend the existing PLAN-FD-5 capability with finer-grained comparison semantics rather than create a second diff abstraction.
-
-## 6. Product success criteria
-
-The product hypothesis is proven when:
-
-1. The player understands the fixed production objective, budget, deadline, and available equipment without needing Arcogine-specific tooling knowledge.
-2. Capacity investment creates an understandable trade-off rather than making "buy more machines" universally optimal.
-3. Spatial arrangement creates an understandable performance trade-off rather than acting as decoration.
-4. Solving one production bottleneck can expose another, encouraging diagnosis and redesign.
-5. The player can identify the bottleneck and major delay sources from presented evidence rather than the raw event log.
-6. A retry is useful as an experiment: the player can relate a changed game-owned draft to changed authoritative run outcomes.
-7. At least two credible solutions exist for the reference challenge, creating a meaningful capacity/layout/cost trade-off.
-8. Scoring rewards contract success, deadline performance, and capital efficiency without obscuring why one design performed better.
-
-The consumer-readiness gates, ownership rules, integration acceptance criteria, and explicit non-goals for implementing this slice are defined in [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), not duplicated here.
-
-## 7. Documentation boundary
-
-This document owns only the concrete product hypothesis: player fantasy, loop, decisions, reference challenge, player-facing evidence, and product success criteria.
-
-[Factory-Design Game Consumer Initiative](factory-design-game-consumer.md) owns the Arcogine/game responsibility boundary, upstream readiness dependencies, implementation entry criteria, integration acceptance criteria, and non-goals. [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md) owns the runtime gates themselves. [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) owns the accepted PLAN-ENG-W1 decomposition and work-item identity contract.
-
-Detailed art direction, content expansion, campaign design, and distribution planning should remain outside Arcogine until the vertical slice provides evidence that those investments are justified.
+Until then this file intentionally contains no reference level parameters, scoring formula, UI technology choice, tutorial sequence, or other product hypothesis.

--- a/docs/planning/factory-simulation-engine-readiness.md
+++ b/docs/planning/factory-simulation-engine-readiness.md
@@ -1,844 +1,179 @@
-# Factory Simulation Engine Readiness
+# Factory Simulation Engine Readiness Implementation Plan
 
-> **Status:** Proposed  
-> **Scope:** Prepare Arcogine's factory runtime for external consumers after the canonical factory-model boundary is established  
-> **Authority:** Planning only; this document defines runtime-readiness gates, not current capability or accepted architecture  
-> **Prerequisite:** the model-seam entry gate (§1.1) — narrower than full PLAN-FD-1 to PLAN-FD-4 in [Factory Design Capability](factory-design-capability.md)  
-> **Related:** [Factory Design Architecture](../architecture/factory-design.md), [ADR-0003](../architecture/decisions/0003-canonical-factory-model-boundary.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md), [ADR-0009](../architecture/decisions/0009-deterministic-dispatch-closure-and-work-decomposition-boundary.md), [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md), [ADR-0011](../architecture/decisions/0011-runtime-observation-and-event-contract.md), [ADR-0014](../architecture/decisions/0014-factory-model-semantic-policy-evolution.md), [ADR-0015](../architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md), [Engine Semantics v1](../architecture/engine-semantics-v1.md), [PLAN-ENG-4 Runtime Observation and Event Delivery](runtime-observation-event-delivery.md), [PLAN-ENG-5 Spatial Runtime Consequences](spatial-runtime-consequences.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Factory-Design Game Consumer Initiative](factory-design-game-consumer.md), [ISA-95 Semantic Mapping](../architecture/isa-95-semantic-mapping.md), [Architecture Overview](../architecture/overview.md)
+> **Status:** Active; workload/dispatch/session/work-decomposition and core observation/event semantics are complete, while outward consumer convergence and spatial runtime consequences remain admitted work  
+> **Scope:** Implementation-ready work required to make Arcogine's deterministic factory runtime usable through stable consumer contracts  
+> **Authority:** Planning only; result-affecting future policy questions live in research  
+> **Related:** [Factory Design Capability](factory-design-capability.md), [ADR-0007](../architecture/decisions/0007-consumer-neutral-session-control-primitives.md), [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md), [ADR-0011](../architecture/decisions/0011-runtime-observation-and-event-contract.md), [ADR-0015](../architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md), [Runtime Observation/Event Delivery](runtime-observation-event-delivery.md), [Spatial Runtime Consequences](spatial-runtime-consequences.md), [Engine Evolution Research](../research/engine-evolution.md)
 
-## 1. Purpose
+## 1. Runtime boundary
 
-Arcogine should become a consumer-ready deterministic production runtime before a factory-design game is used as an integration client.
-
-This plan begins **after** Arcogine can validate, publish, and instantiate an immutable canonical factory model. It does not own the factory-design schema, publication lifecycle, or consumer draft model.
-
-The intended dependency is:
+The runtime consumes one published factory model and owns deterministic execution consequences:
 
 ```text
-Model-seam entry gate (below)
-        |
-        v
 Published FactoryModelVersion
         |
         v
-Factory runtime readiness
+FactoryRuntime
         |
-        v
-Headless capacity/layout acceptance scenarios
-        |
-        v
-Stable external-consumer contract
-        |
-        v
-Factory-design game implementation
+        +--> explicit workload
+        +--> child work items
+        +--> deterministic resource selection
+        +--> queues / processing / transfers
+        +--> bounded advancement
+        +--> supported observations/events
 ```
 
-The game is a downstream proof that Arcogine is usable as an engine. It must not be the place where missing workload, execution, scheduling, session, observation, or transfer semantics are invented under UI pressure.
+The runtime does not author Factory semantics, Governance history, game scoring, or production-control trust/reconciliation semantics.
 
-A CLI command, JUnit harness, or thin reference consumer may prove a readiness gate. That is engine verification, not game implementation.
+## 2. Current landed baseline
 
-### 1.1 Model-seam entry gate
+The following Engine capability is complete and must not be reopened by adjacent work:
 
-Runtime readiness does not wait on the full [Factory Design Capability](factory-design-capability.md) plan — several of PLAN-FD-1 to PLAN-FD-4's own acceptance criteria are deliberately deferred capability (see that plan's §3.1 implementation-status table), not blockers for engine work. The entry requirement for PLAN-ENG-1 is narrower:
+### PLAN-ENG-1 — Explicit workload and execution
+
+- immutable `Order` intent is separate from mutable execution;
+- workload can be submitted without economy/demand/agents;
+- quantity consumes proportional production work;
+- economy-driven and explicit submission share the same authoritative acceptance path.
+
+### PLAN-ENG-2 — Deterministic resource dispatch
+
+- explicit eligible resource instances define current eligibility;
+- operational availability/queue state remain distinct from eligibility;
+- deterministic ranking/tie-breaking is fixed by current Engine semantics;
+- equivalent compatible resources can execute independent work.
+
+### PLAN-ENG-3 — Consumer-neutral simulation session
+
+- runtime owns its scheduler/session state;
+- bounded advancement/reset semantics are consumer-neutral;
+- callers do not inject authoritative simulated time or scheduler ownership.
+
+### PLAN-ENG-W1 — Intra-order work decomposition
+
+ADR-0010 is implemented:
+
+- one quantity-bearing accepted `Order` remains aggregate intent/correlation;
+- quantity creates deterministic unit-quantity sibling `Job`s;
+- `JobId` is independently dispatchable work-item identity;
+- aggregate progress/completion remains order-level;
+- exactly one aggregate completion fact is emitted;
+- the supported 100,000-child ceiling has executable benchmark evidence.
+
+### PLAN-ENG-4-A/B/C — Supported observation/event core
+
+The consumer-neutral runtime now provides:
+
+- opaque per-run `RunId` correlation;
+- durable source `ModelFingerprint` provenance;
+- supported current-state observation;
+- ordered supported runtime events distinct from internal scheduler `Event`s;
+- post-authoritative event publication;
+- stable order/work correlation;
+- a fresh observation sufficient to reconstruct supported consumer state without replay.
+
+## 3. Current implementation queue
+
+Only the following Engine work is currently admitted.
+
+### PLAN-ENG-4-D — Outward consumer convergence
+
+Use [Runtime Observation/Event Delivery](runtime-observation-event-delivery.md) as the detailed implementation companion.
+
+Required outcome:
+
+- legacy API/SSE projects supported runtime semantics rather than internal scheduler events;
+- outward DTOs remain projections and never re-enter domain decision paths;
+- frontend consumption follows the supported envelope/observation boundary;
+- CLI/reference/headless paths either consume the supported runtime contract directly or document a deliberate broader orchestration adapter;
+- current-state API/reference documentation changes only with shipped behavior.
+
+The API/SSE and CLI/reference changes may land separately when that keeps reviews narrow.
+
+### PLAN-ENG-5 — Spatial runtime consequences
+
+Use [Spatial Runtime Consequences](spatial-runtime-consequences.md) as the detailed implementation plan. ADR-0014, ADR-0015, Factory Model v2 canonicalization, and Engine Semantics v1 define the accepted contract.
+
+The admitted sequence includes:
+
+1. pin pre-existing result-affecting Engine semantics and required arithmetic corrections;
+2. implement Factory Model v2 spatial facts/validation and canonical identity;
+3. establish `EngineSemanticsVersion` and propagate required runtime provenance;
+4. implement deterministic transfer arithmetic and inbound admission reservation;
+5. activate coherent transfer state/events/observations;
+6. close availability/no-rerouting edge semantics and late-join diagnostics; and
+7. complete V1/V2 historical coexistence before final closure.
+
+No pathfinding, conveyor graph, transport-resource scheduling, congestion, rerouting, or orientation is part of this admitted work.
+
+## 4. Dependency order
 
 ```text
-Required before engine PLAN-ENG-1:
-- canonical FactoryModel seam exists
-- deterministic structural validation exists
-- immutable publication exists
-- a model provenance identity policy exists
-- runtime instantiates only from the published model
-- representative baseline behavior is preserved
+completed model seam
+    |
+    v
+PLAN-ENG-1 complete
+    |
+PLAN-ENG-2 complete
+    |
+PLAN-ENG-3 complete
+    |
+PLAN-ENG-W1 complete
+    |
+PLAN-ENG-4 A/B/C complete
+    |\
+    | +--> PLAN-ENG-4-D outward convergence
+    |
+    +----> PLAN-ENG-5 spatial consequences
 ```
 
-This gate is satisfied by what had already landed when PLAN-ENG-1 began. Historically, PLAN-ENG-1 did **not** depend on the then-unimplemented PLAN-FD-3 durable cross-process fingerprint contract; that historical sequencing remains valid and PLAN-ENG-1 is not retroactively reopened. Since then, PLAN-FD-3/PLAN-GOV-1-1 has landed: [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md) and `FactoryModelVersion.fingerprint()` establish the durable `factory-model:v1` semantic identity contract. `FactoryModelVersion.contentHash()` remains legacy compatibility only and must not be treated as the durable provenance identity. PLAN-ENG-4 therefore uses the durable `ModelFingerprint` as mandatory source-model provenance under [ADR-0011](../architecture/decisions/0011-runtime-observation-and-event-contract.md). Run identity and ordered runtime-event provenance are PLAN-ENG-4 concerns; optional controlled-revision provenance is carried only when authoritatively supplied and does not make Governance PLAN-GOV-1-3 persistence a prerequisite for Engine readiness.
+PLAN-ENG-4 core closure no longer blocks spatial work. Outward convergence should consume settled provenance from the spatial/Engine-semantics work where the detailed delivery plans require it rather than migrating an envelope that is immediately revised.
 
-## 2. Boundary with factory design and operational execution
+## 5. Determinism and provenance invariants
 
-The [Factory Design Capability](factory-design-capability.md) owns model-side concerns:
+For identical explicit inputs, deterministic simulation semantics are scoped to:
 
-```text
-Product/operation definitions
-Resource definitions and installed instances
-Capability or explicit eligibility requirements
-Semantic layout
-Executability validation
-Publication/model identity/provenance
-Deterministic instantiation boundary
-```
+- the same published semantic model;
+- the same `EngineSemanticsVersion`;
+- the same workload/commands;
+- the same seed/random inputs; and
+- any other explicit result-affecting input introduced by accepted semantics.
 
-This plan owns deterministic simulation-runtime concerns:
+`RunId` is correlation only and must not affect outcomes. `ControlledRevisionId` is optional provenance only when the runtime has an authoritative upstream revision binding; Engine never synthesizes one.
 
-```text
-Production orders
-Work items
-Quantity execution semantics
-Resource dispatch
-Queues and assignments
-Active operations
-Transfers in progress
-Simulation runtime events/observations
-Performance
-Simulation session control
-```
+Internal scheduler events, supported runtime events, model revision history, Governance evidence/decision history, challenge attempt history, and future Operational command/observation history remain distinct histories.
 
-Where a concern crosses the model/runtime boundary, the published model owns stable authored input semantics and runtime owns changing simulated consequences. PLAN-ENG-5 sharpens that split further:
+## 6. Distribution hardening
 
-```text
-Factory model v2
-    floor dimensions
-    resource position + anchored footprint
-    ticksPerCell
-    handlingTicks
+Recovery/versioning/checkpoint/packaging work is not a core blocker for spatial implementation. It may be admitted after the supported outward contract is stable and its concrete compatibility requirements are selected.
 
-Engine semantics
-    how Arcogine interprets those facts
-    including distance, destination binding, admission reservation,
-    transfer timing and availability/no-rerouting rules
+The currently established recovery invariant is:
 
-Runtime
-    transfer start / in-flight / completion
-    supported observations/events
-```
+- supported event sequence is monotonic within a run;
+- a fresh observation is authoritative current state;
+- silent history truncation must never be reported as successful resume;
+- exact checkpoint/restore, when implemented, must preserve the source model, Engine semantics, simulated time, runtime state, scheduler/random state, and event position required for exact continuation.
 
-`ModelFingerprint` identifies the authored design; [ADR-0015](../architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md) separately identifies the result-affecting Engine interpretation with `EngineSemanticsVersion`. Runtime may derive indexes or compiled structures from the published model, but it does not author another factory model and never mutates the published version.
+Candidate extensions whose contract is not yet selected remain in [Engine Evolution Research](../research/engine-evolution.md).
 
-The sibling [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md) track consumes stabilized production semantics later and owns the additional boundary created by real-world consequence. This plan therefore does **not** own:
+## 7. Research boundary
 
-- production execution-context identity or environment separation;
-- verified operational actor/source/target trust and authorization;
-- external-device command acknowledgement/result lifecycles;
-- production deployment targeting/application or applied-artifact provenance;
-- telemetry/external-observation ingestion and source provenance;
-- modeled-versus-observed twin reconciliation;
-- fail-safe physical actuation, credential lifecycle, or live-adapter recovery semantics.
+The following are not implementation items in this plan:
 
-`FactoryRuntime` is a consumer-neutral **simulation runtime**, not a production-control runtime by implication. An Operational Execution prototype may use Engine-owned semantics or synthetic fixtures while this plan is incomplete, but a synthetic operational adapter is not evidence that an Engine gate is complete, and protocol-driven operational types must not become a second production ontology.
+- lot/batch/material-lot semantics;
+- generalized capability requirements or resource pools/work centers;
+- dispatch policy evolution beyond the accepted current Engine semantics;
+- new advancement/session semantics without a concrete consumer failure case; and
+- unselected transport/recovery technology or protocol choices.
 
-## 3. Charter and architecture alignment
+Do not add delivery coordinates for these questions until research produces a concrete semantic contract and deterministic acceptance evidence.
 
-This initiative supports the [Product Charter](../product/charter.md) by strengthening one executable model across design, simulation, verification, and future execution contexts.
+## 8. Validation policy
 
-It follows these constraints:
+Each admitted slice must:
 
-- Arcogine owns executable production semantics; consumers receive controlled commands, events, and purpose-specific observations.
-- Mutable runtime state has one authoritative owner.
-- Request, execution, and performance concerns remain distinguishable.
-- Deterministic/reproducible simulation outcome is scoped to the same published model, `EngineSemanticsVersion`, explicit workload, seed/random inputs, and ordered external commands; additional explicit inputs join that tuple when they can affect outcome.
-- `RunId` is correlation identity and must not influence simulation outcomes.
-- Runtime contracts are established before transport-specific API shapes become public compatibility obligations.
-- The [ISA-95 semantic mapping](../architecture/isa-95-semantic-mapping.md) is a modeling reference, not a requirement for full ISA-95 implementation or conformance.
-- Game-specific scoring, rendering, progression, and player-economy concepts do not enter runtime semantics.
-- Operational trust, deployment, external-observation, and reconciliation semantics remain outside this simulation-readiness track.
-
-## 4. Readiness policy
-
-Game implementation begins only after the design prerequisite, PLAN-ENG-1 to PLAN-ENG-5, and the currently activated PLAN-ENG-W1 capability below are satisfied by headless evidence.
-
-```text
-Prerequisite  Model-seam entry gate satisfied (§1.1) — not full Design PLAN-FD-1 to PLAN-FD-4
-        ↓
-PLAN-ENG-1        Explicit workload and execution model
-        ↓
-PLAN-ENG-2        Capability-based deterministic dispatch
-        ↓
-PLAN-ENG-3        Consumer-neutral simulation session
-        ↓
-PLAN-ENG-W1            Intra-order execution decomposition
-        ↓
-PLAN-ENG-4        Stable observations and event envelopes
-        ↓
-PLAN-ENG-5        Spatial runtime consequences
-        ↓
-Game consumer may begin
-```
-
-The current fixed-quantity factory-design reference challenge made **PLAN-ENG-W1 — intra-order execution decomposition** active. ADR-0009 records why PLAN-ENG-W1 is separate from PLAN-ENG-2 dispatch; [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) records the accepted PLAN-ENG-W1 architecture. PLAN-ENG-W1 is complete: one accepted quantity-`N` `Order` decomposes deterministically into `N` independently dispatchable unit-quantity `Job`s, `JobId` is the work-item identity, aggregate progress/completion remains order-level, and exactly one order completion is emitted. `LargeOrderDecompositionBenchmarkTest` supplies the required executable evidence at the supported 100,000-child materialization ceiling, including deterministic replay and diagnostic memory/execution measurements. PLAN-ENG-4 core/headless closure has since landed on top of that (§8). PLAN-ENG-2 remains complete for dispatch of independently dispatchable work.
-
-Distribution hardening follows the core gates. A first UI experiment may begin after these gates; a distributable client additionally requires the contract, recovery, persistence, and packaging work in Section 11.
-
-## 5. PLAN-ENG-1 — Explicit production workload and execution model
-
-### 5.1 Goal
-
-Separate immutable production intent from mutable execution and make factory workload independent of the economy demand loop.
-
-The published factory model supplies product and operation definitions. Runtime introduces workload and execution concepts equivalent to:
-
-```text
-Production order
-    immutable workload intent
-    product, quantity, release time
-
-Work item
-    mutable execution state
-    parent order
-    current operation
-    assignment
-    timing/status
-
-Performance observation
-    what actually happened
-```
-
-These are conceptual responsibilities, not accepted Java type names.
-
-### 5.2 Current state and remaining problem
-
-The first behavior-preserving PLAN-ENG-1 slice separated accepted order intent from mutable execution:
-
-```text
-Order (immutable)
-    OrderId
-    product
-    quantity
-    createdAt
-    unitPrice
-        |
-        v
-Job (mutable execution)
-    JobId
-    referenced immutable Order
-    current step
-    assignment
-    timing/status
-```
-
-`FactoryHandler` persists an immutable `Order` before creating execution work; `Job` no longer owns product, quantity, or price fields. Existing `JobView` product/price/value getters remain compatibility projections delegated to the referenced order, while each PLAN-ENG-W1 child projects `quantity() == 1` because it represents one execution unit.
-
-The second PLAN-ENG-1 slice added an explicit, consumer-neutral workload-submission entry point: `FactoryRuntime.submitWorkload(productId, quantity, unitPrice)`. `FactoryRuntime` wraps a `FactoryHandler` together with a `Scheduler` it owns internally, so a caller supplies only product/quantity/commercial intent -- never a mutable `Scheduler` or an authoritative simulation time, which stayed internal event-engine plumbing rather than becoming part of the workload boundary. Both `FactoryRuntime.submitWorkload` and the economy-driven `OrderCreation` event resolve to the same package-private `FactoryHandler.submitOrder(productId, quantity, unitPrice, currentTime, scheduler)` acceptance operation -- `FactoryHandler.handleEvent` delegates to it for that event rather than duplicating the logic, and it is not exposed outside the `factory.process` package. `FactoryHandler` already had no compile-time dependency on economy/pricing/demand/agents; this slice makes explicit submission a supported, named entry point instead of something only reachable by hand-constructing an internal event payload and owning a `Scheduler`. `FactoryRuntime` is only constructed from a published model, via `FactoryRuntime.forModel(FactoryModelVersion)` (internally using `FactoryRuntimeAssembler`) -- never wrapped around an already-live `FactoryHandler` some other scheduler might also be driving, so it always owns the exclusive factory/scheduler pair it advances and event ordering stays globally authoritative. It also does not expose the mutable `FactoryHandler` directly; callers observe state through `FactoryRuntime`'s own read-only projections (`ordersView`, `jobsView`, `job`, `machinesView`, `backlog`, `avgLeadTime`, `throughput`, `completedSalesValue`, `completedSales`). A headless test (`ExplicitWorkloadSubmissionTest`) builds a runtime this way and submits workload directly, with no `DemandModel`, `PricingState`, or agent in the loop, and proves repeated identical submissions are deterministic. `FactoryRuntime.advance()` pumps exactly one pending event at a time so a headless caller can drive submitted workload to completion without reaching into scheduler internals; this is deliberately not a general session/advancement API -- PLAN-ENG-3 later completed that broader contract. Economy-driven scenarios continue to work unchanged: `DemandModel.generateOrders` still schedules `OrderCreation` events, which route through the same `submitOrder` logic.
-
-The third PLAN-ENG-1 slice made order quantity consume proportional production work using a historical pre-PLAN-ENG-W1 representation: one `Job` repeated its routing once per unit of quantity, with `routing.stepCount() * quantity` total steps and job-global progress mapped back to routing-local steps. That representation established proportional machine-occupied work and deterministic quantity semantics without yet decomposing an order into independent execution objects. It is retained here as PLAN-ENG-1 baseline history only; it is no longer the current runtime representation and must not be used as current PLAN-ENG-W1 guidance.
-
-PLAN-ENG-W1 replaced that historical one-`Order`/one-`Job` representation with the accepted ADR-0010 shape, now implemented:
-
-```text
-Order (immutable intent, OrderId)
-        |
-        v
-order-level execution aggregate (same OrderId)
-        |
-        +---- Job ordinal 0, executionQuantity 1
-        +---- Job ordinal 1, executionQuantity 1
-        +---- ...
-        +---- Job ordinal N-1, executionQuantity 1
-```
-
-`JobId` is the independently dispatchable work-item identity; each child traverses the routing exactly once; child creation/ID allocation/initial dispatch are deterministic in ordinal order; aggregate `releasedQuantity` and `completedQuantity` are order-level; backlog/completed-sales/lead-time remain order-level measures; and the final child completion emits exactly one `OrderCompleted` carrying explicit `OrderId` plus the completing child `JobId`.
-
-The current `OrderCompleted` payload therefore carries explicit `orderId` together with the completing child `jobId`, as required by ADR-0010. PLAN-ENG-4 remains responsible for the later stable event-envelope contract, not for deciding PLAN-ENG-W1's basic execution identities.
-
-The canonical-model seam is already complete enough for this runtime work, so definition-model changes do not need to be mixed into PLAN-ENG-W1.
-
-### 5.3 Required behavior
-
-Arcogine must support explicit production workload independently of pricing, stochastic demand, and sales agents.
-
-Order intent remains immutable after acceptance. Execution progress belongs to work items or an equivalent execution aggregate. Completion/performance is derived from executed work rather than by mutating the original request into a result record.
-
-The economy subsystem may remain one source of production orders, but the factory runtime must not depend on it as the only source.
-
-### 5.4 Acceptance criteria
-
-PLAN-ENG-1 is satisfied when:
-
-1. Runtime instantiates from a published factory model containing the relevant product/operation definitions.
-2. A caller can submit or preload an explicit production order without enabling pricing, stochastic demand, or agents.
-3. An order for 10 units consumes more production work than an otherwise identical order for 1 unit.
-4. Immutable order intent is distinct from mutable work execution state.
-5. Multiple work items can report progress against one production order when the selected quantity model requires it.
-6. Order completion is derived from executed work and exposed through a supported observation.
-7. The same model version, seed, and workload produce the same ordered result.
-8. Existing economy-driven scenario behavior remains covered or is migrated deliberately.
-
-**PLAN-ENG-1 is complete.** All eight criteria have executable evidence. Historical PLAN-ENG-1 tests document the pre-PLAN-ENG-W1 proportional-work baseline; current PLAN-ENG-W1 acceptance evidence documents the implemented child-job representation and supersedes that historical representation as current runtime semantics:
-
-1. **Runtime instantiates from a published model.** `FactoryRuntime.forModel(FactoryModelVersion)` is the only constructor; there is no path to a `FactoryRuntime` that was not built from a published model. Proven by every test in `EngineReadinessAcceptanceTest`, `ExplicitWorkloadSubmissionTest`, and current PLAN-ENG-W1 acceptance coverage.
-2. **Explicit submission without economy/demand/agents.** `FactoryRuntime.submitWorkload(productId, quantity, unitPrice)` requires no `DemandModel`, `PricingState`, or agent. Proven by `ExplicitWorkloadSubmissionTest` and `EngineReadinessAcceptanceTest.modelAndRuntimeBoundary`.
-3. **Quantity consumes proportional production work.** Historical PLAN-ENG-1 evidence established proportional work in the one-job representation; PLAN-ENG-W1 preserves proportional work by materializing one unit-quantity child per requested unit, each traversing the routing once.
-4. **Immutable order intent vs. mutable execution state.** The `Order`/`Job` split is established: `Order` is immutable; PLAN-ENG-W1 materializes several mutable sibling `Job`s under one order-level aggregate.
-5. **Work-item progress is represented.** Current runtime exposes independently progressing child jobs with stable per-order ordinals and aggregate released/completed quantities.
-6. **Completion derived from executed work.** Exactly one aggregate order completion occurs only after the final child completes.
-7. **Determinism.** PLAN-ENG-W1 acceptance evidence covers deterministic child ordinals, `JobId` allocation, initial dispatch, assignments, ordered events, and aggregate terminal state.
-8. **Economy-driven workload shares the same accepted-order path.** Both economy-driven `OrderCreation` and explicit submission converge on the same acceptance/decomposition semantics.
-
-## 6. PLAN-ENG-2 — Capability-based deterministic dispatch
-
-### 6.1 Goal
-
-Use the published model's resource definitions, installed instances, and operation eligibility/capability semantics to select runtime capacity deterministically.
-
-The model side owns facts equivalent to:
-
-```text
-Resource definition
-    capabilities / nominal processing properties
-
-Resource instance
-    installed identity and definition
-
-Operation requirement
-    capability or explicit eligible-resource semantics
-```
-
-Runtime owns:
-
-```text
-resource availability
-queue state
-active work
-assignment
-dispatch decision
-```
-
-### 6.2 Current problem (resolved)
-
-A routing step used to point to one concrete `MachineId`, so a second equivalent machine could not naturally participate in the route -- even though `OperationStepDefinition.eligibleResources` was already `Set<MachineId>`, `FactoryModelValidator` rejected any step naming more than one, and `FactoryRuntimeAssembler`/`RoutingStep` collapsed to a single machine.
-
-PLAN-ENG-2 removed that restriction: `RoutingStep` now carries `Set<MachineId> eligibleMachines`, and `FactoryHandler` selects among them deterministically at dispatch time. See ADR-0005 for the original dispatch decision; [ADR-0009](../architecture/decisions/0009-deterministic-dispatch-closure-and-work-decomposition-boundary.md) supersedes its slice-scoping conclusion and records the dispatch-vs-decomposition boundary.
-
-### 6.3 Deterministic dispatch
-
-`engine-semantics:v1` records the actually shipped selector and recovery behavior that PLAN-ENG-5 must preserve:
-
-1. start from the step's explicit eligible-resource set;
-2. filter out `Offline` resources while at least one eligible resource is online; if all eligible resources are offline, use the full eligible set as the deterministic candidate set;
-3. rank candidates first by whether `Machine.canAcceptJob()` is true — this is a ranking key, not an eligibility filter;
-4. then rank by `combinedQueueDepth`, consisting of the machine's physical queue plus compatible `pendingMultiEligible` entries;
-5. break remaining ties by lowest `MachineId`;
-6. after selection, dispatch immediately only if the selected machine can accept the job; otherwise route the job to the existing single-machine queue or `pendingMultiEligible` waiting path;
-7. after a completion/recovery transition, drain the relevant per-machine queue before reconsidering `pendingMultiEligible` work.
-
-Projected-completion-time ranking, resource pools, and capability taxonomies remain deliberately deferred. Any change that can alter assignments/outcomes for identical explicit inputs requires a new `EngineSemanticsVersion`, not a silent reinterpretation of `engine-semantics:v1`.
-
-PLAN-ENG-2 is about **dispatch**, not work decomposition: the runtime selects a resource for an independently dispatchable unit of work that already exists. ADR-0010 defines how PLAN-ENG-W1 creates those units within one accepted quantity-scaled order: deterministic unit-quantity sibling `Job`s identified by `JobId`. That decision does not change PLAN-ENG-2's selector or `pendingMultiEligible` semantics.
-
-### 6.4 Acceptance criteria
-
-PLAN-ENG-2 is satisfied when:
-
-1. Runtime consumes model-side resource definitions and installed instances rather than redefining them. **Satisfied** (unchanged by this slice -- `FactoryRuntimeAssembler` builds `Machine`s directly from `ResourceDefinition`).
-2. Two equivalent eligible resource instances can both execute the same operation. **Satisfied** -- proved at both the `FactoryHandler` seam (`MultiResourceDispatchTest`) and end to end through the published-model boundary (`MultiResourceDispatchAcceptanceTest`, driven entirely through `FactoryRuntime`).
-3. Both resources are used when workload justifies parallel capacity. **Satisfied** for sufficient independently dispatchable work: `MultiResourceDispatchAcceptanceTest.publishedMultiEligibleModelSurvivesAssemblyAndDispatchesBothOrdersConcurrently` proves two independent orders occupy both eligible machines at once, through `FactoryRuntime` alone. PLAN-ENG-2 does not require one quantity-scaled order to be decomposed; ADR-0010/PLAN-ENG-W1 provides that separate capability.
-4. Equal candidates resolve reproducibly through a stable tie-break rule. **Satisfied** -- `MultiResourceDispatchTest.equalCandidatesResolveDeterministicallyToTheLowestMachineId` and `MultiResourceDispatchAcceptanceTest.identicalWorkloadFromTwoFreshRuntimesResolvesToTheSameMachineAssignments`.
-5. Adding a second compatible resource changes queueing, utilization, throughput, or completion time in an appropriate workload. **Satisfied** under concurrent independent orders. PLAN-ENG-W1 separately proves the same capacity can affect sibling jobs from one order.
-6. Removing/disabling one instance does not require changing the product definition. **Satisfied**, including machine recovery and cross-machine pending-work reconsideration.
-7. Resource capability, operational status, and queue state remain distinct concepts. **Satisfied** -- `OperationStepDefinition.eligibleResources`, `MachineState`, per-machine queue state, and `pendingMultiEligible` remain separate concepts.
-
-**PLAN-ENG-2 is complete.** Intra-order parallelism is not an unfinished PLAN-ENG-2 condition; it is the separately accepted and functionally implemented PLAN-ENG-W1 execution-decomposition contract in ADR-0010. Also deferred unless a concrete need arises: load-aware ranking beyond the recorded v1 policy and resource pools/capability taxonomies.
-
-## 7. PLAN-ENG-3 — Consumer-neutral simulation session
-
-### 7.1 Goal
-
-Provide transport-independent runtime-control semantics before treating HTTP, SSE, CLI, or an embedded Java adapter as a stable external contract.
-
-Conceptually, a session needs operations equivalent to:
-
-```text
-instantiate/load published model atomically
-submit workload/command and receive accepted/rejected result
-advance one event
-advance until target simulation time
-advance with maximum event bound
-observe current runtime state
-read produced events
-reset deterministically
-```
-
-Model validation/publication belongs upstream. The session may verify that the supplied published model/version is usable, but it should not become a second model-authoring API.
-
-### 7.2 Required command semantics
-
-Every externally initiated runtime change returns a definite result containing at least:
-
-- accepted/rejected status;
-- stable result/rejection code;
-- understandable diagnostic;
-- affected entity identifiers when applicable;
-- session/model provenance;
-- events produced by the accepted command, or a cursor identifying them.
-
-A rejected runtime command must not leave partial mutation.
-
-PLAN-ENG-W1 preserves this contract. In particular, rejected workload submission must leave no partial `Order`, order-level execution aggregate, child `Job`, machine assignment/queue mutation, `pendingMultiEligible` entry, or command-produced event.
-
-### 7.3 Bounded advancement
-
-Interactive consumers control presentation speed by requesting bounded simulated progress. Wall-clock sleeping and rendering cadence remain outside the simulation core.
-
-The session should support enough bounded advancement for:
-
-- event stepping;
-- pause/resume presentation semantics;
-- normal and accelerated presentation speeds;
-- deterministic headless runs;
-- protection against unbounded work monopolizing a caller.
-
-### 7.4 Acceptance criteria
-
-PLAN-ENG-3 is satisfied when a non-graphical reference consumer can:
-
-1. instantiate a published factory model version;
-2. submit explicit production workload and receive structured results;
-3. advance exactly one event;
-4. advance to a selected simulated time with a maximum event bound;
-5. inspect order, work-item, queue, and resource state;
-6. reset and reproduce the same result;
-7. identify the source model version throughout the session;
-8. operate without Spring controllers, frontend DTOs, or mutable domain internals.
-
-**PLAN-ENG-3 is complete.** All eight criteria have identified executable evidence through `FactoryRuntime`; see [ADR-0007](../architecture/decisions/0007-consumer-neutral-session-control-primitives.md). PLAN-ENG-W1 preserves those session semantics while changing the work-item representation.
-
-With PLAN-ENG-3 closed, **PLAN-ENG-W1 is complete (§14.1)**. Its fixed-contract acceptance evidence and required large-order performance/memory benchmark are executable. PLAN-ENG-4 has since stabilized its observation/event contract around PLAN-ENG-W1's `OrderId`/`JobId` identities and aggregate progress semantics, with the supported-envelope evidence executable (§8).
-
-## 8. PLAN-ENG-4 — Stable observations and event envelopes
-
-### 8.1 Goal
-
-Expose enough supported runtime information for a consumer to understand the simulation without reaching into internal stores or reconstructing authoritative state from undocumented events.
-
-[ADR-0011](../architecture/decisions/0011-runtime-observation-and-event-contract.md) is the accepted architecture for PLAN-ENG-4 semantics. The focused [PLAN-ENG-4 Runtime Observation and Event Delivery](runtime-observation-event-delivery.md) plan owns implementation slicing and evidence sequencing. Internal scheduler `Event`/`EventType`/`EventPayload` remain transition machinery rather than the supported external compatibility contract; supported runtime events describe authoritative changes after processing, and a fresh observation remains sufficient to reconstruct current consumer state without full event replay.
-
-Slices PLAN-ENG-4-A (headless run identity and supported observation projection), PLAN-ENG-4-B (supported `RuntimeEventEnvelope`/`RuntimeEventType`/`RuntimeEventPayload`/`AffectedEntityRef` contract, post-authoritative publication, run-scoped monotonic sequencing), and PLAN-ENG-4-C (full headless acceptance closure) are implemented; see the "Implemented evidence" notes under those slices in the focused PLAN-ENG-4 plan for exact contracts, derivation points, and tests. **PLAN-ENG-4 core/headless closure is complete**. PLAN-ENG-4-D (outward SSE/API/CLI/frontend consumer convergence) remains outstanding downstream migration work, and recovery/resynchronization hardening (PLAN-ENG-DH-E) remains distribution hardening; neither blocks PLAN-ENG-5. Prefer landing PLAN-ENG-5 B2's final `EngineSemanticsVersion` provenance shape before PLAN-ENG-4-D so the outward contract is not migrated twice.
-
-### 8.2 Minimum observation
-
-The consumer-neutral observation should contain, directly or through purpose-specific projections:
-
-```text
-Session
-    session/run ID
-    model fingerprint
-    controlled revision ID [optional when authoritatively bound]
-    engine semantics version [required by ADR-0015 when PLAN-ENG-5-B2 lands]
-    current simulated time
-    run state
-    latest event sequence
-
-Resources
-    instance ID
-    definition ID
-    operational status
-    queue depth
-    active work
-    current operation
-    expected completion time where available
-
-Orders
-    requested quantity
-    released quantity
-    completed quantity
-    status
-
-Work items
-    JobId
-    parent OrderId
-    ordinal within order
-    execution quantity
-    current operation
-    assignment
-    execution state
-    start/end timing
-
-Performance
-    throughput
-    lead time
-    work in process/backlog
-    utilization
-```
-
-The minimum order/work-item split above follows ADR-0010. PLAN-ENG-4 may choose purpose-specific projection types and envelope structure, but it must not collapse aggregate order progress back into one child job or reinterpret `JobId` as an order identity.
-
-### 8.3 Event envelope
-
-Every externally visible supported runtime event has an envelope equivalent to:
-
-```text
-run/session ID
-sequence
-simulation time
-semantic event type
-model fingerprint
-engine semantics version [required by ADR-0015 when PLAN-ENG-5-B2 lands]
-controlled revision ID [optional when authoritatively bound]
-affected entity references
-payload
-```
-
-The sequence is strictly monotonic within one run/session epoch and makes order explicit independently of event timestamps. A reset creates a new run identity and sequence epoch; run identity is correlation metadata and must not influence deterministic simulation outcomes.
-
-ADR-0010 already requires PLAN-ENG-W1's aggregate completion payload to include explicit `OrderId` while retaining the completing child `JobId`. PLAN-ENG-4 preserves that correlation. `ModelFingerprint` is mandatory source-model provenance under ADR-0006/ADR-0011. `ControlledRevisionId` is optional and present only when the runtime was instantiated with an authoritative revision binding. ADR-0015 adds mandatory Engine interpretation provenance; PLAN-ENG-5-B2 implements that additive field without rewriting ADR-0011.
-
-These are **simulation-runtime** events and observations. A future Operational Execution adapter may translate relevant production semantics into its own command/result and external-observation contracts, but PLAN-ENG-4 does not define production telemetry envelopes, external source authenticity, or digital-twin reconciliation.
-
-### 8.4 Acceptance criteria
-
-PLAN-ENG-4 is satisfied when:
-
-1. Every externally visible runtime entity has a stable identifier within the session semantics that own it.
-2. Observation state and emitted events agree about the same authoritative transition history.
-3. Event ordering is explicit and reproducible.
-4. A consumer can identify the active bottleneck using supported observations rather than internal stores.
-5. Requested, assigned, started, completed, and reported states are distinguishable.
-6. Runtime observations and supported runtime events carry the durable source `ModelFingerprint`; a controlled revision ID is carried only when authoritatively bound.
-7. API/UI DTOs remain outward projections and are not reused as domain decision inputs.
-8. A fresh observation can reconstruct current view state without replaying the entire history.
-9. Successful state-change runtime events are published only after the relevant authoritative processing succeeds; rejected changes do not produce successful state-change events.
-10. Supported event sequence is strictly monotonic within a run/session and independent of simulation timestamp; same-time events remain explicitly ordered.
-11. PLAN-ENG-W1 runtime events preserve `OrderId`/child `JobId` correlation where work-item changes belong to an aggregate order.
-12. Reset creates a new run identity/sequence epoch without changing deterministic semantic outcomes for otherwise identical inputs.
-
-ADR-0015 adds one provenance requirement to the supported PLAN-ENG-4 shapes; implementing that addition is PLAN-ENG-5 B2 work and does not reopen the already-complete PLAN-ENG-4 headless behavior.
-
-## 9. PLAN-ENG-5 — Spatial runtime consequences
-
-### 9.1 Goal and accepted architecture
-
-Apply deterministic production consequences to semantic layout supplied by the published factory model.
-
-The hard-to-reverse architecture is now resolved by [ADR-0014](../architecture/decisions/0014-factory-model-semantic-policy-evolution.md), [ADR-0015](../architecture/decisions/0015-engine-semantics-identity-and-reproducibility.md), and the normative [Engine Semantics v1](../architecture/engine-semantics-v1.md). Implementation remains pending and is decomposed by the focused [PLAN-ENG-5 delivery plan](spatial-runtime-consequences.md).
-
-Factory V2 owns exactly these new authored facts:
-
-```text
-floor width / height
-resource position x / y = footprint minimum-coordinate reference cell
-footprint width / height
-ticksPerCell
-handlingTicks
-```
-
-They are required, validated, canonical and fingerprinted under `factory-model:v2`. Orientation, paths, aisles, conveyors, transport resources, floor identity, connection points and route topology are not V2. Existing `factory-model:v1` remains fully supported under its existing non-spatial semantics; there is no automatic V1→V2 lift.
-
-Engine semantics v1 owns the first interpretation:
-
-- preserve the actual PLAN-ENG-2 selection and recovery semantics recorded in §6.3;
-- bind a concrete destination only when the selected destination is currently admissible for binding;
-- distinct-resource distance is Manhattan distance between V2 position reference cells;
-- `transferDuration = handlingTicks + ticksPerCell * manhattanDistance` using exact integer arithmetic;
-- footprint does not affect v1 transfer distance;
-- `handlingTicks` is applied once per inter-resource transfer;
-- same-resource consecutive operations create no transfer state/duration/events;
-- a distinct-resource transfer with zero authored magnitudes still has authoritative start/completion transitions at one `SimTime`;
-- binding consumes destination **admission capacity**, distinct from active processing and queue state;
-- binding is immutable after transfer start; v1 does not reroute;
-- destination/source availability changes after departure do not change the fixed destination or completion time; an offline destination at arrival receives the job through the existing waiting path after transfer completes.
-
-Runtime owns the mutable consequence: `TRANSFER_STARTED`, in-flight `TRANSFERRING`, `TRANSFER_COMPLETED`, the fixed completion time, destination reservation/admission load, and supported observations/events. A consumer may interpolate visual movement from authoritative times and canonical placement; frame-by-frame coordinates are not authoritative runtime state.
-
-### 9.2 Hierarchy is not layout
-
-Resource scope and physical placement remain separate dimensions:
-
-```text
-Resource scope
-    Factory -> Work Center / Resource Pool -> Resource Instance
-
-Spatial layout
-    Floor -> Position -> Footprint
-```
-
-Moving a resource changes canonical spatial content and therefore `ModelFingerprint` without changing stable resource identity or hierarchy membership. Changing pool/work-center membership does not implicitly move it.
-
-### 9.3 Provenance and reproducibility
-
-`ModelFingerprint` identifies which authored Factory design ran. `EngineSemanticsVersion` identifies which Arcogine interpretation ran. The durable result inputs are conceptually:
-
-```text
-ModelFingerprint
-+ EngineSemanticsVersion
-+ explicit workload
-+ seed/random inputs
-+ ordered external commands
-```
-
-A released Engine semantics version retains an immutable specification and pinned behavioral conformance fixtures; permanent exact re-execution of every historical version is not promised. `RunId` remains correlation identity only.
-
-### 9.4 Acceptance criteria
-
-PLAN-ENG-5 is satisfied when:
-
-1. Runtime consumes validated V2 semantic layout from a published model rather than accepting editor-specific geometry directly.
-2. Two otherwise equivalent V2 designs with different canonical positions produce different transfer/completion times under the same `engine-semantics:v1` when Manhattan distance differs.
-3. Repeated execution with identical model, semantics version, workload, seed and ordered commands is deterministic.
-4. Transfer start/completion and in-flight state are observable and attributable through supported events/observations without replay.
-5. Moving a resource changes `ModelFingerprint` and transfer behavior without changing resource identity.
-6. Results retain both `ModelFingerprint` and `EngineSemanticsVersion` provenance.
-7. Destination admission reservation remains distinct from processing activity and queue depth, including when the bound destination goes offline before arrival.
-8. Zero-duration and same-resource cases follow the exact semantics-v1 rules and deterministic PLAN-ENG-4 sequence ordering.
-9. V1 artifacts/fingerprints remain unchanged and receive no synthesized spatial facts or transfer semantics.
-10. Resource-pool/hierarchy changes do not implicitly change spatial placement.
-11. No pathfinding, worker, vehicle, aisle, conveyor, transport-capacity or congestion model is required to satisfy the gate.
-
-The focused PLAN-ENG-5 plan breaks this acceptance boundary into twelve semantic implementation slices, starting with pre-Gate-5 conformance fixtures and V2 model work, converging on one vertically coherent transfer-activation slice, then closing edge cases, observation/KPI evidence and the final headless proving case.
-
-## 10. Headless engine acceptance scenarios
-
-The gates and active PLAN-ENG-W1 capability are proven before a game client exists. Model variants are published through the design capability and instantiated as separate runtimes.
-
-### 10.1 PLAN-ENG-2 capacity benchmark — independently dispatchable work
-
-```text
-Product
-    CUT -> ASSEMBLE -> INSPECT
-
-Production workload
-    two or more independent orders/jobs totaling 20 units
-
-Published model A
-    one cutter
-    one assembler
-    one inspector
-
-Published model B
-    two equivalent cutters
-    one assembler
-    one inspector
-```
-
-Expected evidence:
-
-- both runs are deterministic;
-- model B dispatches independently dispatchable work to both cutters;
-- cutter queueing, throughput, utilization, or total completion time changes;
-- if assembly becomes the new bottleneck, supported observations expose it;
-- no product definition is rewritten to name the second cutter.
-
-This benchmark intentionally proves PLAN-ENG-2 only: it does not require one quantity-scaled order to split across both cutters. The current reference consumer does require that separate behavior, so PLAN-ENG-W1 has its own fixed-contract benchmark below.
-
-### 10.2 PLAN-ENG-W1 fixed-contract work-decomposition benchmark
-
-```text
-Product
-    CUT -> ASSEMBLE -> INSPECT
-
-Production requirement
-    one accepted Order for 20 units
-
-Published model A
-    one cutter
-    one assembler
-    one inspector
-
-Published model B
-    two equivalent cutters
-    one assembler
-    one inspector
-```
-
-Expected evidence under ADR-0010:
-
-- exactly one accepted parent `Order` exists for the 20-unit requirement;
-- exactly 20 sibling unit-quantity `Job`s exist under that order;
-- child ordinals, `JobId` allocation, and initial dispatch order are deterministic;
-- each child independently traverses `CUT -> ASSEMBLE -> INSPECT` exactly once and preserves its own operation precedence;
-- model B can execute different sibling jobs from the same order concurrently on both eligible cutters;
-- aggregate `releasedQuantity` is 20 after successful acceptance and aggregate `completedQuantity` advances exactly once per completed child from 0 through 20;
-- exactly one `OrderCompleted` is emitted, carrying explicit parent `OrderId` and the child `JobId` whose completion caused the aggregate transition;
-- backlog, completed-sales count/value, and order lead-time semantics remain order-level rather than multiplying by child count;
-- adding the second cutter changes queueing, utilization, throughput, or completion time for this fixed-contract workload;
-- repeated fresh runs reproduce child identities/order, assignments, ordered events, progress transitions, and terminal state;
-- quantity 1 remains the degenerate one-order/one-child case;
-- the proof uses Arcogine-owned execution semantics rather than game-owned splitting logic.
-
-The PLAN-ENG-W1 acceptance suite must also preserve existing PLAN-ENG-2 independent-order behavior, offline/recovery behavior, PLAN-ENG-3 reset/replay and bounded advancement, and rejected-submission atomicity.
-
-A non-functional large-order benchmark (for example quantity 100,000) must record the memory/execution impact of unit decomposition. PLAN-ENG-W1 accepts quantity-proportional resident work-item count because arbitrary chunking would invent batch semantics; measured evidence should determine whether a later representation-efficiency design is required.
-
-### 10.3 PLAN-ENG-5 layout benchmark
-
-```text
-Same product definition
-Same production order
-Same resource identities
-Same processing durations
-Same EngineSemanticsVersion = engine-semantics:v1
-
-Published V2 model A
-    resources close together
-
-Published V2 model B
-    same resources placed farther apart
-```
-
-Expected evidence:
-
-- processing work is identical;
-- canonical placement difference changes `ModelFingerprint`;
-- transfer duration differs according to the semantics-v1 Manhattan rule;
-- total completion time differs;
-- transfer events/observations explain the difference, including a reconstructable in-flight view;
-- repeated runs reproduce each model's ordered semantic outcomes;
-- each result retains both model fingerprint and Engine semantics provenance;
-- V1 golden vectors/fingerprints remain unchanged and no V1 spatial defaults are synthesized.
-
-## 11. Distribution hardening after the core gates
-
-These capabilities are required before treating an external client as distributable, but they do not block the first headless readiness proof.
-
-| Capability | Requirement |
-|---|---|
-| Public contract versioning | Version model, command, event, observation, and protocol schemas |
-| Reliable event recovery | Support monotonic event IDs and a defined reconnect/resynchronization strategy |
-| Exact checkpoint and restore | Persist source model identity, Engine semantics identity, simulated time, runtime state, queues, active work, scheduler contents, random state, and event position |
-| Sidecar lifecycle and packaging | Start, health-check, version-check, communicate with, and stop a bundled local runtime without requiring a separate Java installation |
-| Compatibility tests | Keep consumer-contract fixtures that fail on accidental breaking changes |
-
-PLAN-ENG-4 establishes the recovery primitives—run identity, monotonic supported-event sequence, observation cursor, and transport-neutral event semantics—but not the complete recovery mechanism. ADR-0015 adds Engine interpretation provenance that any future exact checkpoint/recovery format must retain. Distribution hardening later owns retained supported-event history, reconnect/resume cursors, explicit gap detection/resynchronization, contract versioning, and exact checkpoint/restore. Recovery uses a fresh observation plus ordered deltas when history cannot be resumed; it does not require event sourcing or full-history replay.
-
-A game save may wrap an Arcogine checkpoint with game-owned state. Arcogine does not own campaign progress, score, camera state, or user preferences.
-
-This distribution hardening is for simulation consumers. Production connectivity additionally depends on the Operational Execution/Digital Twin readiness gates and must not infer production safety from simulation packaging/recovery maturity.
-
-## 12. Explicit non-goals
-
-Engine readiness does not require:
-
-- defining or persisting consumer drafts;
-- a complete ISA-95 object model/hierarchy/transaction set/B2MML profile/conformance claim;
-- Enterprise or Site entities without a concrete use case;
-- personnel, worker skills, fatigue, or pathfinding;
-- raw-material procurement/suppliers/BOM merely for this initiative;
-- maintenance, failure, quality, or shift-management domains;
-- live production connectivity or operational execution;
-- production identity/trust/authorization or credential lifecycle;
-- production deployment application or effective applied-artifact provenance;
-- external telemetry ingestion or digital-twin reconciliation;
-- fail-safe physical actuation or production adapter recovery;
-- dynamic mutation of published factory structure while work is in flight;
-- generalized material-lot identity/genealogy, configurable production batch sizes, transfer batches, or split/merge semantics as part of PLAN-ENG-W1;
-- setup-family optimization, priority/due-date scheduling, or generalized scheduler semantics merely to implement PLAN-ENG-W1;
-- a generic plugin framework;
-- multiplayer/distributed simulation/remote hosting;
-- game rendering, scoring, progression, narrative, tutorials, or player economy.
-
-The objective is a consumer-ready deterministic production **simulation** runtime over a published factory model, not a universal MES/digital-twin/game framework.
-
-## 13. Delivery order and first runtime milestone
-
-### 13.1 Prerequisite
-
-Complete the behavior-preserving canonical-model seam from [Factory Design Capability](factory-design-capability.md) — this is the model-seam entry gate defined in §1.1, not the full PLAN-FD-1 to PLAN-FD-4 acceptance criteria:
-
-```text
-Scenario factory semantics
-      -> FactoryModel
-      -> validate/publish
-      -> instantiate existing runtime
-      -> preserve deterministic results
-```
-
-### 13.2 Runtime delivery order
-
-1. Separate accepted immutable order intent from mutable job execution. **Implemented as the first behavior-preserving PLAN-ENG-1 slice.**
-2. Add explicit workload submission independent of the economy/pricing loop. **Implemented as the second PLAN-ENG-1 slice** (`FactoryRuntime.submitWorkload`, backed by package-private `FactoryHandler.submitOrder`).
-3. Make quantity consume proportional production work. **Implemented as the third PLAN-ENG-1 slice** using repeated routing inside one `Job`; retained as historical pre-PLAN-ENG-W1 evidence, not current runtime behavior.
-4. Capability/eligibility-driven deterministic dispatch. **Implemented as PLAN-ENG-2**; see ADR-0009 for the dispatch/decomposition boundary.
-5. Consumer-neutral session and bounded advancement. **Implemented as PLAN-ENG-3**; see ADR-0007.
-6. **PLAN-ENG-W1 — intra-order execution decomposition. Complete.** Architecture resolved by ADR-0010; quantity `N` -> `N` unit-quantity sibling `Job`s, with fixed-contract and large-order evidence.
-7. **PLAN-ENG-4 — stable runtime observations and ordered authoritative runtime events. Core/headless closure complete.** PLAN-ENG-4-D outward convergence and PLAN-ENG-DH-E recovery hardening remain downstream and do not block PLAN-ENG-5.
-8. **PLAN-ENG-5 — architecture accepted; implementation pending.** ADR-0014 fixes Factory V2 evolution, ADR-0015 fixes Engine semantic identity/reproducibility, `engine-semantics:v1` fixes the first interpretation, and [the focused PLAN-ENG-5 plan](spatial-runtime-consequences.md) decomposes implementation into twelve incremental semantic slices (`PLAN-ENG-5-0`, `PLAN-ENG-5-A1..A3`, `PLAN-ENG-5-B1..B2`, `PLAN-ENG-5-C1..PLAN-ENG-5-C4`, `PLAN-ENG-5-D`, `PLAN-ENG-5-E`).
-9. Public-contract, recovery, persistence, and packaging hardening.
-
-### 13.3 First runtime milestone
-
-> **Run a deterministic explicit production order through separate order intent and work execution without using the economy demand loop.**
-
-Definition of done:
-
-```text
-Published model supplies product/operation definitions
-Production order exists as runtime workload
-Quantity creates proportional work
-Work execution is distinct from order intent
-Order progress is observable
-Completion is deterministic
-Economy and sales agent are optional workload sources
-Existing scenario behavior remains covered
-```
-
-This milestone deliberately excludes changing the canonical-model boundary, layout consequences, public HTTP versioning, checkpointing, sidecar packaging, and game UI.
-
-## 14. Open decisions and ADR triggers
-
-| Decision | Trigger for resolution |
-|---|---|
-| Final aggregate/type boundaries for order and work execution | PLAN-ENG-1 baseline implemented; PLAN-ENG-W1 parent/child shape further resolved by ADR-0010 |
-| Intra-order execution decomposition and work-item identity | **Resolved by ADR-0010 and complete; fixed-contract and 100,000-child benchmark evidence are executable** |
-| Future lot/batch sizing or material-lot identity | A concrete domain requirement supplies real lot/batch semantics beyond PLAN-ENG-W1 unit decomposition |
-| Capability pools versus explicit eligible-instance sets | A concrete scheduling/control use case cannot be expressed cleanly by explicit eligibility |
-| Deterministic dispatch policy | **Current result-affecting behavior is frozen by `engine-semantics:v1`; a semantics-changing revision requires a new `EngineSemanticsVersion`** |
-| Session interface/module ownership | Resolved by PLAN-ENG-3 / ADR-0007; revisit only if a concrete consumer proves `FactoryRuntime` is no longer the right boundary |
-| Tick/event-count advancement semantics | Interactive/headless responsiveness tests |
-| Observation/event contract semantics | **Resolved by ADR-0011; ADR-0015 adds Engine-semantics provenance, implemented by PLAN-ENG-5-B2; outward migration remains PLAN-ENG-4-D** |
-| Spatial model-policy evolution | **Resolved by ADR-0014 (`factory-model:v2`); implementation in PLAN-ENG-5-A1/A2/A3** |
-| Spatial metric/transfer policy | **Resolved for `engine-semantics:v1` by ADR-0015 + the normative Engine Semantics v1 specification; implementation in PLAN-ENG-5-C1..PLAN-ENG-5-C4** |
-| Engine semantics identity/reproducibility | **Resolved by ADR-0015; implementation in PLAN-ENG-5-0/B1/B2 and conformance closure in PLAN-ENG-5-E** |
-| Public compatibility policy | Before external consumer contract publication |
-
-### 14.1 PLAN-ENG-W1 — complete execution capability: intra-order execution decomposition
-
-Intra-order parallelism is a **complete PLAN-ENG-W1 Engine execution capability**, not unfinished PLAN-ENG-2 work. ADR-0010 records the child-job identity and aggregate-completion shape. `LargeOrderDecompositionBenchmarkTest` supplies the required executable evidence at the supported 100,000-child materialization ceiling.
-
-The accepted PLAN-ENG-W1 model is implemented: Arcogine materializes deterministic unit-quantity child jobs under one authoritative order-execution aggregate; the game supplies only one production requirement.
-
-```text
-Order
-    immutable production intent
-    OrderId
-    requested quantity N
-        |
-        v
-order-level execution aggregate
-    identity: same OrderId
-    requested/released/completed quantity
-        |
-        +---- Job ordinal 0, executionQuantity 1, JobId
-        +---- Job ordinal 1, executionQuantity 1, JobId
-        +---- ...
-        +---- Job ordinal N-1, executionQuantity 1, JobId
-```
-
-PLAN-ENG-W1 therefore does **not** need another design round to choose whether one unit becomes one execution object: for this first capability, it does. This is a deliberately minimal unit-decomposition policy, not a generalized lot/batch framework.
-
-Required implementation semantics are fixed by ADR-0010:
-
-- accepting quantity `N` creates exactly `N` unit-quantity sibling `Job`s under one `Order`;
-- `JobId` is the independently dispatchable work-item identity already used by machine queues, active work, pending work, and task events;
-- no new `ExecutionUnitId`, `LotId`, or `BatchId` is introduced;
-- child ordinal is immutable deterministic ordering metadata, not identity;
-- all PLAN-ENG-W1 children are released atomically at acceptance, so `releasedQuantity == requestedQuantity` after successful submission;
-- each child traverses the routing exactly once and has no sibling precedence beyond its own routing order;
-- PLAN-ENG-2's selector and `pendingMultiEligible` semantics are reused unchanged;
-- aggregate `completedQuantity` increments exactly once per child final completion;
-- the `N-1 -> N` aggregate transition emits exactly one `OrderCompleted`, carrying explicit `OrderId` and the completing child `JobId`;
-- backlog, completed-sales count/value, lead time, and existing order-throughput measures remain order-level;
-- `FactoryRuntime.submitWorkload` continues to return one `OrderId` and rejected submission remains zero-partial-mutation across the entire parent/child creation operation;
-- runtime observation must expose aggregate order progress rather than forcing consumers to infer it by counting child jobs;
-- child creation, `JobId` allocation, initial dispatch, queueing, pending-work reconsideration, machine tie-breaking, and same-time event ordering remain deterministic;
-- implementation must include the fixed-contract acceptance benchmark in §10.2 and a large-order performance/memory benchmark.
-
-This decision intentionally leaves material-lot genealogy, configurable batch sizes, transfer batches, split/merge, setup optimization, inventory allocation, generalized scheduling, and durable cross-session work-item identity out of PLAN-ENG-W1. Those require separate accepted semantics when a concrete use case justifies them.
-
-PLAN-ENG-W1 remains placed **before PLAN-ENG-4** deliberately. PLAN-ENG-4 stabilizes observations and event envelopes around the execution identities and aggregate progress model PLAN-ENG-W1 establishes rather than around the obsolete one-Job-per-Order runtime shape.
-
-`IntraOrderExecutionAcceptanceTest` proves the fixed quantity-20 workload: one order, twenty deterministic children, concurrent use of two eligible cutters, aggregate completion, one business completion, and pre-mutation rejection above the supported 100,000-child materialization limit. `LargeOrderDecompositionBenchmarkTest` executes that ceiling, proves its deterministic decomposition and terminal semantics, and records diagnostic memory/execution measurements.
-
-The canonical model/run/runtime boundary is tracked by ADR-0003. Operational execution-context/trust/command/deployment/reconciliation decisions belong to the sibling operational track and should receive their own ADRs when hard-to-reverse contracts are selected. Record additional accepted Engine decisions as ADRs rather than expanding this plan into a decision log.
-
-## 15. Documentation lifecycle
-
-While this work is proposed, this file remains under `docs/planning/`.
-
-As gates become implemented:
-
-- update [`../architecture/overview.md`](../architecture/overview.md) with established runtime architecture;
-- update [Factory Design Architecture](../architecture/factory-design.md) only as the model boundary becomes accepted/implemented;
-- update the [ISA-95 semantic mapping](../architecture/isa-95-semantic-mapping.md) when manufacturing concepts change, while distinguishing accepted target architecture from implementation status;
-- update [`../reference/api.md`](../reference/api.md) only for implemented public behavior;
-- add ADRs for durable execution, scheduling, session, persistence, and compatibility decisions;
-- keep headless acceptance scenarios executable and version-controlled;
-- keep production connectivity, deployment, external observation, reconciliation, and trust semantics in the sibling Operational Execution track until they become implemented current architecture.
-
-Once the readiness initiative is complete or abandoned, reduce this file to a concise historical outcome or retire it after durable decisions and current behavior are represented in authoritative locations.
+1. start from current `main` and preserve accepted predecessor behavior;
+2. use executable deterministic tests for every result-affecting invariant;
+3. avoid using a UI or protocol adapter as evidence for core Engine semantics;
+4. keep internal scheduler machinery separate from supported consumer contracts; and
+5. reconcile implementation status in this plan and the detailed delivery companion when work lands.

--- a/docs/planning/governance-conformance-capability.md
+++ b/docs/planning/governance-conformance-capability.md
@@ -1,958 +1,201 @@
-# Governance and Conformance Capability Plan
+# Governance and Conformance Capability Implementation Plan
 
-> **Status:** Proposed; PLAN-GOV-1 complete, PLAN-GOV-2 (initial slice) complete, PLAN-GOV-3 complete, PLAN-GOV-4 (initial slice) complete  
-> **Scope:** Establish the cross-domain substrate for durable semantic identity, controlled revision history, semantic change, requirements, conformance, evidence, and governed change  
-> **Authority:** Planning only; this document defines delivery dependencies and readiness criteria, while current-state PLAN-GOV-1 behavior is also recorded in the architectural overview and accepted ADRs  
-> **Related:** [Governance and Conformance Architecture](../architecture/governance-conformance.md), [Governance PLAN-GOV-1 Continuity Notes](governance-continuity.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md), [ADR-0008](../architecture/decisions/0008-controlled-revision-identity-and-lineage.md), [Product Charter](../product/charter.md), [Factory Design Capability Plan](factory-design-capability.md), [Factory Design Architecture](../architecture/factory-design.md), [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md), [Standards Alignment](../architecture/standards-alignment.md)
+> **Status:** Active; PLAN-GOV-1 complete, PLAN-GOV-2 initial slice complete, PLAN-GOV-3 complete, PLAN-GOV-4 initial slice complete; PLAN-GOV-5 is the next admitted Governance slice  
+> **Scope:** Implementation-ready sequence for evidence, governed change, exceptions, mappings, and audit projections over the landed identity/change/conformance substrate  
+> **Authority:** Planning only; durable semantics remain owned by Governance architecture and accepted ADRs  
+> **Related:** [Governance Architecture](../architecture/governance-conformance.md), [Identity/History Compatibility Guard](governance-continuity.md), [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md), [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md), [ADR-0008](../architecture/decisions/0008-controlled-revision-identity-and-lineage.md)
 
-## 1. Purpose
+## 1. Boundary
 
-Arcogine should not respond to the opportunity for compliance automation by building framework checklists first. Governance should be derived from authoritative semantic models, their controlled revision history, observed facts, and explicit governance decisions.
-
-The generic sequence is:
+Governance derives decisions from explicit semantic state, change, requirements, assertions, evidence, and accountable workflow records. It does not become telemetry ingestion, production command execution, or a framework-specific checklist engine.
 
 ```text
-Canonical domain models
+semantic artifact + controlled revision
         |
         v
-Durable semantic fingerprint + controlled revision lineage
+semantic ChangeSet / impact
         |
         v
-Semantic ChangeSets
+requirement + assertion
         |
         v
-Requirements and assertions
+conformance evaluation / finding
         |
         v
-Conformance evaluation
+evidence / evidence use
         |
         v
-Evidence and findings
+governed change / authorization / exception
         |
         v
-Governed change / exceptions / risk
-        |
-        v
-Framework mappings and compliance projections
+optional framework mappings / audit projection
 ```
 
-The same primitives support design review, architecture governance, deployment authorization, internal policy, safety constraints, customer commitments, auditability, digital-twin interpretation, and agent governance. Operational execution and reconciliation consume or produce some of the same facts, but remain a sibling capability rather than part of the Governance runtime.
+## 2. Landed substrate
 
-## 2. Relationship to current factory-model and operational work
+### PLAN-GOV-1 — Durable fingerprint and controlled revision history — COMPLETE
 
-The canonical factory-model work is the first implementation proving ground.
+Provides durable semantic identity, opaque historical revision identity, authoritative history, lineage, recording provenance, and exact historical semantic-state resolution.
 
-The implemented seam now provides:
+Downstream work must preserve the [Identity/History Compatibility Guard](governance-continuity.md).
 
-```text
-FactoryModel
-    -> structural validation
-    -> immutable publication
-    -> durable factory-model:v1 semantic fingerprint
-    -> canonical semantic artifact encoding/strict historical reconstruction
-    -> authoritative controlled-revision acceptance and durable history
-    -> runtime instantiation
-    -> runtime/result provenance work in progress
-```
+### PLAN-GOV-2 — Semantic ChangeSet and impact — COMPLETE (initial slice)
 
-ADR-0006 and its implementation establish the durable semantic fingerprint contract. ADR-0008 establishes controlled revision identity and lineage. PLAN-GOV-1-2 implements its value contracts, and PLAN-GOV-1-3 now implements authoritative revision acceptance, durable reopenable history, repository-level lineage integrity, and exact historical semantic-state resolution for the factory proving ground.
+Provides domain-neutral semantic add/remove/modify changes, stable affected-entity references/impact scope, change provenance, and optional external change reference association. Factory semantic comparison proves the first domain use.
 
-The dependency order remains:
+Do not replace this with generic text/JSON diff or source-control semantics.
 
-```text
-PLAN-GOV-1-1 durable semantic fingerprint                 complete
-          ↓
-PLAN-GOV-1-2 controlled revision identity/value contract  complete
-          ↓
-PLAN-GOV-1-3 authoritative revision persistence +
-     exact historical semantic-state resolution  complete
-          ↓
-PLAN-GOV-1 durable identity/history substrate              complete
-          ↓
-PLAN-GOV-2 semantic ChangeSet                              complete (initial slice)
-          ↓
-PLAN-GOV-3 requirement/assertion contract                  complete
-          ↓
-PLAN-GOV-4 conformance evaluation/findings                 complete (initial slice)
-          ↓
-PLAN-GOV-5 evidence
-          ↓
-PLAN-GOV-6 review/authorization/governed-change integration
-```
+### PLAN-GOV-3 — Requirement/assertion contract — COMPLETE
 
-Evaluating a proposed change's conformance before it is authorized is the strategic point (see [architecture §11](../architecture/governance-conformance.md#11-pre-change-conformance-is-strategically-important)); an authorization/deployment integration that isn't preceded by conformance evaluation would authorize changes Arcogine hasn't yet assessed.
+Provides versioned requirements/assertions, scopes, catalogue selection against real impact scope, and exact external requirement source/provenance where evaluation depends on it.
 
-> **PLAN-FD-5 semantic comparison is no longer only an editor convenience. It is an enabling primitive for governed change and impact analysis once the model seam is stable.**
+### PLAN-GOV-4 — Conformance evaluation and findings — COMPLETE (initial slice)
 
-This does not imply generic patch/merge infrastructure. The need is semantic change attribution.
+Provides deterministic pre-change evaluation over explicit subject/revision/requirement/assertion inputs with attributable evaluation result and findings.
 
-### 2.1 Boundary with Operational Execution and Digital Twin
+The initial slice does not claim durable historical persistence of every evaluation/evidence record; that is downstream work.
 
-The sibling [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md) track is an early consumer/proving ground for Governance-owned identity, change, conformance, and evidence-use contracts.
-
-The dependency is explicit:
+## 3. Current implementation queue
 
 ```text
-Governance PLAN-GOV-1
-    durable semantic fingerprint + controlled revision identity/history
-        |
-        +--> Operational deployment / historical reconciliation
-
-Governance PLAN-GOV-2
-    semantic ChangeSet / impact
-        |
-        +--> Operational drift/calibration candidate change
-
-Governance PLAN-GOV-4
-    conformance / findings
-        |
-        +--> governed operational-change assessment when policy requires it
-
-Governance PLAN-GOV-5
-    Evidence + EvidenceUse
-        |
-        +--> independently provenanced operational observations used as evidence
-```
-
-Operational Execution owns telemetry/external-observation acquisition, operational source trust/authenticity provenance, command/result facts, deployment target application/effective artifact provenance, and modeled-versus-observed reconciliation. Governance owns the durable revision/change/evaluation/evidence-use/finding semantics that may reference those facts.
-
-Governance PLAN-GOV-2's initial `ChangeSet`/`ImpactScope`/`SemanticChange` slice is implemented, and Governance PLAN-GOV-4's initial `ConformanceEvaluator`/`ConformanceEvaluation`/`Finding` slice is now implemented. New Operational work that needs semantic ChangeSets, impact attribution, or conformance evaluation must consume the Governance-owned PLAN-GOV-2/PLAN-GOV-4 contracts rather than create new synthetic or parallel production abstractions for PLAN-OPS-7 or similar downstream work. Clearly scoped synthetic fixtures remain acceptable only for genuinely outstanding sibling-owned capabilities such as PLAN-GOV-5 evidence-use semantics. Such fixtures do not satisfy the corresponding Governance gates and must not escape test/fixture scope as duplicate shared production abstractions. PLAN-GOV-1 revision fixtures are likewise no longer appropriate: PLAN-GOV-1 is complete, and the Governance-owned authoritative revision identity/history contract is available.
-
-## 3. Delivery principles
-
-1. Framework-specific content remains downstream of generic conformance. Do not add SOC 2, ISO 27001, GDPR, or similar fields to core business objects.
-2. Do not create a monolithic `BusinessModel`. Each domain retains authoritative ownership of its facts.
-3. Distinguish modeled intent from observed reality. Structural facts may be provable from Arcogine state; operational assertions may require external evidence.
-4. Reuse external workflow systems where they already own organizational process state. Jira may remain authoritative for issue workflow while Arcogine owns semantic impact, evidence use, and controlled revision lineage.
-5. Keep semantic identity and controlled revision identity separate as required by [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md) and concretized by [ADR-0008](../architecture/decisions/0008-controlled-revision-identity-and-lineage.md).
-6. Treat controlled revision lineage as configuration history and evidence addressability, not as approval, deployment, certification, or compliance state.
-7. Keep `ChangeSet`, external workflow references, authorization decisions, deployments, evidence uses, labels, and framework mappings outside the minimum immutable controlled-revision identity core.
-8. Treat external requirement provenance as versioned input in addition to Arcogine's own requirement and assertion versioning. A standards-family label is not sufficient when an evaluation depends on a specific issuing authority, designation, edition/version, clause/locator, or adoption/profile.
-9. Do not bind raw external operational observations to a model fingerprint/revision at source. The revision relationship belongs to `EvidenceUse`, reconciliation, deployment correlation, or another interpretation record when applicable.
-10. Governance authorization and Operational deployment application are separate concerns. Governance may reference the deployment record but does not define adapter/application mechanics.
-11. Preserve future lineage extensions without implementing generic source-control semantics prematurely. PLAN-GOV-1-2 supports `0..1` parent today; branch refs, tags, multi-parent merges, and cryptographic revision-record integrity are deferred rather than forbidden.
-
-## 4. Delivery sequence
-
-```text
-PLAN-GOV-1  Durable fingerprint and controlled revision lineage       complete
-    ↓
-PLAN-GOV-2  Semantic ChangeSet and impact model                        complete (initial slice)
-    ↓
-PLAN-GOV-3  Generic requirement/assertion contract                     complete
-    ↓
-PLAN-GOV-4  Conformance evaluation and findings                         complete (initial slice)
-    ↓
-PLAN-GOV-5  Evidence and observation provenance
-    ↓
-PLAN-GOV-6  Governed change and external workflow integration
-    ↓
+PLAN-GOV-5  Evidence and EvidenceUse
+    |
+    v
+PLAN-GOV-6  Governed change / authorization / external workflow association
+    |
+    v
 PLAN-GOV-7  Exceptions and risk acceptance
-    ↓
+    |
+    v
 PLAN-GOV-8  Framework/control mappings
-    ↓
-PLAN-GOV-9  Audit snapshots and compliance projections
+    |
+    v
+PLAN-GOV-9  Audit snapshots / compliance projections
 ```
 
-PLAN-GOV-1 to PLAN-GOV-5 are architectural substrate. PLAN-GOV-6 to PLAN-GOV-7 establish governance workflow integration. PLAN-GOV-8 to PLAN-GOV-9 make conventional compliance automation possible without turning compliance into Arcogine's core ontology.
+## 4. PLAN-GOV-5 — Evidence and EvidenceUse
 
-## 5. PLAN-GOV-1 — Durable fingerprint and controlled revision lineage
+### Responsibility
 
-### Current status
+Represent independently attributable evidence and the explicit act of using that evidence for a particular requirement/assertion/evaluation context.
 
-**Complete.** PLAN-GOV-1-1, PLAN-GOV-1-2, and PLAN-GOV-1-3 are implemented and executable.
-
-PLAN-GOV-1-1 provides the durable semantic fingerprint contract. PLAN-GOV-1-2 provides `ControlledRevisionId` and immutable controlled-revision/lineage/recording-provenance values. PLAN-GOV-1-3 provides the authoritative acceptance boundary, reopenable durable history, repository-level parent integrity, exact historical semantic-artifact resolution, fingerprint reverification, typed integrity failures, and concurrent duplicate-ID protection.
-
-Downstream authorization, deployment, conformance, evidence, and result-provenance integrations validate their own use of PLAN-GOV-1 identities in their owning capabilities; they are not part of the immutable revision core and did not gate PLAN-GOV-1 closure.
-
-### Goal
-
-Provide two durable, non-conflated identities and the historical substrate required by later governance work:
+The implementation must distinguish:
 
 ```text
-ModelFingerprint
-    deterministic identity of canonical semantic content
+Evidence
+    independent source fact/artifact/provenance
 
-ControlledRevisionId
-    opaque identity of one controlled historical occurrence
-
-ControlledRevision
-    revision ID
-    exactly one model fingerprint
-    parent revision IDs: 0..1 in the current capability
-    recording provenance:
-        recordedAt
-        recorder
+EvidenceUse
+    interpretation/application of that evidence
+    to a subject/revision/requirement/assertion/evaluation
 ```
 
-The invariant is:
-
-> **Durable semantic identity is not historical revision identity.**
-
-Equal semantic content may appear in multiple controlled revisions. A revision's existence does not imply approval, authorization, deployment, conformance, certification, or compliance.
-
-### PLAN-GOV-1-1 — Durable semantic fingerprint
-
-**Status: Complete.**
-
-ADR-0006 defines the versioned, cross-process `ModelFingerprint` contract and the first `factory-model:v1` policy. The implementation supplies the typed fingerprint and canonical binary encoding while retaining legacy `contentHash()` compatibility where needed.
-
-PLAN-GOV-1-1 remains the semantic-content identity layer only. It does not identify historical occurrences.
-
-### PLAN-GOV-1-2 — Controlled revision identity and value contract
-
-**Status: Complete.**
-
-ADR-0008 fixes the following contract:
-
-- `ControlledRevisionId` uses UUIDv4 as opaque durable historical identity;
-- revision identity is not derived from fingerprint, parent, actor, timestamp, human label, or external workflow ID;
-- every controlled revision references exactly one `ModelFingerprint`;
-- root revisions have zero parents and current descendants have one parent;
-- current `0..1` parent cardinality is a capability constraint, not a permanent architectural limit;
-- multiple children may share a parent, so divergence is representable;
-- multi-parent merge semantics, branch refs, tags, rebase/cherry-pick semantics, and cryptographic record integrity are deferred but not precluded;
-- rollback/reversion creates a new revision and may legitimately reuse an earlier fingerprint;
-- minimum provenance records `recordedAt` and the human/service/agent/import source that recorded the revision;
-- ID, fingerprint, lineage, and required recording provenance are immutable once accepted by the authoritative revision store;
-- `ChangeSet`, external workflow references, approval/authorization, deployment, conformance/evidence, labels, and model artifact storage are not fields in the minimum immutable revision core.
-
-The PLAN-GOV-1-2 value slice remains deliberately narrow:
-
-```text
-:types
-    ControlledRevisionId
-
-:governance
-    ControlledRevision
-    RevisionProvenance
-    RevisionRecorder
-```
-
-Those value invariants remain unchanged by PLAN-GOV-1-3.
-
-### PLAN-GOV-1-3 — Authoritative persistence and historical semantic-state resolution
-
-**Status: Complete.**
-
-A controlled revision becomes authoritative only when `ControlledRevisionAuthority.accept(...)` succeeds. Constructing a `ControlledRevision` in JVM memory does not create authoritative history.
-
-The current implementation provides:
-
-```text
-:governance
-    ControlledRevisionAuthority
-    SemanticArtifact
-    SemanticArtifactVerifier
-    HistoricalRevision
-    FileControlledRevisionAuthority
-```
-
-`FileControlledRevisionAuthority` is the current durable adapter. It uses a local JDK filesystem authority root with versioned immutable revision records, immutable semantic-artifact records, a filesystem lock, and atomic revision-record installation. It was selected because the repository had no existing database/persistence infrastructure and PLAN-GOV-1-3 required executable restart durability without introducing heavyweight infrastructure.
-
-The filesystem layout and binary record encoding are private adapter mechanics, not a selected permanent production persistence architecture. No new ADR was required: the only durable semantic artifact format used by the factory proving ground is the already accepted ADR-0006 `factory-model:v1` canonical representation. A future hard-to-reverse database, retention, migration, or artifact-store contract should receive its own ADR when selected.
-
-Acceptance enforces:
-
-- a revision ID is unused and cannot be silently rebound or overwritten;
-- the revision fingerprint equals the supplied semantic artifact fingerprint;
-- recomputing the durable fingerprint from the canonical artifact reproduces that `ModelFingerprint`;
-- a named parent is already authoritative and intact;
-- the current self-parent/`0..1` value invariants remain in force;
-- an immutable semantic artifact exists before the revision record reaches its atomic authoritative commit point;
-- concurrent conflicting acceptance attempts for one revision ID serialize at the authority boundary so only one binding can win.
-
-The semantic artifact is stored separately from the historical occurrence. Multiple revisions may therefore resolve to the same immutable artifact. The historical `F1 -> F2 -> F1` case produces three controlled revisions while the equal-F1 occurrences reuse the same canonical semantic content.
-
-For the factory proving ground, `FactoryModelArtifactV1` exposes the same canonical `factory-model:v1` bytes used by the durable fingerprint policy and provides strict historical decoding. Decoding rejects malformed UTF-8, invalid structural encodings, trailing bytes, and decodable-but-noncanonical representations. Resolution therefore supports:
-
-```text
-ControlledRevisionId
-    -> ControlledRevision
-    -> ModelFingerprint
-    -> exact canonical semantic artifact
-    -> exact historical FactoryModelVersion
-```
-
-Resolution never substitutes the mutable current model. Stored artifacts are reverified against their recorded fingerprint. Missing revisions, missing artifacts, fingerprint mismatch, unsupported artifact policy, corrupt revision metadata, and corrupt artifact data fail explicitly through typed Governance failure codes rather than vendor/filesystem exceptions.
-
-The authority's consistency strategy installs/verifies the immutable artifact first and treats atomic revision-record installation as the authoritative commit point. Normal failed acceptance removes a newly-created artifact before returning. A hard process failure before the revision commit can at worst leave an unreferenced immutable artifact; it cannot expose a partially authoritative revision.
-
-### Required properties
-
-- Equal semantic content can have the same model fingerprint across distinct controlled revisions.
-- A later rollback may therefore have the same fingerprint as an earlier revision while remaining historically distinct.
-- Controlled revision identity must not be inferred from the fingerprint or a human label such as `v7`.
-- The same controlled revision ID always identifies the same immutable accepted revision record.
-- Revision lineage is explicit and independent of fingerprint equality.
-- A revision cannot name itself as parent; the authoritative store requires a named parent to pre-exist acceptance.
-- Recording provenance identifies when Arcogine accepted the historical record and who/what recorded it, without implying authorization.
-- Human version/revision labels may exist for presentation but are not fundamental identity.
-- External workflow references are associations, not revision identity.
-- Authorization, deployment, conformance, evidence, and framework/compliance state remain separate records/projections.
-- Exact historical semantic state is reconstructed from the stored canonical artifact rather than current runtime/model state.
+Raw Operational observations, when they later exist, remain Operational facts with their own source/subject/time/trust provenance. Governance may reference them as evidence without rebinding them at ingestion to a model/revision.
 
 ### Acceptance criteria
 
-Criteria 1-5 define completion of the PLAN-GOV-1 identity/history substrate. Criteria 6-7 are cross-capability compatibility boundaries: PLAN-GOV-1 makes those references possible without absorbing downstream state into revision identity, while concrete downstream integrations are accepted in their owning capability slices.
+PLAN-GOV-5 is ready to close when:
 
-PLAN-GOV-1 is ready when:
+1. evidence has stable identity and source/provenance appropriate to its type;
+2. one evidence item can be reused in several explicit EvidenceUse records without rewriting the evidence;
+3. EvidenceUse identifies the exact semantic subject/revision and requirement/assertion/evaluation context it supports;
+4. time/applicability and source version are explicit when material;
+5. missing/stale/inapplicable evidence produces explicit unknown/failure semantics rather than implicit pass;
+6. external observations can be fixture-backed without inventing duplicate Operational telemetry types; and
+7. historical evaluation remains attributable after later semantic or evidence changes.
 
-1. A durable semantic fingerprint contract is explicitly specified and testable across supported process/version boundaries. **Satisfied by PLAN-GOV-1-1.**
-2. Controlled revision identity/value semantics are implemented according to ADR-0008, including UUIDv4 identity, exactly one fingerprint, current `0..1` parent lineage, rollback-as-new-revision, and immutable recording provenance. **Satisfied by PLAN-GOV-1-2.**
-3. Controlled revisions have authoritative durable identities independent of process memory and semantic fingerprint equality. **Satisfied by PLAN-GOV-1-3 durable acceptance/reopen tests.**
-4. The authoritative store enforces revision-ID uniqueness, immutable ID-to-record binding, and parent existence/integrity under the chosen lineage policy. **Satisfied by PLAN-GOV-1-3 duplicate/rebind, lineage, failure-atomicity, and concurrency tests.**
-5. An authoritative controlled revision can resolve to the exact semantic state/artifact needed for historical reconstruction. **Satisfied by PLAN-GOV-1-3 canonical artifact resolution, reopen, fingerprint-reverification, and corruption tests.**
-6. Authorization and deployment records can independently reference a revision without becoming revision identity. **Compatibility boundary fixed by ADR-0008; concrete authorization/deployment integration is accepted downstream.**
-7. A downstream result can retain the semantic fingerprint and, when applicable, the controlled revision ID. **Compatibility boundary; concrete result-provenance integration is accepted by the owning producer/consumer capability.**
+### Non-goals
 
-### ADR status
+No telemetry ingestion, connector trust/authentication, document-management system, vector search, generic evidence lake, or production adapter belongs in this slice.
 
-The identity decisions are fixed by ADR-0004, ADR-0006, and ADR-0008. PLAN-GOV-1-3 did **not** require a new ADR because its filesystem record layout, directory names, lock mechanics, and fingerprint-derived physical artifact key are private, replaceable adapter details rather than a selected permanent persistence architecture; the semantic artifact bytes themselves reuse ADR-0006's existing `factory-model:v1` contract.
+## 5. PLAN-GOV-6 — Governed change and external workflow integration
 
-A new ADR remains appropriate if future work commits Arcogine to a hard-to-reverse production persistence, migration, retention, artifact-store, integrity, or multi-parent/ref contract.
+### Responsibility
 
-## 6. PLAN-GOV-2 — Semantic ChangeSet and impact model
+Represent the Governance decision that a candidate controlled revision is authorized/rejected/otherwise dispositioned, while allowing an external workflow system to remain authoritative for organizational process state.
 
-### Current status
+Keep separate:
 
-**Complete for the initial slice.** The generic `ChangeSet` contract, its semantic-change taxonomy,
-its impact-scope seam, and its factory-domain (PLAN-FD-5) comparison adapter are implemented and tested
-against the real PLAN-GOV-1-3 authoritative persistence boundary.
-
-Implementation:
-
-```text
-:governance (com.arcogine.governance.change) -- generic, domain-neutral
-    SemanticChangeKind          ENTITY_ADDED / ENTITY_REMOVED / ENTITY_MODIFIED
-    ChangedEntityRef            stable (entityType, entityId) identity + presentation label
-    SemanticChange               (kind, entity, detail)
-    ImpactScope                  deterministic Set<ChangedEntityRef> derived from semantic changes;
-                                  intersects(Set<ChangedEntityRef>) is the future-PLAN-GOV-3 matching seam
-    ExternalChangeReference      (system, identifier) -- association only
-    ChangeProvenance             (source, reason, optional ExternalChangeReference)
-    ChangeSet                    immutable record; deterministically re-sorts semantic changes in
-                                  its canonical constructor so equivalent comparisons always produce
-                                  equal content and order
-    SemanticChangeExtractor      domain adapter SPI (mirrors SemanticArtifactVerifier)
-    ChangeSetFactory              orchestrates ControlledRevisionAuthority.resolve(...) ->
-                                  SemanticChangeExtractor.compare(...) -> ChangeSet, for both
-                                  revision-to-revision and base-revision-to-candidate-snapshot paths
-
-:factory (com.arcogine.factory.change) -- domain-owned PLAN-FD-5 comparison content
-    FactoryModelSemanticComparator implements SemanticChangeExtractor, keyed on MachineId /
-        operation id / ProductId stable identity for add/remove/content classification; per
-        ADR-0006 ("current list ordering remains semantic in v1"), a reorder of the top-level
-        resources/operations/products lists is additionally reported as an ENTITY_MODIFIED change
-        against the moved entity, so a behavior-affecting reorder (e.g. product order affecting
-        deterministic demand generation) is never absorbed as a no-op
-```
-
-`ChangeSetFactory.fromCandidateSnapshot` additionally takes a `SemanticArtifactVerifier` and, before
-recording a caller-supplied candidate's declared fingerprint as `ChangeSet` identity, recomputes that
-fingerprint from the candidate's own canonical bytes and rejects a mismatch with an explicit
-`IllegalArgumentException` -- mirroring `FileControlledRevisionAuthority`'s existing
-fingerprint-to-bytes verification precedent for authoritative artifacts.
-
-`:factory`'s main source now depends on `:governance` (a new edge alongside the existing
-`:types <- governance` and `:types <- simulation <- factory` branches) so the domain can implement
-Governance's generic `SemanticChange`/`SemanticChangeExtractor` vocabulary directly, per the
-capability plan's guidance to prefer "a dependency direction where a domain produces semantic
-comparison facts that Governance associates with controlled history." `:governance` itself still
-depends only on `:types` in main source and gained no dependency on `:factory` or any other domain.
-This was ordinary implementation decomposition following an existing pattern
-(`SemanticArtifactVerifier`/`FactoryModelArtifactV1`), not a hard-to-reverse architectural choice,
-so it did not require a new ADR.
-
-Representative tests (exact names, see the listed files):
-
-- `product/governance/src/test/java/com/arcogine/governance/change/ChangeSetTest.java` --
-  `semanticChangesAreStoredInDeterministicOrderRegardlessOfInputOrder`,
-  `orderingDoesNotCollideForDelimiterBearingButLegallyDistinctEntityIdentities`
-  (colliding-looking `(entityType, entityId)` pairs normalize identically regardless of input order),
-  `impactScopeIsDerivedFromChangedEntitiesAndDeduplicated`, `noSemanticChangesIsAValidNoOpTransition`,
-  `resultingRevisionIdIsAbsentForAnUnpersistedCandidate`,
-  `externalChangeReferenceIsRetainedAsAssociationNotIdentity`,
-  `minimumContractHasNoAuthorizationDeploymentOrEvidenceFields`.
-- `product/governance/src/test/java/com/arcogine/governance/change/ChangeSetFactoryTest.java`
-  (exercises the real `FileControlledRevisionAuthority` + `FactoryModelSemanticComparator`, not
-  test-only injection) --
-  `comparesTwoAuthoritativeRevisionsThroughHistoricalResolution`,
-  `equalSemanticFingerprintAcrossDistinctRevisionsYieldsNoSemanticChangesButDistinctIdentity`
-  (same-fingerprint rollback across distinct revision IDs),
-  `candidateSnapshotIsComparedWithoutBecomingAControlledRevision`,
-  `candidateSnapshotWithFingerprintNotMatchingItsBytesIsRejected`
-  (fingerprint-to-bytes binding verification, mirroring `FileControlledRevisionAuthority`),
-  `externalChangeRequestReferenceSurvivesEndToEnd`,
-  `impactScopeIsUsableForFutureRequirementScopeMatching`.
-- `product/domains/factory/src/test/java/com/arcogine/factory/change/FactoryModelSemanticComparatorTest.java`
-  (pure PLAN-FD-5 comparator unit tests) --
-  `identicalModelsWithIdenticalConstructionOrderProduceNoSemanticChanges`,
-  `reorderingTopLevelResourcesIsAttributedAsEntityModifiedPerAdr0006`,
-  `reorderingProductsIsAttributedAsEntityModified`,
-  `reorderingEligibleResourcesWithinAStepDoesNotProduceASemanticChange`,
-  `addedResourceIsClassifiedAsEntityAddedWithStableIdentity`,
-  `removedResourceIsClassifiedAsEntityRemoved`,
-  `modifiedResourceCapacityIsClassifiedAsEntityModifiedByStableId`,
-  `renamingAnEntityDoesNotChangeWhichEntityIsAffected`.
-
-**Boundary called out explicitly, per delivery principle 1 and the PLAN-GOV-2 acceptance criteria below:**
-acceptance criterion 4 ("impact analysis can determine which registered requirements are
-potentially affected") was satisfied at PLAN-GOV-2-close time only as an honest *seam* --
-`ImpactScope.intersects(Set<ChangedEntityRef>)` -- because PLAN-GOV-3's requirement registry did not exist
-yet; `ChangeSetFactoryTest.impactScopeIsUsableForFutureRequirementScopeMatching` proved the seam
-against a hypothetical in-test scope only. PLAN-GOV-3 (below) now implements the requirement side of that
-seam (`RequirementScope`, `RequirementCatalogue`) and proves the same `ImpactScope` matches real
-registered `Requirement` values
-(`RequirementScopeTest.requirementScopeCanMatchExistingG2ImpactScope`,
-`RequirementCatalogueTest.impactAnalysisSelectsOnlyRequirementsWithIntersectingScope`). No PLAN-GOV-4+
-capability (assertion evaluation results, conformance findings, evidence, exceptions,
-authorization workflow) is implemented or claimed by PLAN-GOV-3.
-
-### Goal
-
-Represent a meaningful transition between controlled revisions or between a base revision and a candidate semantic snapshot in domain terms sufficient for review, impact analysis, and governance.
-
-A `ChangeSet` or equivalent should identify:
-
-```text
-base controlled revision / fingerprint
-candidate fingerprint
-resulting controlled revision, when persisted
-semantic changes
-changed entities
-change source/reason
-external change-request reference
-```
-
-### Non-goal
-
-Do not build generic JSON patching, arbitrary text merge, collaborative cursors, or a distributed source-control system for models merely to satisfy PLAN-GOV-2.
-
-### Impact analysis
-
-Useful first questions include:
-
-```text
-Which business objects are affected?
-Which requirements evaluate over those objects?
-Which existing evidence becomes stale or invalid?
-Which owners/reviewers have authority over the affected scope?
-Which runtime/deployment contexts would consume the changed model?
-```
+- semantic `ChangeSet` / impact;
+- conformance/evidence result;
+- authorization/governance decision;
+- optional external workflow reference; and
+- any future Operational deployment/application record.
 
 ### Acceptance criteria
 
-PLAN-GOV-2 is ready when:
+1. authorization references the exact controlled revision/candidate state;
+2. authorization does not redefine revision identity or mutate the immutable revision core;
+3. impact/conformance/evidence can be traced into the decision;
+4. external workflow references are associations, not identity;
+5. a later deployment can reference the authorization/revision without Governance owning target adapter/application mechanics; and
+6. the decision remains historically attributable after later workflow/model changes.
 
-1. Two relevant semantic states can be compared in domain terms rather than only byte-for-byte.
-   **Satisfied:** `ChangeSetFactory` resolves both states through the PLAN-GOV-1-3
-   `ControlledRevisionAuthority.resolve(...)` historical boundary and hands them to
-   `FactoryModelSemanticComparator`, which compares `FactoryModel` content, not artifact bytes.
-2. Changed entities can be identified with stable domain identity. **Satisfied:**
-   `ChangedEntityRef` keys on `MachineId`/operation id/`ProductId` for add/remove/content
-   classification (not list position), while top-level list order remains attributed as a real
-   change per ADR-0006; proven by
-   `identicalModelsWithIdenticalConstructionOrderProduceNoSemanticChanges`,
-   `reorderingTopLevelResourcesIsAttributedAsEntityModifiedPerAdr0006`, and
-   `renamingAnEntityDoesNotChangeWhichEntityIsAffected`.
-3. At least one domain change has a meaningful typed/classified representation. **Satisfied:**
-   `SemanticChangeKind` (`ENTITY_ADDED`/`ENTITY_REMOVED`/`ENTITY_MODIFIED`) applied to factory
-   resources, operations, and products.
-4. Impact analysis can determine which registered requirements are potentially affected.
-   **Satisfied at PLAN-GOV-2-close time only as the minimum honest seam** --
-   `ImpactScope.intersects(Set<ChangedEntityRef>)` let a future requirement scope match against
-   affected entities without redesigning `ChangeSet`, since PLAN-GOV-3's requirement registry did not yet
-   exist. PLAN-GOV-3 (§7 below) now implements that registry (`RequirementScope`, `RequirementCatalogue`)
-   and proves it selects real registered requirements from a real `ImpactScope`.
-5. ChangeSet provenance can retain an external change-request identifier. **Satisfied:**
-   `ChangeProvenance`/`ExternalChangeReference`, proven end-to-end by
-   `externalChangeRequestReferenceSurvivesEndToEnd`.
+## 6. PLAN-GOV-7 — Exceptions and risk acceptance
 
-## 7. PLAN-GOV-3 — Generic requirement and assertion contract
+### Responsibility
 
-### Current status
-
-**Complete.** `:governance` now provides, still depending on nothing beyond `:types` in its main
-source set:
-
-```text
-com.arcogine.governance.requirement
-    RequirementId, RequirementVersion, Requirement
-    RequirementScope
-    RequirementSource (sealed): ArcogineNativeRequirementSource, ExternalRequirementSource
-
-com.arcogine.governance.assertion
-    AssertionId, AssertionVersion, Assertion<T>
-    EvidenceRequirement (MODEL_STATE_SUFFICIENT / EXTERNAL_EVIDENCE_REQUIRED)
-    AssertionRule<T>, StructuralAssertionOutcome
-
-com.arcogine.governance.catalogue
-    RequirementCatalogue
-```
-
-`Requirement` and `Assertion` equality is identity+version only (mirroring how
-`ChangedEntityRef` already excludes its presentation-only `label`); an `Assertion`'s
-`AssertionRule` implementation is therefore explicitly never part of its identity, proven by
-`AssertionIdentityTest.assertionIdentityIsNotDerivedFromEvaluatorImplementationClass`.
-`RequirementScope` reuses PLAN-GOV-2's `ChangedEntityRef`/`ImpactScope` directly rather than introducing a
-second entity-reference or impact abstraction, and `RequirementScope.intersects(ImpactScope)`
-delegates to the existing `ImpactScope.intersects(Set<ChangedEntityRef>)` seam. `RequirementCatalogue`
-is an immutable, in-memory, deterministically ordered registry -- not a database, workflow engine,
-or framework-ingestion mechanism.
-
-The first proving requirement/assertion pair is Arcogine-native, structurally evaluable from
-authoritative state, and independent of external evidence
-(`StructuralProvingCaseTest`), using a minimal test-domain fixture rather than a permanent
-factory-owned policy or a duplicate of `FactoryModelValidator`, per the PLAN-GOV-3 non-goals. PLAN-GOV-4's
-conformance-result model (`PASS`/`FAIL`/`UNKNOWN`/`NOT_APPLICABLE`, `Finding`,
-`ConformanceEvaluation`) and PLAN-GOV-5's evidence model (`Evidence`/`EvidenceUse`) are explicitly not
-implemented; `EvidenceRequirementDeclarationTest
-.productionAssertionAndRequirementTypesContainNoG4OrG5Concepts` and
-`GovernanceModuleBoundaryTest` provide regression evidence for both the PLAN-GOV-4/PLAN-GOV-5 boundary and the
-`:factory`/Spring-free module boundary.
-
-No new ADR was required: this slice implements the requirement/assertion/scope shape already
-documented in [architecture §7](../architecture/governance-conformance.md#7-generic-conformance-model)
-and this plan's PLAN-GOV-3 acceptance criteria via ordinary, replaceable value/API decomposition. It does
-not freeze a persistence model (the catalogue is in-memory only), an expression/query language
-(scope is a plain deterministic entity set, not a DSL), or a cross-domain authority decision beyond
-what PLAN-GOV-1/PLAN-GOV-2 already established.
-
-### Goal
-
-Define explicit requirements independently of any particular compliance framework while preserving both Arcogine's own requirement/assertion versions and enough external source identity to reproduce the requirement that actually governed an evaluation.
-
-```text
-Requirement
-    stable identity
-    version
-    source authority, when external
-    source designation, when external
-    source edition/version
-    source locator
-    adoption/profile, when applicable
-    human meaning
-
-Scope
-    business objects to which it applies
-
-Assertion
-    stable identity
-    version
-    deterministic evaluation rule or evaluator
-    required evidence class
-```
-
-For an Arcogine-native requirement, the source may be an internal policy or architecture authority rather than an external standard. For an external requirement, a family-level reference such as `ISA-95 / IEC 62264` is insufficient if the obligation depends on a specific publication. The contract must be able to distinguish, for example, an IEC publication from a modified ANSI/ISA adoption or a national adoption without assuming that aligned editions are textually or normatively identical.
-
-External source identity does not replace Arcogine's requirement or assertion version. The same external clause may support multiple Arcogine requirement versions as scope, interpretation, or executable semantics evolve.
-
-The first requirement should be Arcogine-native and structurally evaluable from authoritative model state rather than imported from an external framework.
+Represent explicit governance disposition of known non-conformance without rewriting the underlying factual result.
 
 ### Acceptance criteria
 
-PLAN-GOV-3 is ready when:
+- finding/conformance result remains immutable factual input;
+- exception/risk acceptance records rationale and accountable actor/approver;
+- effective/expiration time is explicit;
+- expired exceptions become visible without history rewrite; and
+- compensating controls/evidence may be linked explicitly.
 
-1. A requirement has stable identity and can be versioned separately from both the model it evaluates and the edition/version of any external source it cites.
-   **Satisfied:** `RequirementId`/`RequirementVersion` carry no `ModelFingerprint`/
-   `ControlledRevisionId`/source-edition coupling; proven by
-   `RequirementIdentityTest.sameRequirementIdentityCanApplyToDifferentModelRevisions`,
-   `RequirementIdentityTest.requirementVersionIsIndependentOfModelFingerprintAndControlledRevision`,
-   and `RequirementSourceProvenanceTest.sameExternalClauseCanSupportDifferentArcogineRequirementVersions`.
-2. An assertion has stable identity and version independently of the requirement and model revision it evaluates.
-   **Satisfied:** `AssertionIdentityTest.assertionIdentityAndVersionAreIndependentOfRequirementVersion`
-   and `.assertionIdentityIsNotDerivedFromEvaluatorImplementationClass`.
-3. Scope selection is explicit and deterministic.
-   **Satisfied:** `RequirementScope` is a plain, deterministically ordered `ChangedEntityRef` set
-   reusing the real PLAN-GOV-2 seam; proven by `RequirementScopeTest.scopeSelectionIsDeterministic`,
-   `.scopeUsesStableChangedEntityIdentity`, `.requirementScopeCanMatchExistingG2ImpactScope`,
-   `.unrelatedImpactDoesNotSelectRequirement`, and
-   `RequirementCatalogueTest.impactAnalysisSelectsOnlyRequirementsWithIntersectingScope`.
-4. An assertion can declare whether model state alone is sufficient or external evidence is required.
-   **Satisfied:** `EvidenceRequirement`, proven by
-   `EvidenceRequirementDeclarationTest.structuralAssertionDeclaresModelStateSufficient` and
-   `.observationDependentAssertionDeclaresExternalEvidenceRequired`.
-5. Requirement wording/source and executable assertion semantics are distinguishable.
-   **Satisfied:** `Requirement` (meaning) and `Assertion`/`AssertionRule` (executable semantics)
-   are separate types; proven by `AssertionIdentityTest.requirementMeaningIsDistinctFromExecutableAssertionSemantics`
-   and `StructuralProvingCaseTest`.
-6. An external requirement can identify its exact source authority, designation, edition/version, locator, and applicable adoption/profile where those facts affect meaning.
-   **Satisfied:** `ExternalRequirementSource`, proven by
-   `RequirementSourceProvenanceTest.externalRequirementRetainsExactAuthorityDesignationEditionAndLocator`,
-   `.differentExternalEditionsRemainDistinguishable`, and
-   `.differentAdoptionsOrProfilesRemainDistinguishableWhenSpecified`.
-7. The contract is generic enough to represent internal policy and architecture rules.
-   **Satisfied:** `ArcogineNativeRequirementSource` requires no external metadata; proven by
-   `RequirementSourceProvenanceTest.arcogineNativeRequirementDoesNotRequireExternalSourceMetadata`
-   and used by the PLAN-GOV-3 proving case itself.
+## 7. PLAN-GOV-8 — Framework/control mappings
 
-### Test evidence
+### Responsibility
 
-- `product/governance/src/test/java/com/arcogine/governance/requirement/` --
-  `RequirementIdentityTest`, `RequirementSourceProvenanceTest`, `RequirementScopeTest`.
-- `product/governance/src/test/java/com/arcogine/governance/assertion/` --
-  `AssertionIdentityTest`, `EvidenceRequirementDeclarationTest`, `StructuralProvingCaseTest`.
-- `product/governance/src/test/java/com/arcogine/governance/catalogue/RequirementCatalogueTest.java`.
-- `product/governance/src/test/java/com/arcogine/governance/GovernanceModuleBoundaryTest.java` --
-  proves `:governance` stays domain-neutral (no `:factory`/Spring dependency in the main source
-  set or main sources).
-
-## 8. PLAN-GOV-4 — Conformance evaluation and findings
-
-**Status: implemented for its initial slice.** `com.arcogine.governance.conformance` adds the
-generic `ConformanceResult` taxonomy (`PASS`/`FAIL`/`UNKNOWN`/`NOT_APPLICABLE`), the immutable
-`ConformanceEvaluation` and `Finding` records, and the deterministic `ConformanceEvaluator` that
-turns one PLAN-GOV-3 `Requirement`/`Assertion<T>` pair, an optional PLAN-GOV-2 `ImpactScope`, an optional
-authoritative state `T`, a `ModelFingerprint`, and an optional `ControlledRevisionId` into one
-`ConformanceEvaluation`. It consumes the real PLAN-GOV-2/PLAN-GOV-3 contracts directly -- no parallel scope,
-change, or requirement representation -- and never calls `Instant.now()`, a random source, or any
-other system clock, so evaluation stays reproducible from its inputs alone. `Finding` is produced
-only for `FAIL`, enforced by `ConformanceEvaluation`'s canonical constructor, and it never
-synthesizes a `ControlledRevisionId` for an unpersisted candidate (mirroring `ChangeSet`/PLAN-GOV-1-3).
-This slice does **not** implement PLAN-GOV-5 evidence, authorization, deployment, workflow, a permanent
-severity taxonomy, persistence, or any REST/CLI/UI transport;
-`GovernanceModuleBoundaryTest.productionGovernanceCodeNeverReferencesG5PlusConcepts` provides
-regression evidence for that boundary.
-
-No new ADR was required: this slice implements the evaluation/finding shape already documented in
-[architecture §7](../architecture/governance-conformance.md#7-generic-conformance-model) via
-ordinary, replaceable value/API decomposition. It introduces no new durable identity, no
-persistence model, and no cross-domain authority decision beyond what PLAN-GOV-1 to PLAN-GOV-3 already established.
-
-### Goal
-
-Evaluate requirements against an exact semantic state and produce explainable results.
-
-A useful result model supports at least:
-
-```text
-PASS
-FAIL
-UNKNOWN
-NOT_APPLICABLE
-```
-
-An evaluation retains:
-
-```text
-model fingerprint
-controlled revision ID, when available
-requirement identity/version
-assertion identity/version
-scope
-result
-explanation
-affected entities
-evaluation time / applicable period
-```
-
-A failed result produces a finding rather than mutating the underlying business model.
+Add conventional framework/control projection only after generic requirements/conformance/evidence/governed change work.
 
 ### Acceptance criteria
 
-PLAN-GOV-4 is ready when:
+- requirements/controls/mappings are independently versioned;
+- one control may map to several framework requirements;
+- business/domain objects do not acquire framework-specific compliance booleans;
+- historical evaluations do not silently change when mappings/framework versions change; and
+- imported source text/content respects source/licensing constraints.
 
-1. The same semantic fingerprint/revision and requirement/assertion identities and versions produce deterministic structural results.
-   **Satisfied:** `ConformanceEvaluator.evaluate` is a pure function of its arguments (no clock,
-   randomness, or mutable state); proven by
-   `ConformanceEvaluatorTest.deterministicPassYieldsPassResult` (repeated-call equality) and
-   `.deterministicFailProducesFinding`.
-2. Findings identify affected entities and the failed assertion.
-   **Satisfied:** `Finding` carries `requirementId`/`requirementVersion`, `assertionId`/
-   `assertionVersion`, and `affectedEntities`, computed as the full requirement scope when no
-   `ImpactScope` is supplied and as the intersection of the requirement's scope with the supplied
-   `ImpactScope` otherwise; proven by `ConformanceEvaluatorTest
-   .failWithNoImpactScopeAttributesTheFullRequirementScopeAsAffected` and
-   `.failWithPartialImpactScopeAttributesOnlyTheIntersectingEntities` (a multi-entity requirement
-   scope with an `ImpactScope` covering only part of it).
-3. Results distinguish missing evidence from proven non-conformance.
-   **Satisfied:** an `EXTERNAL_EVIDENCE_REQUIRED` assertion, and a `MODEL_STATE_SUFFICIENT`
-   assertion evaluated with no supplied state, both yield `UNKNOWN` rather than `FAIL`; proven by
-   `ConformanceEvaluatorTest.missingEvidenceRequirementIsUnknownNotFailOrPass` and
-   `.unknownResultNeverCarriesAFindingAndIsDistinctFromFail`. `NOT_APPLICABLE` is likewise
-   distinct from `PASS`/`FAIL`/`UNKNOWN`, proven by `.notApplicableIsDistinctFromPassFailAndUnknown`.
-   `PASS` never carries a `Finding`, proven by `.passProducesNoFinding`.
-4. Evaluation output is immutable or historically attributable.
-   **Satisfied:** `ConformanceEvaluation`/`Finding` are immutable records; the optional
-   `ControlledRevisionId` is never fabricated when absent, and when supplied is resolved and
-   verified against the PLAN-GOV-1 `ControlledRevisionAuthority` as an authoritative binding to the
-   evaluated `ModelFingerprint` rather than accepted as an unverified caller assertion, proven by
-   `ConformanceEvaluatorTest
-   .controlledRevisionIsAbsentAndNeverSynthesizedForAnUnpersistedCandidate`,
-   `.controlledRevisionIsCarriedThroughWhenAuthoritativelyBoundToTheEvaluatedFingerprint`,
-   `.generatedButNeverAcceptedRevisionCannotBeAttributedToAnEvaluation`, and
-   `.revisionAuthoritativelyBoundToADifferentFingerprintCannotBeAttributedToAnEvaluation`.
-5. A proposed `ChangeSet` can be evaluated before authorization/deployment for at least one requirement.
-   **Satisfied:** `PreChangeConformanceProvingCaseTest
-   .preChangeCandidateIsEvaluatedAgainstRequirementsAffectedByItsRealImpactScope` builds a real
-   `ChangeSet` via `ChangeSetFactory` against the PLAN-GOV-1-3 authority, selects affected requirements
-   from a real `RequirementCatalogue` via the resulting `ImpactScope`, and evaluates one with
-   `ConformanceEvaluator` before any authorization or deployment concept is involved.
+Start with one small legally usable proving set; broad framework coverage is not part of the first slice.
 
-The last criterion is the first major strategic milestone: pre-change conformance rather than only post-change monitoring.
+## 8. PLAN-GOV-9 — Audit snapshots and compliance projections
 
-### Test evidence
+### Responsibility
 
-- `product/governance/src/test/java/com/arcogine/governance/conformance/ConformanceEvaluatorTest.java`
-  -- deterministic PASS/FAIL, `Finding` shape, `UNKNOWN` for missing evidence and for missing
-  state, `NOT_APPLICABLE` distinctness, and optional/never-synthesized `ControlledRevisionId`.
-- `product/governance/src/test/java/com/arcogine/governance/conformance/PreChangeConformanceProvingCaseTest.java`
-  -- the pre-change proving case against real PLAN-GOV-1-3/PLAN-GOV-2/PLAN-GOV-3 contracts.
-- `product/governance/src/test/java/com/arcogine/governance/GovernanceModuleBoundaryTest.java` --
-  extended with `productionGovernanceCodeNeverReferencesG5PlusConcepts`, a regression guard against
-  PLAN-GOV-5 evidence, authorization, deployment, or severity-taxonomy concepts appearing in production
-  Governance code ahead of their own gates.
-
-## 9. PLAN-GOV-5 — Evidence and observation provenance
-
-### Goal
-
-Support assertions whose truth depends on observations outside Arcogine's authoritative semantic model.
-
-Per [Evidence must be attributable and temporal](../architecture/governance-conformance.md#9-evidence-must-be-attributable-and-temporal), the evidence source record and its use in one evaluation are distinct:
-
-```text
-Evidence (source-level, no model fingerprint/revision)
-    source
-    provenance
-    observedAt
-    applicable period
-    external identity/reference
-    integrity metadata where required
-
-EvidenceUse (binds evidence to one evaluation)
-    related assertion/control
-    model fingerprint
-    controlled revision ID, when applicable
-    scope/applicability at time of use
-```
-
-External evidence is generally reusable across model versions as long as each `EvidenceUse` independently re-establishes scope and applicability; only structural evidence derived directly from Arcogine's own model state naturally collapses the two into one record. Initial adapters should be driven by a concrete requirement, not a desire to match a vendor's integration count.
-
-Operational observations sourced through the sibling Operational Execution capability keep their operational observation ID, source/time/trust provenance, and lifecycle. PLAN-GOV-5 references those facts as `Evidence`; it does not re-ingest them, add a source-level revision binding, or create a second telemetry identity.
+Produce a reproducible historical projection over exact semantic state, controlled revision, requirement/assertion versions, evidence/evidence use, findings, decisions/exceptions, and mappings where applicable.
 
 ### Acceptance criteria
 
-PLAN-GOV-5 is ready when:
+1. a historical result can be reconstructed from exact versioned inputs;
+2. the system can explain pass/fail/unknown and supporting evidence;
+3. evidence/exception applicability periods remain attributable;
+4. later requirement/assertion/source/mapping changes do not silently reinterpret old snapshots; and
+5. a reviewer can traverse from requirement/assertion through source, affected semantic state, evidence, finding, decision, and revision history.
 
-1. External evidence is distinguishable from Arcogine-derived structural evidence.
-2. Evidence is attributable to source and observation time, independent of any model fingerprint or revision.
-3. An assertion can combine intended model state with observed external state.
-4. An `EvidenceUse` can become stale/invalid when its scope, applicable period, or affected semantics change, without invalidating the underlying `Evidence` record for other uses.
-5. A historical evaluation can identify the evidence set (and the `EvidenceUse` bindings) it relied on.
-6. A pre-existing operational observation can be referenced as evidence without changing its operational identity or provenance.
+## 9. End-to-end milestone
 
-## 10. PLAN-GOV-6 — Governed change and external workflow integration
+The next meaningful Governance milestone is:
 
-### Goal
+> Take one proposed semantic change with an authoritative controlled revision and ChangeSet, select a real versioned requirement/assertion, evaluate it before authorization, attach explicit evidence/evidence use, record a separate authorization decision and external workflow reference where applicable, and later reconstruct why that revision was accepted or rejected.
 
-Connect semantic `ChangeSet`s, candidate controlled revisions, and technical evidence to enterprise change-management workflows without recreating Jira inside Arcogine or absorbing operational deployment mechanics.
+Deployment is not required to prove this milestone; future Operational application remains a sibling responsibility.
 
-Target relationship:
+## 10. Cross-track rules
 
-```text
-External issue / change request
-        |
-        v
-Arcogine ChangeSet
-        |
-        v
-Candidate controlled revision
-        |
-        +--> semantic impact
-        +--> validation/simulation/conformance evidence
-        +--> required approvals/owners
-        |
-        v
-Authorization decision/evidence
-required by applicable change-control policy
-(e.g. ApprovalRecord, standing authorization,
-pre-approved standard change, emergency
-justification, automated policy)
-        |
-        v
-Operational deployment record, when deployed
-```
+- Factory/other domains own their semantic models and supply typed comparison/evidence where required.
+- Engine runtime observations/events are not Governance evidence records by default.
+- Future Operational external observations may be referenced through EvidenceUse without Governance ingesting telemetry or inferring subject correspondence.
+- Implemented Governance contracts must be consumed by downstream tracks; fixtures may stand in only for genuinely unimplemented sibling-owned inputs.
 
-### Authority boundary
+## 11. Non-goals
 
-Jira or another workflow system may remain authoritative for issue workflow, assignments, discussions, and transitions. Arcogine retains the stable external reference and the technical/governance facts required to explain the semantic change and its resulting revision.
+Do not build broad framework libraries, auditor marketplaces, questionnaire automation, generic policy generation, trust-center surfaces, a monolithic business-object graph, a replacement for Jira/change-management systems, generic Git branch/merge semantics, telemetry ingestion, production commands, or digital-twin reconciliation merely to advance this plan.
 
-External change references are separate associations/provenance records, not immutable identity fields of `ControlledRevision`.
+## 12. Documentation/ADR rule
 
-If Arcogine later owns an authorization decision itself, that decision must be modeled explicitly with actor, authority, and provenance rather than inferred from mutable UI state.
+Update architecture/current-state docs only when capabilities land. Add an ADR only when implementation commits to a durable hard-to-reverse semantic/protocol/persistence contract not already governed by existing ADRs.
 
-The Operational Execution capability owns applying the authorized revision to a target, adapter/profile/transformation provenance, effective applied-artifact/external-version identity, operational verification/result facts, and reconciliation. PLAN-GOV-6 owns the governed-change/authorization interpretation and references that operational deployment record when it exists.
-
-### Acceptance criteria
-
-PLAN-GOV-6 is ready when:
-
-1. A `ChangeSet`/revision can reference an external change request through a separate association/provenance relationship.
-2. Impact and conformance information can be surfaced into the change workflow.
-3. Approval/authorization records reference the relevant controlled revision rather than defining revision identity.
-4. Operational deployment, when it occurs, is separately attributable to the deployed revision through a referenced Operational Execution deployment record.
-5. Governance does not duplicate target adapter/application/effective-artifact mechanics owned by Operational Execution.
-6. External project-management metadata is not duplicated without semantic need.
-7. A reviewer can trace a governed model transition back to the external record that tracked/governed the change.
-
-## 11. PLAN-GOV-7 — Exceptions and risk acceptance
-
-### Goal
-
-Represent explicit governance decisions when a known non-conformance is tolerated temporarily or conditionally.
-
-```text
-Finding
-Remediation
-Exception
-RiskAcceptance
-CompensatingControl
-Expiration
-```
-
-An approved exception does not change a failed assertion into `PASS`; it changes the governance disposition of the finding.
-
-### Acceptance criteria
-
-PLAN-GOV-7 is ready when:
-
-1. Findings retain their factual conformance result independently of disposition.
-2. Exceptions have rationale, accountable owner/approver, and effective/expiration periods.
-3. Expired exceptions become visible without rewriting history.
-4. Compensating controls/evidence can be linked when used.
-
-## 12. PLAN-GOV-8 — Controls and framework mappings
-
-### Goal
-
-Introduce conventional compliance abstractions only after generic conformance and evidence are working.
-
-```text
-Framework
-  -> Requirement
-      -> satisfied by Control
-          -> implemented by business semantics/process/policy
-          -> verified by Assertions
-          -> supported by Evidence
-```
-
-One control may map to multiple frameworks. Framework versions and mappings must be historically attributable so an old audit is not silently reinterpreted through today's mapping.
-
-### First framework policy
-
-Do not attempt broad framework coverage. Select one small, legally permissible set of requirements sufficient to prove cross-framework mapping and evidence reuse. Review licensing and source terms before importing copyrighted or proprietary control text.
-
-### Acceptance criteria
-
-PLAN-GOV-8 is ready when:
-
-1. Requirements and controls are versioned independently of business model revisions/fingerprints.
-2. One control can map to more than one requirement/framework.
-3. Business objects do not acquire framework-specific compliance booleans.
-4. Framework/mapping changes do not mutate historical evaluations.
-5. Evidence reuse respects scope, time, and semantic compatibility.
-
-## 13. PLAN-GOV-9 — Audit snapshots and compliance projections
-
-### Goal
-
-Produce a reproducible audit/compliance view over exact semantic state, controlled revision history, requirements, controls, evidence, findings, and exceptions.
-
-An audit snapshot should identify:
-
-```text
-model fingerprint
-controlled revision ID
-requirement identity/version
-assertion identity/version
-requirement source identity/version
-framework/mapping version, when applicable
-control mappings
-assertion results
-supporting evidence
-findings
-exceptions/risk acceptances
-generation time
-```
-
-The first useful UX can be headless/export-oriented. Do not build a large GRC dashboard before the historical semantics work.
-
-### Acceptance criteria
-
-PLAN-GOV-9 is ready when:
-
-1. A historical compliance result can be reconstructed from explicit versioned inputs, including the Arcogine requirement/assertion identities and versions and the exact external requirement source identity that governed the evaluation, when applicable.
-2. The system can explain why a control passed, failed, or was unknown.
-3. Evidence and exceptions are traceable to sources and applicable periods.
-4. A change in today's Arcogine requirement/assertion versions, framework mapping, or source standard edition does not silently alter a previous audit snapshot.
-5. A reviewer can traverse from a versioned requirement and assertion to the governing source, control, affected business objects, semantic fingerprint, controlled revision, evidence, and change history.
-
-## 14. First end-to-end milestone
-
-The first milestone should deliberately avoid a full external compliance framework:
-
-> **Take a proposed semantic change to an Arcogine model, derive its candidate fingerprint, persist a controlled revision linked through a separate association to an external change request, evaluate one Arcogine-native requirement before authorization/deployment, record the authorization decision separately, and reconstruct why the resulting semantic state was considered conformant.**
-
-PLAN-GOV-1 supplies the durable fingerprint, authoritative controlled revision, and exact historical-state prerequisites for this milestone, PLAN-GOV-2's initial slice supplies semantic change attribution and affected-entity identification, PLAN-GOV-3 supplies a registered, versioned requirement whose scope can match that affected-entity identification, and PLAN-GOV-4's initial slice now supplies deterministic pre-change assertion evaluation and findings (`PreChangeConformanceProvingCaseTest`). The milestone remains outstanding because PLAN-GOV-5/PLAN-GOV-6 must still provide evidence-use semantics and separate workflow/authorization records; PLAN-GOV-4 also does not yet provide durable persistence of evaluation results across later changes.
-
-Definition of done:
-
-```text
-Durable semantic fingerprint contract exists                         [PLAN-GOV-1 complete]
-Controlled revision identity exists                                 [PLAN-GOV-1 complete]
-Authoritative controlled revision persistence exists                 [PLAN-GOV-1 complete]
-Exact historical semantic state is resolvable                        [PLAN-GOV-1 complete]
-Base revision -> ChangeSet -> candidate revision is attributable      [PLAN-GOV-2 complete]
-Affected entity is identified                                        [PLAN-GOV-2 complete]
-One versioned requirement applies                                    [PLAN-GOV-3 complete]
-Pre-change assertion evaluates deterministically                      [PLAN-GOV-4 complete]
-Finding is produced if violated                                       [PLAN-GOV-4 complete]
-External change-request provenance can be linked separately           [PLAN-GOV-6+]
-Authorization is a separate record referencing the revision           [PLAN-GOV-6+]
-Deployment is not required to prove the milestone
-Historical evaluation remains attributable after later changes        [PLAN-GOV-5+]
-No framework-specific field exists on the business object
-```
-
-A concrete example could be an ownership requirement once the relevant owner/authority semantics exist.
-
-## 15. What not to build yet
-
-Do not prioritize:
-
-- dozens of compliance frameworks;
-- hundreds of SaaS integrations;
-- auditor marketplaces or certification workflow;
-- questionnaire automation;
-- generic policy-document generation;
-- trust-center marketing surfaces;
-- broad vendor-risk management;
-- a monolithic cross-domain business object graph;
-- generic Git branch/merge/rebase semantics for models without a concrete workflow;
-- a replacement for Jira or another organizational change-management system;
-- telemetry ingestion, production command execution, target adapter/application logic, or digital-twin reconciliation inside Governance.
-
-Those may become valid product capabilities later, but they should not distract from the semantic substrate that differentiates Arcogine.
-
-## 16. Documentation and ADR updates as work lands
-
-As implementation progresses:
-
-- [`../architecture/overview.md`](../architecture/overview.md) records PLAN-GOV-1's established current-state behavior;
-- [`governance-continuity.md`](governance-continuity.md) records the implemented PLAN-GOV-1-3 persistence/resolution mechanism and downstream continuity constraints;
-- keep [ADR-0004](../architecture/decisions/0004-model-identity-revision-lineage-and-external-change-control.md) as the authority for semantic identity vs. revision identity and the external change-control boundary;
-- keep [ADR-0006](../architecture/decisions/0006-durable-semantic-fingerprint-contract.md) as the authority for the durable semantic fingerprint contract;
-- keep [ADR-0008](../architecture/decisions/0008-controlled-revision-identity-and-lineage.md) as the authority for controlled revision identity, current lineage cardinality, rollback, recording provenance, immutability, and the persistence boundary;
-- no PLAN-GOV-1-3 ADR was added because the current filesystem adapter is replaceable infrastructure and the semantic artifact format is already governed by ADR-0006;
-- create a follow-up ADR if a future implementation commits to a hard-to-reverse production persistence, artifact-resolution, migration, retention, or revision-record-integrity contract;
-- update factory/domain architecture docs when later identity/change requirements alter those models;
-- update the sibling [Operational Execution and Digital Twin Readiness](operational-execution-digital-twin-readiness.md) when PLAN-GOV-2/PLAN-GOV-4/PLAN-GOV-5 contract availability changes its blocked/fixture-backed criteria;
-- update [`../architecture/standards-alignment.md`](../architecture/standards-alignment.md) when Arcogine moves from reference/mapping toward an actual tested conformance profile;
-- create later lineage ADRs only when concrete branch/ref/multi-parent merge semantics are required;
-- create ADRs for semantic `ChangeSet` contracts, temporal evidence semantics, and hard-to-reverse external protocols when implementation commits to them;
-- update product/reference docs only for capabilities that actually ship.
-
-Once this initiative is complete or superseded, retain durable decisions in ADR/current architecture and retire or reduce this planning artifact.
+Untriggered lineage/source-control extensions and Operational ontology questions remain outside this implementation plan until concrete research/architecture work promotes them.

--- a/docs/planning/governance-continuity.md
+++ b/docs/planning/governance-continuity.md
@@ -1,195 +1,55 @@
-# Governance PLAN-GOV-1 Continuity Notes
+# Governance Identity/History Downstream Compatibility Guard
 
-> **Status:** PLAN-GOV-1 complete; continuity note retained for downstream Governance work  
-> **Scope:** Record the implemented PLAN-GOV-1 identity/history substrate and the interpretation later Governance gates must preserve  
-> **Authority:** This note does not supersede ADR-0004, ADR-0006, ADR-0008, the Governance architecture, or the Governance capability plan.  
-> **Related:** [Governance and Conformance Capability Plan](governance-conformance-capability.md), [Governance and Conformance Architecture](../architecture/governance-conformance.md), [Standards Alignment](../architecture/standards-alignment.md)
+> **Status:** PLAN-GOV-1 complete; this file exists only to protect downstream implementation from reopening or absorbing the completed identity/history core  
+> **Scope:** Implementation invariants for later Governance/Engine/Operational work that references controlled revisions  
+> **Authority:** Planning guard only; accepted ADRs and current architecture own the durable semantics
 
-## 1. PLAN-GOV-1 completion state
+## Completed substrate
 
-The repository now has the complete PLAN-GOV-1 substrate:
+PLAN-GOV-1 supplies:
 
-- PLAN-GOV-1-1: ADR-0006 and `factory-model:v1` provide durable `ModelFingerprint` semantics;
-- PLAN-GOV-1-2: `ControlledRevisionId`, immutable `ControlledRevision`, current `0..1` parent lineage, rollback-as-new-revision semantics, and minimum recording provenance are implemented;
-- PLAN-GOV-1-3: authoritative controlled-revision acceptance, durable history, repository-level parent integrity, and exact historical semantic-artifact resolution are implemented.
+- durable semantic `ModelFingerprint` semantics;
+- opaque `ControlledRevisionId` historical identity;
+- immutable controlled revision values with current zero-or-one parent lineage;
+- recording provenance;
+- authoritative append-only acceptance;
+- durable reopenable history;
+- exact historical semantic-artifact resolution; and
+- explicit integrity failures for duplicate/missing/corrupt/mismatched state.
 
-The authoritative chain is now executable across process/reopen boundaries:
-
-```text
-ControlledRevisionId
-    -> one immutable accepted ControlledRevision
-    -> explicit valid parent lineage
-    -> one durable ModelFingerprint
-    -> immutable recording provenance
-    -> exact immutable canonical semantic artifact
-```
-
-A `ControlledRevision` value merely constructed in JVM memory is still not authoritative. Authority begins only when `ControlledRevisionAuthority.accept(...)` succeeds.
-
-## 2. PLAN-GOV-1 closure remains a compatibility boundary for downstream records
-
-Later authorization, deployment, result, conformance, evidence, and workflow records may reference `ControlledRevisionId`, but they do not define revision identity and were not circular prerequisites for PLAN-GOV-1 closure.
-
-The dependency direction remains:
-
-```text
-PLAN-GOV-1 durable identity + authoritative history
-        |
-        +--> later ChangeSet / impact records
-        +--> later conformance / evidence records
-        +--> later authorization / exception records
-        +--> later deployment / reconciliation records
-```
-
-The immutable controlled-revision core therefore remains limited to historical identity, fingerprint binding, lineage, and recording provenance. External workflow references, labels/tags, `ChangeSet`, authorization, deployment, conformance/evidence, and framework mappings remain separate records.
-
-## 3. Configuration-management and GRC standards relationship
-
-Arcogine's Governance substrate supports disciplined configuration identification and status/history accounting, but it is not itself a certification or compliance claim.
-
-A useful conceptual mapping remains:
-
-```text
-configuration identification
-        -> ModelFingerprint
-        -> ControlledRevisionId
-
-configuration status accounting
-        -> authoritative controlled revision history
-        -> explicit parent lineage
-        -> recording provenance
-
-change control
-        -> later ChangeSet / impact / authorization / workflow records
-
-configuration audit / governance verification
-        -> later requirements / assertions / evaluations / evidence / findings
-```
-
-ISO 10007:2017 remains a useful configuration-management reference; NIST SP 800-53 Rev. 5 CM-3 remains a useful change-control reference; ISO/IEC 27001:2022 remains relevant only as an organizational management-system context. PLAN-GOV-1 does not make Arcogine or any organization conformant, compliant, or certified under those standards.
-
-Git-like history is also not the entire Governance ontology. PLAN-GOV-1 supplies the horizontal immutable configuration-history dimension. PLAN-GOV-2+ add the vertical governance dimensions: change rationale, requirements/conformance, evidence/findings, authorization/exception, and deployment/operational facts.
-
-## 4. PLAN-GOV-1-3 implementation outcome
-
-### 4.1 Identity semantics were not reopened
-
-PLAN-GOV-1-3 preserves ADR-0008 exactly:
-
-- `ControlledRevisionId` remains opaque UUIDv4 historical identity;
-- revision identity remains independent of `ModelFingerprint`;
-- every revision references exactly one fingerprint;
-- distinct revisions may legitimately share one fingerprint;
-- current lineage remains zero or one parent;
-- rollback/reversion creates a new revision and may reuse an earlier fingerprint;
-- accepted ID, fingerprint, lineage, `recordedAt`, and recorder are immutable;
-- multi-parent merge semantics, branch/ref/tag semantics, ChangeSets, authorization, deployment, conformance/evidence, and framework mappings remain outside PLAN-GOV-1.
-
-The historical `F1 -> F2 -> F1` case is explicitly covered: the first and third revisions are distinct historical occurrences even though they resolve to the same durable semantic content.
-
-### 4.2 Authoritative acceptance boundary
-
-`:governance` now owns the `ControlledRevisionAuthority` contract. Its acceptance operation is distinct from value construction and exposes supported lookup, deterministic history iteration, and historical resolution.
-
-The first durable adapter is `FileControlledRevisionAuthority`. It is deliberately a narrow JDK-filesystem implementation rather than a production database commitment because the repository had no pre-existing persistence infrastructure to reuse.
-
-Its authority root contains private, versioned storage records conceptually equivalent to:
-
-```text
-authority-root/
-    authority.lock
-    revisions/<ControlledRevisionId>.revision
-    artifacts/<internal fingerprint-derived key>.artifact
-```
-
-The artifact path key is only a physical adapter detail. The complete `ModelFingerprint` remains the semantic-content identity and is persisted in both the revision/artifact relationship where required.
-
-Revision acceptance is append-only. An existing revision ID is never overwritten, including when the submitted immutable record is otherwise equal. Rebinding the same ID to different immutable content fails deterministically.
-
-### 4.3 Parent and concurrency integrity
-
-A non-root revision may be accepted only after its named parent is already authoritative. A missing parent fails explicitly; self-parenting remains rejected by the PLAN-GOV-1-2 value invariant. Because accepted history is append-only and a parent must pre-exist its child, cycles are structurally unavailable under the current `0..1` model without introducing graph machinery.
-
-Acceptance is serialized by the authority's process lock and durable filesystem lock. Duplicate-ID validation occurs inside that lock and the revision record is installed with an atomic filesystem move, so concurrent conflicting acceptance attempts cannot produce two authoritative bindings.
-
-### 4.4 Semantic artifact storage and exact reconstruction
-
-PLAN-GOV-1-3 reuses ADR-0006's existing released `factory-model:v1` canonical bytes rather than defining a second model serialization format. `FactoryModelArtifactV1` exposes the factory-domain artifact boundary for:
-
-- encoding a published `FactoryModelVersion` to its canonical bytes;
-- strict decoding back to the exact semantic model state;
-- recomputing the durable `ModelFingerprint` from stored bytes.
-
-The decoder validates the policy prefix, counts, UTF-8, optional floating-point representation, complete input consumption, and canonical re-encoding. A decodable-but-noncanonical artifact is rejected rather than reinterpreted.
-
-The filesystem authority stores immutable semantic artifacts separately from revision records and naturally deduplicates repeated fingerprints. Therefore `Revision A -> F1`, `Revision B -> F2`, `Revision C -> F1` produces three revision records and two immutable semantic artifacts.
-
-Historical resolution is:
+The authoritative chain is:
 
 ```text
 ControlledRevisionId
-    -> ControlledRevision
-    -> recorded ModelFingerprint
+    -> immutable accepted ControlledRevision
+    -> explicit parent lineage
+    -> ModelFingerprint
     -> exact canonical semantic artifact
-    -> FactoryModelArtifactV1.decode(...), for the current factory proving ground
 ```
 
-It never consults whichever factory model happens to be current in memory.
+Constructing a value in memory does not create authoritative history. Authority begins only at the accepted Governance authority boundary.
 
-### 4.5 Fingerprint verification and consistency strategy
+## Invariants downstream implementations must preserve
 
-Before authority acceptance commits a revision, the supplied artifact must be supported by the configured semantic-artifact verifier, its declared fingerprint must equal the revision fingerprint, and recomputing the durable fingerprint from the canonical bytes must reproduce that same `ModelFingerprint`.
+1. Semantic-content identity and historical-revision identity remain distinct.
+2. Equal semantic content may appear in several distinct controlled revisions.
+3. Rollback/reversion is a new historical occurrence and may reuse an earlier fingerprint.
+4. Accepted revision ID, fingerprint, lineage, and recording provenance are immutable.
+5. Authorization, deployment, conformance, evidence, labels, external workflow references, and semantic ChangeSets remain separate records/relationships.
+6. Historical resolution uses the recorded immutable artifact, never whichever model happens to be current in memory.
+7. A named parent must already be authoritative under the current lineage capability.
+8. Revision acceptance must never expose a partially authoritative record.
 
-The adapter installs/verifies the immutable artifact before atomically installing the revision record. The revision-record atomic move is the authoritative commit point. Normal failure removes a newly staged artifact before returning. A process failure between artifact installation and revision commit can leave only an unreferenced immutable artifact; it cannot leave an authoritative revision that precedes its artifact. Unreferenced artifacts are not controlled revisions and do not make history authoritative.
+## Current adapter boundary
 
-The implementation therefore avoids a generic transaction framework while preserving the PLAN-GOV-1 invariant that no partially accepted revision is exposed.
+`FileControlledRevisionAuthority` is the current durable adapter proving restart/reopen, atomic append-only acceptance, integrity behavior, and exact artifact resolution.
 
-### 4.6 Restart durability and corruption behavior
+Its directory layout, binary record format, lock mechanics, and physical artifact key are replaceable implementation details. They are not a selected production database/storage architecture.
 
-Reopening a new `FileControlledRevisionAuthority` over the same authority root reconstructs accepted revision metadata, provenance, lineage, and semantic artifacts from durable files. Reopen tests prove that this is not process-memory persistence.
+A hard-to-reverse production persistence/migration/retention/integrity choice requires its own architecture decision when such a concrete implementation is admitted.
 
-Integrity failures are typed at the Governance boundary. At minimum the implementation distinguishes:
+## Downstream use
 
-- duplicate revision ID;
-- missing parent;
-- missing revision;
-- missing artifact;
-- fingerprint mismatch;
-- unsupported artifact policy;
-- storage-integrity failure.
+Later Governance evidence/governed-change work, Engine optional revision provenance, and future Operational deployment/reconciliation may reference authoritative `ControlledRevisionId` values. They must consume this substrate rather than create alternate revision identity/history.
 
-Stored revision metadata that cannot be decoded fails explicitly. Missing artifacts fail explicitly. Stored artifacts are reverified during resolution; malformed/corrupt artifacts or fingerprint disagreement fail instead of silently substituting current state, another revision, or repaired content. The authority also refuses to use acceptance of a later same-fingerprint revision as an implicit repair for an already-accepted revision whose artifact has gone missing.
-
-### 4.7 Persistence technology / ADR decision
-
-No new ADR was required for PLAN-GOV-1-3.
-
-The filesystem authority is the smallest current adapter that proves durable reopen semantics, atomic append-only authority, concurrent uniqueness, corruption handling, and canonical artifact resolution without introducing an external service. Its binary record layout, directory names, lock mechanics, and fingerprint-derived physical artifact key are private implementation details rather than a selected production persistence architecture.
-
-The durable semantic artifact itself is not a new format: it is the already accepted ADR-0006 `factory-model:v1` canonical representation. A future PostgreSQL, document, event-store, object-store, or other adapter can implement the same Governance authority contract without changing `ControlledRevisionId` or `ModelFingerprint` semantics. A future hard-to-reverse production storage/migration/retention contract should receive its own ADR when selected.
-
-## 5. PLAN-GOV-1 completion evidence
-
-PLAN-GOV-1 is complete because executable tests now prove, together with the unchanged PLAN-GOV-1-1/PLAN-GOV-1-2 suites:
-
-- durable root acceptance and reopen/restart lookup;
-- immutable ID-to-record binding and deterministic duplicate/rebind rejection;
-- existing-parent acceptance, missing-parent rejection, and self-parent rejection;
-- three distinct historical occurrences for `F1 -> F2 -> F1` and legitimate same-fingerprint revisions;
-- exact historical semantic reconstruction independent of current model state;
-- resolved-artifact fingerprint equality with the recorded `ModelFingerprint`;
-- mismatch rejection and explicit missing/corrupt-artifact failures;
-- exact immutable provenance persistence;
-- failure without partially authoritative revision state;
-- concurrent conflicting duplicate-ID acceptance with exactly one authoritative winner;
-- deterministic exposed history ordering;
-- first-run/reopen durability;
-- unchanged PLAN-GOV-1-1/PLAN-GOV-1-2 identity/value invariants.
-
-The Java quality gate required by `AGENTS.md` passes with compilation, test compilation, Checkstyle, full tests, JaCoCo reporting, and JaCoCo coverage verification.
-
-## 6. What remains deferred
-
-PLAN-GOV-1 completion deliberately does **not** implement PLAN-GOV-2+ concerns: semantic `ChangeSet`, requirements/assertions, conformance evaluation, Evidence/EvidenceUse/findings, authorization/approval workflow, deployment, external workflow integration, labels/tags/branches, multi-parent merges, generic source control/event sourcing, framework mappings, operational telemetry/reconciliation, simulation event persistence, or challenge attempt history.
-
-Those capabilities can now reference stable durable `ControlledRevisionId` values and resolve exact historical semantic state without expanding the immutable revision core.
+This file contains no open lineage/source-control research programme. Branch/ref/tag/multi-parent semantics are not implementation work until a concrete workflow is promoted through the normal research/architecture/planning boundary.

--- a/docs/planning/operational-execution-digital-twin-readiness.md
+++ b/docs/planning/operational-execution-digital-twin-readiness.md
@@ -1,406 +1,48 @@
-# Operational Execution and Digital Twin Readiness
+# Operational Execution and Digital-Twin Implementation Admission
 
-> **Status:** Proposed; PLAN-OPS-1 is architecture-blocked pending revision of ADR-0013  
-> **Scope:** Establish the semantic and safety boundaries required before Arcogine can connect its shared production semantics to independently existing operational systems  
-> **Authority:** Planning only; this document defines readiness dependencies and future implementation sequencing, not current production capability  
-> **Related:** [Operational Execution and Digital Twin Architecture](../architecture/operational-execution-digital-twin.md), [ADR-0013: Durable operational identity](../architecture/decisions/0013-execution-context-identity.md), [Product Charter](../product/charter.md), [Architecture Overview](../architecture/overview.md), [Factory Design Architecture](../architecture/factory-design.md), [Governance and Conformance Architecture](../architecture/governance-conformance.md), [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md), [Runtime Observation and Event Delivery](runtime-observation-event-delivery.md), [Governance and Conformance Capability](governance-conformance-capability.md)
+> **Status:** NOT ADMITTED — no Operational implementation slice is currently safe to execute  
+> **Scope:** Record the concrete admission conditions for future Operational work without embedding unresolved architecture in delivery planning  
+> **Authority:** Planning only; unresolved semantics live in research and Proposed architecture/ADRs
 
-## 1. Purpose
+## Current landed dependencies
 
-Arcogine's executable core is simulation-first. This track applies requirements pressure from future digital-twin and real-system use without creating a parallel operational ontology or prematurely building a production-control platform.
+The following reusable substrate is available and must be consumed rather than duplicated:
 
-The target is continuity across synthetic, hybrid, and externally grounded realization of the same semantic model:
+- canonical published production-system semantics from Factory Design;
+- durable semantic fingerprint and controlled-revision identity/history from Governance;
+- Governance semantic change/impact, requirement/assertion, and initial conformance/finding contracts;
+- Engine runtime observation/event core and deterministic simulation semantics.
 
-```text
-Published production semantics
-        ↓
-Governed semantic identity / revision when applicable
-        ↓
-Subjects, operations, state transitions
-        ↓
-Synthetic and/or external realization
-        ↓
-External observations with independent provenance
-        ↓
-Authoritative subject correspondence
-        ↓
-Reconciliation
-        ↓
-Drift / calibration feedback
-```
+Operational Execution itself remains unimplemented.
 
-The earlier plan treated a global execution context (`PRODUCTION / STAGING / SIMULATION`) as the first foundation. Architecture review has rejected that premise. Hybrid execution is expected: one modeled system can simultaneously contain synthetic subjects, externally observed subjects, physically controllable subjects, real actors, synthetic agents, and historical inputs.
+## Why no implementation slice is admitted
 
-The track therefore proceeds from relational requirements — identity, correspondence, realization, trust, evidence, consequence, and reconciliation — rather than from one global environment kind.
+ADR-0013 still has no accepted equality/lifecycle rule for the durable operational-history identity. Other shared boundaries—actor/capability ownership, external operation realization, authoritative subject correspondence, and temporal reconciliation—must also be resolved only to the extent required to define a concrete safe slice.
 
-## 2. Current repository grounding
+Those questions are tracked in [Operational Execution and Digital-Twin Boundary Research](../research/operational-execution-digital-twin-boundaries.md) and the [Agency and Decision Boundary investigation](../research/agency-decision-boundary.md), not here.
 
-The relevant landed baseline is:
+## Constraints any future implementation must preserve
 
-- Factory Design provides the canonical shared production-system semantics.
-- Governance durable fingerprint/revision identity and history are implemented and authoritative.
-- Governance semantic change/impact, requirement/assertion, and initial conformance/finding contracts are implemented and should be consumed rather than duplicated.
-- Governance evidence-use/authorization capabilities remain outstanding where required.
-- Engine runtime observation/event core/headless closure is complete.
-- `RunId` identifies one simulation runtime epoch and is not the future durable operational-history identity.
-- `EngineSemanticsVersion` identifies result-affecting Engine interpretation and remains Engine-owned.
-- Operational Execution remains unimplemented.
-- ADR-0013 is Proposed and on architecture-review hold; its former `ExecutionContextKind` contract is not an implementation target.
+Any promoted Operational slice must preserve:
 
-## 3. Converged architecture constraints
+- one shared semantic production model rather than a simulation-only/production-only fork;
+- no global `PRODUCTION / STAGING / SIMULATION` or equivalent whole-execution taxonomy;
+- independently provenanced raw external observations;
+- explicit external-subject to Arcogine-subject correspondence rather than identity inference from names/endpoints/configuration;
+- requested operation, external command/result, actual transition, observation, and reconciled interpretation as distinct facts;
+- verified identity/trust/authority and fail-safe behavior where external consequence requires them;
+- Governance-owned revision/change/conformance/evidence-use contracts where applicable;
+- Engine-owned simulation semantics and provenance rather than a parallel Operational simulator.
 
-The readiness sequence must preserve these constraints:
+## Promotion criteria
 
-1. **One semantic model.** Synthetic and externally grounded execution reuse the same domain semantics rather than forking simulation-only and production-only models.
-2. **No global simulation/production taxonomy.** `PRODUCTION / STAGING / SIMULATION` and a replacement `SIMULATION / OPERATIONAL` binary are not durable whole-execution kinds.
-3. **Hybrid composition is normal.** Reality relationship, trust, authority, and consequence can differ by subject and relationship inside one execution.
-4. **Digital twin is relational.** Twin-ness comes from authoritative relationships between modeled subjects and independently existing subjects, observations, provenance, and reconciliation.
-5. **Operations and transitions are not transport concepts.** The same semantic operation can have synthetic or external realization. Requested operation, accepted command, actual transition, observation, and reconciled interpretation remain distinct.
-6. **External observations are independent facts.** They retain their own source/subject/time/quality/trust provenance and need not invent Arcogine model, revision, or operational-history identity at ingestion.
-7. **Subject correspondence is explicit.** Arcogine must never infer physical/external identity from matching names, endpoints, namespaces, configuration, or connector topology.
-8. **Authorization semantics are not inherently operational.** Actor/action/capability semantics should be usable in synthetic execution; verified external identity, trust roots, physical safety, and consequence are additional real-world requirements.
-9. **Replay is not a context kind.** Seek/reconstitution, replay, checkpoint/restore, and fork are distinct capabilities.
-10. **No new higher-rank execution ID yet.** A concept above `RunId` requires a proven lifecycle/equality rule before introduction.
+The first Operational delivery coordinate may be created only after:
 
-## 4. Readiness sequence under architecture review
+1. the exact semantic referent of the proposed slice is settled;
+2. any required ADR is Accepted or otherwise no longer an implementation blocker;
+3. module/track ownership is known and does not duplicate Factory, Engine, Governance, or shared actor semantics;
+4. prerequisites are explicit and landed or deliberately fixture-backed;
+5. failure/safety semantics are explicit for consequential behavior; and
+6. executable acceptance evidence is defined.
 
-The previous linear sequence remains useful as a list of concerns but is **not currently an implementation queue**:
-
-```text
-PLAN-OPS-1  Durable operational identity
-PLAN-OPS-2  Actor, trust, authority, and capability boundary
-PLAN-OPS-3  External operation / command-result lifecycle
-PLAN-OPS-4  Deployment target and deployment-record semantics
-PLAN-OPS-5  External observation ingestion and provenance
-PLAN-OPS-6  Modeled-versus-observed reconciliation
-PLAN-OPS-7  Divergence, drift, and calibration feedback
-PLAN-OPS-8  Operational resilience / recovery semantics
-PLAN-OPS-9  First live-system adapter proving ground
-```
-
-Do not interpret adjacency in this list as proof that every item is a strict prerequisite for the next. Architecture review may redistribute shared semantics across Factory, Engine, Governance, and Operational ownership before implementation begins.
-
-The only immediate critical-path work for this track is resolving the durable identity question in ADR-0013 and reconciling downstream sequencing against the accepted result.
-
-## 5. PLAN-OPS-1 — Durable operational identity
-
-### Goal
-
-Define the identity needed by future durable operational records to distinguish one independently continuing operational history/partition from another without embedding a global reality/consequence kind.
-
-The identity must remain distinct from:
-
-```text
-RunId
-ModelFingerprint
-ControlledRevisionId
-actor identity
-target identity
-external subject identity
-```
-
-It must survive ordinary continuity events such as process restart and infrastructure replacement. If Arcogine supports deliberate independent continuation/forking, that divergence must not silently share one history identity.
-
-### Architecture blocker
-
-ADR-0013 must answer this before PLAN-OPS-1 can be implemented:
-
-> What exactly is the independently continuing operational history/partition that needs identity, and what makes two records belong to the same one versus different ones?
-
-The answer must survive at least:
-
-- restart;
-- active/passive failover;
-- disaster-recovery standby;
-- commissioning-to-production lifecycle change;
-- gaining or losing telemetry;
-- gaining or losing external control capability;
-- hybrid physical/synthetic composition;
-- several independent interpretations of one physical installation;
-- historical inspection without continuation;
-- deliberate divergent fork.
-
-Until that rule is explicit:
-
-- do not create `ExecutionContextKind`;
-- do not implement `PRODUCTION / STAGING / SIMULATION` context taxonomy;
-- do not create a replacement SIMULATION/OPERATIONAL kind;
-- do not create `OperationalScopeId`, `ExecutionId`, `RealizationId`, or another renamed identifier merely to unblock code;
-- do not create the formerly proposed minimal `:operational` module just to materialize identity types.
-
-### Retained constraints
-
-A future accepted identity should remain opaque, Arcogine-owned, explicitly established, and not inferred from profile/hostname/URL/deployment namespace/actor/target/run/revision/model identity. No central registry is required merely to state durable identity semantics.
-
-Raw external observations remain independent of this identity at ingestion.
-
-## 6. PLAN-OPS-2 — Actor, trust, authority, and capability
-
-### Goal
-
-Establish reusable semantics for who/what may perform which operation on which subject, while adding the stronger trust/assurance requirements needed when external consequence exists.
-
-Synthetic execution may legitimately require humans, autonomous agents, NPCs, adversaries, delegated roles, approvals, protected resources, and forbidden actions. Therefore PLAN-OPS-2 must not assume that actor/action/capability semantics are meaningful only in production operation.
-
-Future real-system use additionally requires:
-
-- claimed versus verified identity;
-- peer/source/target authenticity and trust basis;
-- credential/secret lifecycle;
-- least privilege;
-- revocation/expiry or equivalent loss of trust;
-- physical safety enforcement;
-- fail-safe behavior when verification or integrity fails.
-
-The exact module/domain ownership of the reusable actor/capability contract remains an architecture question. Operational should not manufacture a duplicate generic authorization model merely because it is the first consequential consumer.
-
-## 7. PLAN-OPS-3 — External operation / command-result lifecycle
-
-### Goal
-
-Represent external realization of semantic operations without confusing requests or adapter results with actual state transitions.
-
-The required distinction is:
-
-```text
-requested operation
-!= accepted command
-!= actual transition
-!= observation of transition
-!= reconciled interpretation
-```
-
-A future external operation lifecycle may require stable correlation/identity, actor and authority provenance, target identity/trust, requested/effective values, semantic source provenance, submission/acknowledgement facts, timeout/retry/idempotency rules, partial outcomes, cancellation/compensation where meaningful, and links to resulting evidence/reconciliation.
-
-The semantic operation/transition vocabulary should remain usable across synthetic and external realization where the meaning genuinely matches. Ownership of that shared contract must be decided before PLAN-OPS-3 introduces parallel operation semantics.
-
-## 8. PLAN-OPS-4 — Deployment target and deployment-record semantics
-
-### Goal
-
-Apply governed semantic intent to an external target while preserving the effective representation actually applied.
-
-Governance durable revision/history capability is already available and must be consumed.
-
-A deployment record eventually needs provenance for:
-
-- source model fingerprint and controlled revision when applicable;
-- external target identity;
-- transformation/mapping/profile identity/version;
-- material tool version;
-- rendered/applied artifact fingerprint or authoritative external applied reference;
-- authorization;
-- application acknowledgement;
-- verification outcome;
-- rollback/compensation reference where meaningful.
-
-Deployment identity is not the unresolved durable operational-history identity, model/revision identity, or target identity.
-
-## 9. PLAN-OPS-5 — External observation ingestion, provenance, and subject correspondence
-
-### Goal
-
-Ingest external facts with independent provenance and establish the authoritative correspondence needed before those facts can be interpreted as evidence about Arcogine semantic subjects.
-
-### Raw observation boundary
-
-A durable raw observation should be able to identify at least:
-
-- observation identity;
-- source system/identity;
-- source trust/authenticity provenance where applicable;
-- namespace-qualified external subject identity;
-- observed value/fact and unit/dimension where applicable;
-- source event/measurement time;
-- ingestion/receipt time;
-- quality/confidence metadata;
-- genuine command/deployment/run correlation when known;
-- raw-source reference where retention policy allows.
-
-Raw ingestion does not require an Arcogine operational-history identity, `ModelFingerprint`, or `ControlledRevisionId`.
-
-### Authoritative external-subject correspondence
-
-Before reconciliation can claim that an observation about an external subject is evidence about an Arcogine semantic subject, the track must provide an explicit correspondence responsibility equivalent to:
-
-```text
-external identity namespace + external subject
-                    ↕
-        authoritative correspondence
-                    ↕
-          Arcogine semantic subject
-```
-
-The future contract must address at least:
-
-- namespace-qualified external subject identity;
-- Arcogine semantic subject reference;
-- asserting/mapping authority;
-- mapping/profile version;
-- effective interval;
-- historical preservation;
-- explicit unknown/unmapped state;
-- conflict/replacement/alias semantics where required.
-
-Names, endpoints, configuration keys, namespace placement, and connector topology never prove identity.
-
-Subject correspondence answers which subjects correspond. It does not itself say how observations arrive or how operations are realized. Do not model it as `direction = observe | actuate`.
-
-Raw ingestion can exist before a subject is mapped, but reconciliation cannot assert modeled-versus-observed correspondence without an authoritative subject binding.
-
-## 10. PLAN-OPS-6 — Modeled-versus-observed reconciliation
-
-### Goal
-
-Produce historically attributable Arcogine interpretations of independently observed reality without overwriting modeled intent or pretending prediction is observation.
-
-PLAN-OPS-6 depends locally on:
-
-- PLAN-OPS-5 raw observation provenance; and
-- the authoritative subject-correspondence contract needed to state what an external observation is about in Arcogine terms.
-
-Reconciliation must eventually account for:
-
-- selected model fingerprint/controlled revision where applicable;
-- observations considered;
-- correspondence assertions used;
-- source authority/trust decisions;
-- freshness and temporal alignment;
-- reconciliation policy/version;
-- pending external operations/deployments;
-- match/pending/stale/missing/conflict/divergence/unknown semantics;
-- reproducibility/attribution of the interpretation.
-
-Modeled intent, external reality, observation, reconciled interpretation, and simulated/predicted continuation remain distinct.
-
-Late and corrected evidence creates requirements pressure for explicit valid/effective time versus knowledge/recorded time. Do not select a bitemporal persistence technology until the concrete history/query requirements justify it.
-
-## 11. PLAN-OPS-7 — Divergence, drift, and calibration feedback
-
-### Goal
-
-Turn modeled-versus-observed differences into governed improvement without directly mutating published semantics.
-
-Operational drift analysis should consume Governance-owned semantic `ChangeSet`/impact, requirement/assertion, conformance/finding, and later evidence-use contracts rather than duplicate them.
-
-The feedback path remains:
-
-```text
-modeled expectation + reconciled operational behavior
-        ↓
-drift/discrepancy analysis
-        ↓
-candidate calibration or semantic change
-        ↓
-validation / simulation / conformance
-        ↓
-controlled revision
-        ↓
-optional deployment
-```
-
-## 12. PLAN-OPS-8 — Operational resilience / recovery
-
-### Goal
-
-Define failure, idempotency, retry, recovery, trust-loss, and ambiguity semantics for whichever durable command/observation/correspondence contracts have actually been accepted.
-
-Do not design resilience against the withdrawn execution-context taxonomy.
-
-At minimum future consequential paths must preserve:
-
-- explicit idempotency/retry rules;
-- ambiguous outcomes as ambiguous;
-- fail-safe handling of unverifiable actors/sources/targets;
-- external rejection/partial failure visibility;
-- distinction between logical rollback and physical reversibility;
-- observation loss as unknown/stale rather than implicit success;
-- restart/recovery semantics consistent with the accepted durable operational identity.
-
-## 13. PLAN-OPS-9 — First live-system adapter proving ground
-
-### Goal
-
-Use one narrow real-system integration to prove the accepted semantic boundaries rather than letting a protocol define Arcogine's ontology.
-
-The proving case must demonstrate, as applicable:
-
-- external subject identity kept distinct from Arcogine subject identity;
-- authoritative subject correspondence;
-- observation mapping/provenance;
-- operation-realization mapping separately from subject correspondence;
-- verified actor/source/target trust where consequence requires it;
-- command/request/result separated from observed/reconciled reality;
-- model/revision and transformation provenance;
-- failure/idempotency/recovery behavior;
-- no dependence on a global simulation/staging/production kind.
-
-A protocol test server can prove adapter mechanics but does not by itself close the full track.
-
-## 14. Replay, seek, checkpoint, and fork
-
-These are intentionally not part of PLAN-OPS-1 context classification.
-
-The architecture distinguishes:
-
-- **seek/reconstitution** — obtain state at historical time;
-- **replay** — reconstruct/derive by consuming retained historical inputs or trace;
-- **checkpoint/restore** — resume runtime state;
-- **fork** — create an independently evolving continuation from selected historical state.
-
-The current Engine supported-event boundary does not promise unbounded retained history, and `EngineSemanticsVersion` does not promise permanent exact execution support for every historical version.
-
-Do not introduce a higher-rank execution identity until checkpoint/recovery or another concrete capability proves the lifecycle rule it would identify.
-
-## 15. Cross-track ownership cautions
-
-### Factory Design / Engine
-
-Factory/Engine remains authoritative for canonical production semantics and deterministic simulation runtime behavior. Operational requirements may reveal a reusable semantic operation/transition contract, but Operational must not create a duplicate merely to reach external systems.
-
-`EngineSemanticsVersion` remains Engine-owned interpretation provenance, including future Engine-driven prediction or virtual-commissioning simulation where applicable.
-
-### Governance
-
-Operational owns acquisition/provenance of external facts and reconciliation. Governance owns durable semantic revision/history, semantic change, requirements/assertions, conformance/findings, evidence use, exceptions, and governed change.
-
-External facts may become Governance evidence through explicit evidence-use relationships without changing their operational provenance.
-
-## 16. Fixture rules
-
-1. A fixture may stand in for a genuinely outstanding sibling-owned input; it does not define that sibling contract.
-2. Implemented Governance fingerprint/revision, semantic change/impact, requirement/assertion, and conformance/finding contracts must be consumed rather than recreated as synthetic production types.
-3. Synthetic evidence-use/authorization fixtures remain acceptable only while those Governance capabilities are genuinely outstanding and do not count as sibling completion.
-4. Synthetic operational adapters do not satisfy Engine distribution-hardening requirements.
-5. No fixture may reintroduce the withdrawn global execution-context taxonomy as if it were an accepted contract.
-
-## 17. Immediate next action
-
-Do **not** implement PLAN-OPS-1 yet.
-
-The next architecture step is:
-
-1. Resolve the exact referent and lifecycle/equality semantics of the durable operational-history identity.
-2. Revise ADR-0013 in place while it remains Proposed.
-3. Reconcile this readiness plan and the Operational architecture against the revised ADR.
-4. Only then identify the narrowest safe implementation slice.
-
-Other open architecture questions — shared operation/transition ownership, exact correspondence cardinality, and temporal twin history — should be investigated only where necessary to resolve or safely sequence the accepted contracts, not as open-ended framework design.
-
-## 18. Track exit condition
-
-Operational Execution / Digital Twin readiness is not complete until at least one proving path demonstrates that Arcogine can connect its semantic model to independently existing operational subjects without collapsing identities or truth sources.
-
-A mature exit condition includes:
-
-- accepted durable operational-history identity semantics;
-- actor/authority/trust semantics appropriate to consequential use;
-- external operation/command lifecycle separated from actual transitions and observations;
-- deployment/applied-artifact provenance;
-- raw external observations with independent source/subject/time provenance;
-- authoritative external-subject ↔ Arcogine-subject correspondence;
-- reconciliation that preserves modeled, observed, reconciled, and predicted distinctions;
-- drift/calibration feeding governed change rather than direct model mutation;
-- resilience/idempotency/recovery semantics;
-- a live-adapter proving case that demonstrates subject correspondence and operation realization as separate responsibilities;
-- no dependency on a global `PRODUCTION / STAGING / SIMULATION` execution kind.
+When those conditions are met, add the narrowest concrete implementation slice here. Do not restore the previous speculative multi-step Operational sequence merely as a roadmap placeholder.

--- a/docs/planning/runtime-observation-event-delivery.md
+++ b/docs/planning/runtime-observation-event-delivery.md
@@ -1,160 +1,39 @@
 # PLAN-ENG-4 Runtime Observation and Event Delivery
 
-> **Status:** Active implementation plan  
+> **Status:** Active implementation companion; PLAN-ENG-4-A/B/C are complete, PLAN-ENG-4-D outward consumer convergence remains outstanding  
 > **Owner:** Factory Simulation Engine Readiness / PLAN-ENG-4  
 > **Architecture authority:** [ADR-0011](../architecture/decisions/0011-runtime-observation-and-event-contract.md)  
-> **Parent plan:** [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)  
-> **Upstream execution identity:** [ADR-0010](../architecture/decisions/0010-intra-order-execution-decomposition-and-work-item-identity.md) / PLAN-ENG-W1  
-> **Session boundary:** [ADR-0007](../architecture/decisions/0007-consumer-neutral-session-control-primitives.md) / PLAN-ENG-3
+> **Parent plan:** [Factory Simulation Engine Readiness](factory-simulation-engine-readiness.md)
 
 ## 1. Purpose
 
-This file is the implementation/delivery companion for Engine Readiness PLAN-ENG-4. It records the execution order, code boundaries, acceptance evidence, transport migration, and cross-track responsibilities needed to implement ADR-0011 without turning event streaming into a separate Arcogine initiative.
+Implement ADR-0011 through a consumer-neutral Engine contract, then converge outward consumers on that contract without turning internal scheduler events or transport DTOs into domain semantics.
 
-Event streaming is not a new top-level track. Its semantic owner is Engine Readiness PLAN-ENG-4; transport recovery/versioning maturity remains Engine distribution hardening. Governance, Challenge/Game, and Operational Execution remain sibling or downstream tracks with their existing ownership boundaries.
-
-The core rule is:
+The core rule remains:
 
 > Internal events drive simulation. Supported observations expose current authoritative state. Supported runtime events expose ordered authoritative change. Transports only project those contracts.
 
-## 2. Current repository position
+## 2. Completed core
 
-As of 2026-09-01:
+### PLAN-ENG-4-A — Runtime identity and supported observation — COMPLETE
 
-- PLAN-ENG-1 is complete.
-- PLAN-ENG-2 is complete.
-- PLAN-ENG-3 is complete through `FactoryRuntime` and ADR-0007.
-- PLAN-ENG-W1 is complete through ADR-0010, the implemented `Order -> Job*` child-job model, and the executable 100,000-child large-order benchmark.
-- PLAN-ENG-4 core/headless closure is complete through PLAN-ENG-4-A, PLAN-ENG-4-B, and PLAN-ENG-4-C: the consumer-neutral engine boundary carries stable observation/event contracts around the correct `OrderId` aggregate and child `JobId` work-item identities, with executable acceptance evidence. PLAN-ENG-4-D (outward consumer convergence) remains outstanding.
-- PLAN-ENG-5 may proceed; PLAN-ENG-4 core closure no longer blocks it.
-- public-contract versioning, recovery, checkpoint/restore, persistence, and packaging remain later distribution hardening.
+`FactoryRuntime` exposes a consumer-neutral immutable observation containing:
 
-The current legacy API is not the PLAN-ENG-3 session implementation. `interfaces/api` still has its own `SimThread`/`IntegratedHandler` loop and streams internal scheduler `Event` objects directly over SSE. That path is maintained current behavior, not the architectural owner of PLAN-ENG-4.
+- opaque `RunId` correlation;
+- durable source `ModelFingerprint`;
+- simulated time and advancement state;
+- latest supported event sequence;
+- resource state/queues/active work;
+- aggregate order progress;
+- child work-item state with `JobId` to `OrderId` correlation;
+- cross-machine pending work; and
+- supported performance facts.
 
-The current CLI headless `run` path also remains on `ScenarioLoader -> HeadlessHandler -> SimRunner.runScenario(...)` rather than the newer `FactoryRuntime` seam. That broader orchestration path is a downstream consumer-convergence decision after the PLAN-ENG-4 headless contract is stable, not a reason to widen `FactoryRuntime` prematurely.
+A fresh observation is sufficient to reconstruct current supported consumer state without replaying internal scheduler history.
 
-## 3. Current implementation debt PLAN-ENG-4 must not fossilize
+### PLAN-ENG-4-B — Supported RuntimeEvent contract — COMPLETE
 
-### 3.1 Internal Event is still scheduler machinery
-
-`product/simulation/.../Event.java` currently contains only:
-
-```text
-simulation time
-event type
-payload
-```
-
-It has no run identity, supported sequence, durable model provenance, or external compatibility contract. This is correct for scheduler machinery and should remain possible after PLAN-ENG-4.
-
-### 3.2 `FactoryRuntime` still returns internal events
-
-PLAN-ENG-3's `FactoryRuntime.advance()` / `advanceUntil(...)` return processed internal `Event`s. `CommandResult.scheduledEvents()` captures the internal events scheduled as a direct command effect.
-
-Those are useful headless control/evidence surfaces but are not the supported runtime-event contract. PLAN-ENG-4 must add separate supported types rather than silently rebranding those internal values.
-
-### 3.3 Legacy `SimThread` publication is pre-authoritative in several paths
-
-The current API loop can perform:
-
-```text
-EventLog.append(event)
-notifyListeners(event)
-handler.handleEvent(event, scheduler)
-```
-
-That means the current SSE stream can expose a transition attempt before authoritative processing succeeds. PLAN-ENG-4's supported publication rule is the opposite: derive/publish a successful state-change event only after authoritative processing has occurred.
-
-This is a migration target, not a reason to weaken ADR-0011.
-
-### 3.4 Current SSE is coupled to internal event taxonomy
-
-`SseController` currently:
-
-```java
-.name(event.eventType().name())
-.data(event, MediaType.APPLICATION_JSON)
-```
-
-The current API reference documents that exact behavior. It remains current-state truth until the API migration lands, but it is not the target domain boundary.
-
-When migrated, SSE should be a thin adapter over supported runtime events. Prefer one stable SSE transport event name (for example `runtime-event`), the supported event sequence as the SSE message ID, and semantic `eventType` inside the envelope.
-
-### 3.5 `EventLog` is not the supported recovery journal
-
-The current `EventLog` is a bounded in-memory trace of internal events. It is suitable for simulation trace/debug/export behavior. It does not supply a durable authoritative external history or gap-aware recovery contract.
-
-Do not rename or repurpose it into the PLAN-ENG-4 history. If retained supported events are needed, introduce a separately named responsibility such as `RuntimeEventJournal` or `RuntimeEventHistory`.
-
-## 4. Delivery sequence
-
-### Slice PLAN-ENG-W1-B — Complete: close PLAN-ENG-W1 with large-order benchmark evidence
-
-This prerequisite is complete. `LargeOrderDecompositionBenchmarkTest` executes the supported 100,000-child materialization ceiling, proves deterministic decomposition and terminal semantics, and records diagnostic memory/execution measurements. The existing PLAN-ENG-W1 acceptance suite preserves the fixed-contract and pre-mutation over-limit rejection evidence.
-
-Required work:
-
-- benchmark the implemented unit-child representation at a large accepted quantity (the parent plan currently uses 100,000 as the motivating scale);
-- record resident-memory and execution/event-volume behavior;
-- verify that the current provisional child-materialization limit is justified or adjust it with evidence;
-- determine the evidence-backed supported quantity envelope;
-- keep the benchmark non-semantic: it must not introduce arbitrary batching/chunking merely to improve performance, because configurable batch semantics are explicitly outside PLAN-ENG-W1;
-- update PLAN-ENG-W1 status only when the benchmark evidence is committed and reproducible. **Complete:** the parent Engine Readiness plan records PLAN-ENG-W1 complete and PLAN-ENG-4 active.
-
-This slice must not redesign PLAN-ENG-4.
-
-### Slice PLAN-ENG-4-A — Complete: headless runtime identity and supported observation contract
-
-Add the minimum runtime metadata and observation seam at the `FactoryRuntime` boundary.
-
-Responsibilities:
-
-```text
-RunId (or equivalently named opaque run identity)
-FactoryRuntime owns one RunId
-reset() -> fresh runtime -> fresh RunId
-model fingerprint from FactoryModelVersion.fingerprint()
-latest supported event sequence
-consumer-neutral supported observation projection(s)
-```
-
-Minimum observation responsibilities are defined by ADR-0011 and the Engine plan: run/source provenance, simulated time/run state, resources, aggregate order progress, child work-item state/correlation, and supported performance facts.
-
-`latestEventSequence` starts at `0` before any supported runtime event.
-
-Do not put Spring DTOs or frontend DTOs in this module. Do not create a generic "world state" type if purpose-specific projections preserve a better capability boundary.
-
-**Implemented evidence (2026-09-02):** `FactoryRuntime.observe()` now returns one immutable,
-consumer-neutral current-state projection. Its metadata carries a fresh opaque `RunId`, the durable
-`FactoryModelVersion.fingerprint()` (never the legacy content hash), the `SimTime` as of the latest
-supported boundary, an explicit runtime advancement state (`ACTIVE` when authoritative work is
-pending, otherwise `QUIESCENT` — see the REV-003 correction under PLAN-ENG-4-C), and `latestEventSequence` (`0` before any supported runtime event; PLAN-ENG-4-B below
-wires this cursor to real supported-event sequencing). It is not derived from internal scheduler
-events. The projection contains resources
-(operational state, active child work, per-resource queue depth, and busy ticks), aggregate orders,
-PLAN-ENG-W1 child jobs with `JobId -> OrderId` correlation and ordinal, cross-machine pending work, and the
-authoritative backlog/completed-order/completed-sales/lead-time/throughput aggregates already owned
-by the factory runtime. Collections are immutable and ordered by stable identities. `reset()` uses
-fresh construction and therefore receives a fresh `RunId` while preserving the same semantic
-outcome for the same model and commands. `RuntimeObservationAcceptanceTest` proves these
-facts without the API, Spring, frontend, internal-store access, or scheduler-event replay.
-
-PLAN-ENG-4-B (supported runtime-event taxonomy and post-authoritative publication) and PLAN-ENG-4-C (headless
-event/observation closure) are now implemented (see below); PLAN-ENG-4-D (outward consumer convergence)
-remains outstanding.
-
-### Slice PLAN-ENG-4-B — Complete: Supported RuntimeEvent contract and post-authoritative publication
-
-Introduce separate types equivalent to:
-
-```text
-RuntimeEventEnvelope
-RuntimeEventType
-RuntimeEventPayload
-AffectedEntityRef / typed entity correlation
-```
-
-The envelope carries:
+Supported events are distinct from internal scheduler `Event`/`EventType`/`EventPayload` and carry:
 
 ```text
 runId
@@ -162,488 +41,129 @@ sequence
 simulationTime
 eventType
 modelFingerprint
-controlledRevisionId [optional when authoritatively bound]
-affectedEntityRefs[]
-payload
+controlledRevisionId [optional only when authoritatively bound]
+affected entity references
+semantic payload
 ```
 
-Implementation rules:
+Sequence is allocated only for supported post-authoritative change. Rejected/no-op transitions do not emit successful state-change events. Faults report only authoritative changes that actually occurred.
 
-- `RuntimeEventType != EventType`;
-- `RuntimeEventPayload != EventPayload`;
-- do not define `RuntimeEventEnvelope(..., Event event)`;
-- allocate public sequence only for supported runtime events;
-- allocate sequence after the authoritative transition succeeds;
-- multiple supported events may share one simulated timestamp;
-- rejected commands/transitions do not emit a successful state-change runtime event;
-- a fault after partial mutation reports only authoritative changes that actually happened;
-- the event mapper may inspect resulting authoritative state to enrich a supported payload/correlation;
-- PLAN-ENG-W1 child events preserve `JobId` and parent `OrderId`; aggregate order completion preserves both parent and completing child identities.
+Work-item events preserve child `JobId` and parent `OrderId`; aggregate order completion preserves both aggregate and completing-child correlation where required by ADR-0010.
 
-A run ID is correlation metadata only. It must not participate in simulation decisions or make deterministic outcomes differ.
+### PLAN-ENG-4-C — Headless acceptance closure — COMPLETE
 
-**Implemented evidence (2026-09-02):** `RuntimeEventEnvelope`, `RuntimeEventType`, `RuntimeEventPayload`,
-and `AffectedEntityRef` (`product/domains/factory/.../process/`) introduce the supported,
-consumer-neutral event contract described above; none of them wrap or expose the internal scheduler
-`Event`/`EventType`/`EventPayload`. `FactoryRuntime` now derives and appends a `RuntimeEventEnvelope`
-only after the corresponding authoritative transition has already succeeded:
+Executable acceptance proves:
 
-- `submitWorkload` emits `ORDER_ACCEPTED` (carrying the created child `jobIds`, in ordinal order)
-  after `FactoryHandler.submitOrder` returns successfully, then emits one `JOB_DISPATCHED` or
-  `JOB_WAITING` per created job describing the resulting placement (dispatched to a machine, waiting
-  in that machine's own single-eligible queue, or waiting in the cross-machine multi-eligible
-  backlog) — so a consumer can reconstruct the job creation/assignment/pending-work deltas a
-  quantity>1 submission produces, not just the order-level acceptance fact;
-- `setMachineAvailability` emits `MACHINE_AVAILABILITY_CHANGED` only when `Machine#setAvailability`
-  actually transitioned the machine's online/offline state — a request that is a no-op (e.g. bringing
-  an already-online machine online again) emits nothing and does not advance the sequence — including
-  on the `Faulted` path, since that mutation genuinely happened before a later dispatch-cascade fault,
-  and only that mutation is reported. When a genuine transition to online triggers a dispatch cascade,
-  every job that moved from waiting to dispatched as a result is additionally reported via
-  `JOB_DISPATCHED`, derived by diffing authoritative job state before/after the call;
-- `advance()` derives `JOB_STEP_COMPLETED` from a successfully processed internal `TaskEnd` event
-  (inspecting the resulting `JobView`, never copying the internal payload) and, when that same call's
-  internal scheduler activity also produced an internal `OrderCompleted` event (proving the order's
-  full execution aggregate already completed), additionally emits `ORDER_COMPLETED` carrying both the
-  order and completing child `JobId` for PLAN-ENG-W1 correlation (ADR-0010). Both derivations run in a
-  `finally`, so a step completion that occurred before a later cascade fault is still reported
-  (`RuntimeEventDeliveryAcceptanceTest.faultReportsOnlyAuthoritativeChangesThatActuallyOccurred`).
+- run/sequence/time/model provenance;
+- strict per-run sequence ordering, including same-timestamp events;
+- observation/event cursor consistency;
+- post-authoritative publication;
+- correct order/work correlation;
+- identical semantic streams for identical explicit inputs, excluding intentionally unique run identity;
+- fresh-observation state reconstruction;
+- reset creates a new run/sequence epoch without changing semantic outcomes; and
+- transport/API DTOs do not re-enter domain decision paths.
 
-Sequence is allocated only at emission (`FactoryRuntime.emit`), strictly increasing per run,
-independent of how many internal scheduler events were involved; `RuntimeObservationMetadata
-.latestEventSequence()` is now the live cursor (no longer hardcoded to `0`) and always equals the
-last emitted envelope's sequence, independent of when a caller drains the event list (see below).
-`controlledRevisionId` is always `Optional.empty()` in this slice — PLAN-ENG-4-B does not bind to or
-synthesize one, since no established authoritative binding contract exists yet. This is unrelated to
-Governance PLAN-GOV-1 completion status: PLAN-GOV-1 is complete (`docs/planning/governance-continuity.md`), but
-PLAN-ENG-4 still treats revision provenance as an optional binding because PLAN-GOV-1 completion does not by
-itself mean any given runtime was instantiated from an authoritative controlled revision.
-`modelFingerprint` on every envelope is `FactoryModelVersion.fingerprint()`, never the legacy content
-hash. `FactoryRuntime.drainSupportedEvents()` is the read-only accessor a caller uses instead of
-internal `Event` values: it returns and clears everything accumulated since it was last called.
-It is deliberately draining, not retained/replayable-by-cursor — an unbounded, cursor-addressable
-supported-event history is a separately-named responsibility for later distribution hardening
-(ADR-0011 §8, PLAN-ENG-DH-E), not part of this contract; a caller that needs durable replay retains the
-drained events itself. `advance()`/`advanceUntil` keep returning internal `Event`s unchanged for
-existing PLAN-ENG-3 callers. `RuntimeEventDeliveryAcceptanceTest` proves: run/sequence/time/model provenance
-on the envelope; the enriched `ORDER_ACCEPTED` job-id list and the `JOB_DISPATCHED`/`JOB_WAITING`
-events it implies; strict monotonic sequencing and same-timestamp sequence ordering within one run;
-observation cursor/state consistency with the applied event log; that a rejected command emits
-nothing; that a no-op availability request emits nothing; that a faulted command reports only the
-mutation that actually occurred; PLAN-ENG-W1 `OrderId`/`JobId` correlation on both `JOB_STEP_COMPLETED` and
-`ORDER_COMPLETED`; identical semantic event streams for identical inputs (run ID excluded from the
-comparison); a fresh sequence epoch on `reset()`; and that two distinct run IDs replaying the same
-commands converge to the same event-type sequence and terminal state (run identity does not influence
-simulation outcome).
+The core supported event accessor is draining/non-retained. It is not a durable or cursor-replay journal.
 
-PLAN-ENG-4-C (headless event/observation closure across the full acceptance list, including
-`freshObservationReconstructsCurrentConsumerViewWithoutReplay` and
-`apiDtosDoNotReenterDomainDecisionPaths`) landed separately and is recorded under its own slice
-below; PLAN-ENG-4-D (outward consumer convergence: SSE/API DTO migration, frontend, CLI) remains
-outstanding and is not claimed here. No persistence, recovery,
-checkpoint, or replay semantics were introduced; `FactoryRuntime.drainSupportedEvents()` is a
-draining, non-retained accessor only — it is not a cursor-addressable or replayable journal (that
-remains Slice PLAN-ENG-DH-E).
+## 3. Current implementation queue — PLAN-ENG-4-D
 
-### Slice PLAN-ENG-4-C — Complete: PLAN-ENG-4 headless acceptance closure
+### PLAN-ENG-4-D1 — Legacy API/SSE migration
 
-PLAN-ENG-4 is closed through the consumer-neutral engine boundary before any legacy transport is used as architectural evidence.
+Migrate `interfaces/api` so supported observations/events, rather than internal scheduler events, define outward runtime semantics.
 
-Acceptance evidence should include tests equivalent to:
+The implementation must update together where behavior changes:
 
-```text
-runtimeEventCarriesRunSequenceTimeAndModelProvenance
-sequenceIsStrictlyMonotonicWithinOneRun
-sameTimeEventsRemainOrderedBySequence
-observationLatestSequenceMatchesAppliedRuntimeEvents
-observationReflectsStateReportedByLastRuntimeEvent
-rejectedTransitionDoesNotEmitSuccessfulStateChange
-faultReportsOnlyAuthoritativeChangesThatActuallyOccurred
-w1EventsPreserveOrderIdAndJobIdCorrelation
-identicalInputsProduceIdenticalSemanticEventStreams
-freshObservationReconstructsCurrentConsumerViewWithoutReplay
-resetCreatesNewRunAndSequenceEpoch
-runIdentityDoesNotInfluenceSimulationOutcome
-apiDtosDoNotReenterDomainDecisionPaths
-```
-
-Deterministic stream comparisons ignore or inject intentionally unique run IDs while comparing all semantic event content/order.
-
-PLAN-ENG-4 also requires a supported observation that is sufficient for a consumer to identify the active bottleneck without reaching into internal stores or replaying raw events.
-
-**Implemented evidence (2026-09-02):** the acceptance list above is executable and passing. Most of
-it was already proved by the PLAN-ENG-4-A/PLAN-ENG-4-B suites, which PLAN-ENG-4-C deliberately reuses rather than
-duplicating: `RuntimeEventDeliveryAcceptanceTest` owns
-`runtimeEventCarriesRunSequenceTimeAndModelProvenance`, `sequenceIsStrictlyMonotonicWithinOneRun`,
-`sameTimeEventsRemainOrderedBySequence`, `observationLatestSequenceMatchesAppliedRuntimeEvents`,
-`observationReflectsStateReportedByLastRuntimeEvent`,
-`rejectedTransitionDoesNotEmitSuccessfulStateChange`,
-`faultReportsOnlyAuthoritativeChangesThatActuallyOccurred`,
-`w1EventsPreserveOrderIdAndJobIdCorrelation`, `identicalInputsProduceIdenticalSemanticEventStreams`,
-`resetCreatesNewRunAndSequenceEpoch`, and `runIdentityDoesNotInfluenceSimulationOutcome`;
-`RuntimeObservationAcceptanceTest` owns the observation projection, immutability, and
-fresh-`RunId`-without-changed-outcome facts.
-
-PLAN-ENG-4-C adds the three remaining closure facts, plus two review-driven regression facts (REV-002,
-REV-003) described after them, in
-`product/domains/factory/src/test/java/com/arcogine/factory/process/HeadlessClosureAcceptanceTest.java`:
-
-- `freshObservationReconstructsCurrentConsumerViewWithoutReplay` — drives a runtime to a
-  non-trivial mixed state (one order complete, a second order's child jobs simultaneously
-  completed, in progress, and queued), drains and **discards** every supported event emitted so
-  far, then rebuilds the whole supported consumer view through a pure function of one
-  `FactoryRuntime.observe()` result. No `FactoryHandler`/mutable store, no scheduler `Event` or
-  `EventLog` replay, no previously drained `RuntimeEvent`, and no API/Spring/frontend DTO is
-  available to that reconstruction. It also asserts that `latestEventSequence` survives draining, so
-  a late-joining consumer knows exactly where to continue the stream from;
-- `observationAndSupportedEventsCloseOverTheSameAuthoritativeTransitions` — proves semantic closure
-  in both directions: the supported events emitted after an observation at sequence `S` are exactly
-  `S+1..S'` with no gap or overlap against the later observation's cursor; every transition those
-  events report is consistent with the later observation's authoritative state; and the state the
-  later observation reports that the earlier one did not is explained by the delta. Events are not
-  required to carry redundant full-state payloads;
-- `supportedObservationIdentifiesTheActiveBottleneckWithoutInternalAccess` — runs an unbalanced
-  two-stage routing (fast prep, slow finish) and identifies the finishing resource as the active
-  bottleneck from supported `ResourceObservation` facts alone, independently by carried load
-  (active plus queued work) and by busy-tick utilization, with deterministic tie-breaking by
-  machine id and a reproducible result across an equivalent fresh run.
-
-Review of the slice surfaced two genuine closure gaps, each fixed in production code and pinned by
-its own regression fact in the same test:
-
-- `taskEndDispatchCascadeIsReportedByTheSupportedEventStream` (REV-002) — a `TaskEnd` frees machine
-  capacity, and `FactoryHandler` re-places not only the completing job onto its next routing step
-  but also whatever queued or multi-eligible backlog work that machine can now accept. Emitting
-  only `JOB_STEP_COMPLETED` left a consumer unable to derive those jobs' status or machine
-  assignment from the supported stream, so the closure claim did not actually hold on the `TaskEnd`
-  path;
-- `processingANoOpInternalMarkerLeavesTheSupportedObservationUnchanged` (REV-003) — the internal
-  scheduler also carries markers `FactoryHandler.handleEvent` ignores (the `TaskStart` paired with
-  every dispatched `TaskEnd`; the `OrderCompleted` a terminal `TaskEnd` schedules purely so other
-  internal handlers can observe completion). Processing one is authoritatively a no-op and emits no
-  supported event, yet it moved the scheduler cursor, which `observe()` read directly — so two
-  observations at the same `latestEventSequence` could report different `currentTime`, throughput,
-  or `runState`, contradicting the supported model.
-
-`apiDtosDoNotReenterDomainDecisionPaths` is a structural rather than behavioural fact and is
-enforced as `ArchitectureTest.api_dtos_must_not_reenter_domain_decision_paths` in
-`interfaces/api` — the only module whose test classpath can see both sides of the boundary — which
-fails the build if anything in `com.arcogine.factory..` ever depends on `com.arcogine.api..`,
-`org.springframework..`, or `jakarta.servlet..`.
-
-Three production changes were required, all of them corrections to facts the existing contract
-already claimed rather than new surface:
-
-- **Busy-tick accumulation.** `Machine.busyTicks()` was never accumulated anywhere in the product,
-  so `ResourceObservation.busyTicks()` advertised a utilization fact that was permanently zero.
-  `FactoryHandler.handleTaskEnd` now credits the just-finished step's duration to the resource that
-  performed it, which is the only point where a machine is known to have occupied itself for
-  exactly that long.
-- **`TaskEnd` placement cascade (REV-002).** `FactoryRuntime.advance()` snapshots the placement
-  (status, machine, step) of every job currently occupying machine capacity before processing a
-  `TaskEnd`, and diffs it against authoritative state afterwards, emitting `JOB_DISPATCHED` for
-  everything newly placed and `JOB_WAITING` for a completing job that fell back to waiting. The
-  snapshot is deliberately scoped to jobs occupying capacity — bounded by published machine
-  concurrency, not by backlog size — so a large order's completions stay linear rather than
-  quadratic (`LargeOrderDecompositionBenchmarkTest`).
-- **Supported-boundary coherence (REV-003).** `FactoryRuntime.observe()` no longer reads the
-  internal scheduler cursor. Metadata time (and the throughput derived from it) come from an
-  `observedTime` that advances only when a supported event is emitted, and `RuntimeRunState` comes
-  from whether any *authoritative* event is still queued (`RecordingScheduler
-  .hasPendingAuthoritativeWork()`, counting exactly the payloads `FactoryHandler.handleEvent` acts
-  on) rather than from `Scheduler.isEmpty()`. Every observation-visible metadata and performance
-  fact therefore moves in lockstep with `latestEventSequence`.
-
-No new observation field, event type, scoring concept, or analytics surface was introduced.
-
-No retained runtime-event journal, replay-by-cursor, `Last-Event-ID`, gap detection, or
-checkpoint/restore behaviour was added — that remains Slice PLAN-ENG-DH-E — and no transport, DTO, frontend,
-or CLI behaviour changed, which remains Slice PLAN-ENG-4-D.
-
-### Slice PLAN-ENG-4-D — Converge outward consumers on supported runtime semantics
-
-Only after PLAN-ENG-4-C establishes the headless contract should existing outward consumers migrate or explicitly adapt to it. This is downstream migration/integration work, not a prerequisite for PLAN-ENG-4 core closure or PLAN-ENG-5.
-
-The objective is **semantic convergence**, not forcing every execution path to reuse one concrete runtime type. `FactoryRuntime` remains factory-simulation scoped unless a later architecture decision broadens it; economy/finance/agent orchestration must not be distorted merely to obtain concrete-type reuse.
-
-Current consumer inventory:
-
-- `interfaces/api` uses `SimThread` / `IntegratedHandler` and exposes internal scheduler `Event` values over SSE;
-- `arcogine run` uses `ScenarioLoader -> HeadlessHandler -> SimRunner.runScenario(...)` and may legitimately remain broader than the factory-only session boundary;
-- the PLAN-ENG-4 acceptance/reference consumer must prove supported observations/events without UI-specific DTOs or undocumented internal stores;
-- the frontend is a consumer of the API projection and must not become a semantic authority.
-
-Target dependency direction:
-
-```text
-       supported Engine semantics
-     RuntimeObservation / RuntimeEvent
-          |                 |
-          |                 +--> API adapter --> HTTP / SSE --> frontend
-          |
-          +--> headless/reference consumer
-          |
-          +--> CLI adapter where semantically applicable
-```
-
-Where a broader execution path cannot directly reuse `FactoryRuntime` without changing its legitimate scope, keep the broader orchestration and introduce or preserve an explicit adapter/projection boundary. The adapter may translate supported Engine semantics; it must not redefine them.
-
-#### PLAN-ENG-4-D1 — Legacy API/SSE migration
-
-Migrate `interfaces/api` so supported observations/events, not internal scheduler events, define outward runtime semantics. The exact implementation may require an adapter because today's `SimThread` runs a broader scenario/economy/finance/agent integrated loop rather than `FactoryRuntime`.
-
-When migrated, update in the same slice:
-
+- API runtime-event projection/DTO;
 - `SseController`;
-- outward API event DTO;
 - frontend SSE client/store;
-- SSE integration/contract tests;
+- SSE integration/contract tests; and
 - `docs/reference/api.md`.
 
-Do not update the API reference before behavior changes: that document is a current-state reference.
-
-Preferred SSE shape:
+Preferred transport shape is conceptually:
 
 ```text
 id: <supported sequence>
 event: runtime-event
-data: <supported envelope DTO>
+data: <supported runtime-event envelope DTO>
 ```
 
-The semantic runtime event type stays inside the data envelope. Internal `Event`, `EventPayload`, and `EventLog` remain implementation machinery and must not become outward compatibility types.
+The exact semantic runtime event type stays inside the envelope. Internal `Event`, `EventPayload`, and `EventLog` remain implementation machinery.
 
-#### PLAN-ENG-4-D2 — CLI and reference/headless consumer convergence
+If the legacy integrated API loop cannot consume `FactoryRuntime` directly because it legitimately orchestrates broader economy/finance/agent state, introduce the narrowest adapter/projection that preserves supported Engine semantics. Do not widen `FactoryRuntime` merely for concrete-type reuse.
 
-Evaluate the current CLI/headless path against the supported runtime contract after PLAN-ENG-4-C:
+### PLAN-ENG-4-D2 — CLI/reference consumer convergence
 
-- where factory-only execution can consume the supported runtime/session boundary directly without changing semantics, migrate to that boundary;
-- where `arcogine run` legitimately owns broader scenario/economy/finance/agent orchestration, retain that orchestration and document the deliberate adapter/projection boundary rather than widening `FactoryRuntime` for convenience;
-- provide or preserve a consumer-neutral headless/reference path that can observe `RuntimeObservation` and ordered `RuntimeEvent` semantics without depending on Spring, frontend DTOs, internal scheduler stores, or raw `EventLog` replay;
-- remove duplicated outward observation/event semantics where practical; where reuse would be semantically wrong, make the separate responsibility explicit in code/tests/current planning.
+For each current headless/CLI path:
 
-PLAN-ENG-4-D acceptance requires:
+- use the supported runtime/session boundary directly where semantics match;
+- retain broader scenario orchestration where it owns real extra concerns;
+- make any adapter boundary explicit;
+- provide a consumer-neutral reference path that can consume `RuntimeObservation` and ordered `RuntimeEvent` semantics without Spring/frontend/internal stores/raw `EventLog` replay; and
+- remove duplicated outward observation/event semantics where doing so preserves ownership.
 
-- the CLI/API consumer inventory and direct-consumption versus adapter decisions are documented in current planning or implementation docs;
-- legacy HTTP/SSE projects the supported runtime semantics rather than internal scheduler event taxonomy;
-- headless/reference execution can prove and consume the supported runtime contract without UI-specific code or undocumented internal stores;
-- transport/CLI DTOs remain projections and never re-enter domain decision paths;
-- broader economy/finance/agent orchestration is not forced through `FactoryRuntime` solely for type reuse;
-- behavior-changing slices update current-state docs in the same PR, while unchanged current-state references remain untouched;
-- no new integration framework, protocol selection, generic event bus, or cross-domain interchange ontology is introduced to accomplish convergence.
+### PLAN-ENG-4-D acceptance
 
-### Slice PLAN-ENG-DH-E — Recovery and resynchronization hardening
+PLAN-ENG-4-D closes when:
 
-This is not a PLAN-ENG-4 core blocker and must not hold up PLAN-ENG-5.
+1. current API/SSE projects supported runtime semantics, not internal scheduler taxonomy;
+2. the frontend consumes the supported outward projection;
+3. CLI/reference execution can consume or deliberately adapt the supported runtime contract;
+4. transport/CLI DTOs remain one-way projections;
+5. broader orchestration is not forced through `FactoryRuntime` solely for reuse;
+6. behavior-changing slices update current-state docs in the same PR; and
+7. no protocol/broker/event-bus/interchange framework is introduced to accomplish convergence.
 
-Distribution hardening later owns:
+D1 and D2 should normally be separate reviewable PRs when their code surfaces differ.
 
-- retained supported-event journal/history;
-- oldest/latest retained cursor;
-- reconnect/resume after sequence;
-- explicit history-gap detection;
-- run-ID mismatch handling;
-- fresh-observation resynchronization;
-- SSE `Last-Event-ID` or equivalent adapter behavior;
-- public contract fixtures/versioning;
-- exact checkpoint event position;
-- durability decisions if/when retained history must survive process restart.
+## 4. Provenance boundary
 
-Recovery contract:
+`ModelFingerprint` is required supported provenance and comes from the published model's durable fingerprint, never legacy content hash.
+
+`ControlledRevisionId` is optional and appears only when the runtime has an authoritative upstream revision binding. Governance completion does not imply that every runtime has such a binding, and Engine must not generate/infer one.
+
+The completed Governance identity/history substrate is summarized by [Governance Identity/History Downstream Compatibility Guard](governance-continuity.md).
+
+ADR-0015/PLAN-ENG-5 adds mandatory `EngineSemanticsVersion` provenance. Outward convergence should consume the settled runtime provenance shape rather than publish an immediately obsolete envelope.
+
+## 5. Recovery/resynchronization hardening
+
+Recovery hardening is not a PLAN-ENG-4 core blocker and must not block PLAN-ENG-5. Admit it after outward contract requirements are concrete.
+
+Any implementation must preserve:
 
 ```text
-resume cursor available
-    -> replay retained deltas
+resume cursor retained
+    -> return ordered retained deltas
 
 cursor older than retained history
-    -> RESYNC_REQUIRED (or equivalent explicit result)
+    -> explicit resync-required result
     -> fetch fresh observation
     -> continue after observation.latestEventSequence
 
-cursor belongs to old run
-    -> invalid for new run
+cursor belongs to another run
+    -> reject cursor for this run
     -> fetch fresh observation
 ```
 
-Silent truncation is never considered successful recovery.
+Silent truncation is never successful recovery.
 
-## 5. Provenance integration
+Retained supported-event history, durability across restart, exact checkpoint/restore, public contract versioning, and sidecar packaging are separate implementation responsibilities. Unselected policy/technology choices remain in [Engine Evolution Research](../research/engine-evolution.md) until promoted.
 
-### Model fingerprint
+## 6. Cross-track ownership
 
-`ModelFingerprint` is mandatory PLAN-ENG-4 provenance. PLAN-GOV-1-1 and ADR-0006 have already established `factory-model:v1`; PLAN-ENG-4 should use `FactoryModelVersion.fingerprint()` rather than legacy `contentHash()` for its supported provenance contract.
+- Factory Design owns source model semantics/publication.
+- Engine owns run identity, supported observations/events, sequencing, and simulation recovery semantics.
+- Governance owns controlled revision identity/history, semantic change/conformance/evidence/governed change.
+- Challenge/Game owns challenge evaluation, attempts, rendering, and game state.
+- Operational research/architecture owns future real-world trust, correspondence, external command/result, observation, and reconciliation semantics.
 
-### Controlled revision
+Runtime events are simulation facts. They do not become production telemetry merely because an adapter serializes them.
 
-PLAN-GOV-1 is complete: PLAN-GOV-1-2 and ADR-0008 provide `ControlledRevisionId` and immutable revision/lineage values, while PLAN-GOV-1-3 provides authoritative durable revision persistence and exact historical semantic-state resolution. PLAN-ENG-4 still treats revision provenance as an optional binding because PLAN-GOV-1 completion does not imply that a particular runtime was instantiated from an authoritative controlled revision.
+## 7. Non-goals
 
-Therefore PLAN-ENG-4 uses:
+This plan does not require event sourcing, Kafka/NATS/MQTT, CloudEvents as an Engine-domain type, a generic event bus, revision persistence in Engine, production telemetry trust/reconciliation, game scoring/attempt history, or forcing broader orchestration through `FactoryRuntime`.
 
-```text
-modelFingerprint      required
-controlledRevisionId optional
-```
+## 8. Landing policy
 
-`ControlledRevisionId` is present only when an authoritative upstream revision binding actually exists. Engine must not generate one or infer one from the fingerprint.
-
-No PLAN-ENG-4 dependency may turn Governance persistence into an Engine responsibility.
-
-## 6. Track ownership and cross-track impact
-
-### Factory Design
-
-Factory Design continues to own published executable model semantics, validation/publication, model identity, and semantic layout input. PLAN-ENG-4 consumes the published model and its durable fingerprint; it does not author another model/version system.
-
-### Engine Readiness
-
-Engine owns:
-
-- run/session runtime identity;
-- runtime observations;
-- runtime-event semantic taxonomy/envelope;
-- runtime-event ordering;
-- PLAN-ENG-W1 order/work correlation;
-- later simulation event recovery/versioning/checkpoint integration.
-
-This is the only semantic owner of the PLAN-ENG-4 runtime-event contract.
-
-### Governance / Conformance
-
-Governance owns:
-
-- controlled historical revision identity/lineage;
-- authoritative revision persistence/resolution (PLAN-GOV-1 complete);
-- ChangeSets and impact scoping (PLAN-GOV-2 complete), requirements/assertions (PLAN-GOV-3 complete), conformance evaluation and findings (PLAN-GOV-4 complete);
-- evidence use, governed changes/exceptions in later gates (PLAN-GOV-5+, not yet implemented).
-
-Runtime events are not Governance evidence records by default. A later evidence-use boundary may reference selected runtime observations/events with provenance, but RuntimeEvent, ControlledRevision, EvidenceUse, Finding, and ChangeSet remain distinct concepts.
-
-### Challenge / Game
-
-Challenge/Game owns challenge admissibility, scoring/evaluation policy, attempt provenance/history/comparison, rendering, and game state.
-
-The playable game consumes supported Engine observations/outcome facts/events. It must not:
-
-- define PLAN-ENG-4 event semantics;
-- reconstruct authoritative queue/dispatch state from the raw event stream;
-- simulate missing Engine behavior;
-- treat challenge attempt history as runtime event history;
-- make scoring/evaluation outcomes part of the Arcogine runtime event taxonomy.
-
-Challenge evaluators should prefer final supported outcome facts/observations for evaluation rather than replaying the runtime stream as the source of truth.
-
-### Operational Execution / Digital Twin
-
-Operational Execution owns the additional relationships and safeguards required when independently existing systems and real consequence enter the picture:
-
-- durable operational-history attribution/identity, whose exact referent remains under ADR-0013 review;
-- authoritative external-subject ↔ Arcogine-subject correspondence;
-- verified actor/source/target trust and authorization;
-- semantic operation realization plus command/acknowledgement/result lifecycle for external targets;
-- deployment target/application/effective-artifact provenance;
-- external telemetry/observation ingestion;
-- reconciliation and drift/calibration;
-- operational resilience and live-adapter recovery.
-
-PLAN-ENG-4 runtime events are simulation events. They do not become external operational observations merely because an adapter can serialize them. An operational adapter may translate shared production semantics, but it must preserve the correspondence, trust, provenance, operation-realization, and reconciliation boundaries of the Operational track.
-
-## 7. Important history distinctions
-
-Keep these histories separate:
-
-```text
-model revision history
-    ControlledRevision / Governance lineage
-
-simulation runtime history
-    RuntimeEvent sequence within one run
-
-internal deterministic scheduler trace
-    Event / EventLog
-
-governance evidence/decision history
-    EvidenceUse / Finding / ChangeSet / exception records
-
-challenge attempt history
-    game-owned attempt/evaluation records
-
-external operational observation/operation history
-    Operational Execution-owned records
-```
-
-They can correlate through typed identities and provenance. They are not one generic event/evidence ledger.
-
-## 8. Explicit non-goals
-
-PLAN-ENG-4 and this delivery plan do not require:
-
-- event sourcing;
-- Kafka, NATS, MQTT, WebSocket, or another broker/protocol;
-- CloudEvents as an engine-domain type;
-- durable external event history;
-- exact checkpoint/restore before PLAN-ENG-4 closure;
-- a generic event bus abstraction;
-- a generic rules/evaluation/evidence framework shared with Governance or Challenge;
-- revision persistence inside Engine;
-- production telemetry authenticity/trust/reconciliation;
-- game scoring or attempt-history semantics;
-- forcing broader CLI/economy/finance/agent orchestration through `FactoryRuntime` merely for concrete-type reuse;
-- rewriting accepted ADRs 0005/0007/0009/0010.
-
-## 9. PR landing strategy
-
-Land from fresh `main` in small dependency-ordered PRs rather than maintaining a long stacked branch:
-
-```text
-PR 1  PLAN-ENG-W1 large-order benchmark / close PLAN-ENG-W1
-  ↓
-PR 2  PLAN-ENG-4 headless run identity + observation seam
-  ↓
-PR 3  supported RuntimeEvent + post-authoritative publication
-  ↓
-PR 4  PLAN-ENG-4 acceptance closure / plan-current-architecture reconciliation
-  ↓
-PLAN-ENG-5 may proceed
-
-separate downstream convergence after PLAN-ENG-4-C:
-PR 5a  legacy API/SSE migration
-  ↓
-PR 5b  CLI/reference consumer convergence where needed
-  ↓
-Distribution hardening PRs for recovery/versioning/checkpoint
-```
-
-If implementation naturally makes PLAN-ENG-4-A and PLAN-ENG-4-B one reviewable atomic change, combining them is acceptable, but transport migration must remain separate so transport neutrality is demonstrable.
-
-PLAN-ENG-4-D does not have to be one large PR. API/SSE migration and CLI/reference convergence should land as separate reviewable slices when they have different code surfaces or semantic risks; combine them only if the resulting change remains narrow and coherent.
-
-Do not combine PLAN-ENG-4 with:
-
-- a Kafka/NATS/MQTT selection;
-- Governance persistence;
-- Challenge evaluation;
-- Operational telemetry/reconciliation;
-- PLAN-ENG-5 transfer-policy decisions.
-
-## 10. Documentation propagation rules
-
-As implementation lands:
-
-- `docs/planning/factory-simulation-engine-readiness.md` remains the parent status/gate authority and should be updated for completed slices/evidence;
-- `docs/architecture/overview.md` receives only implemented current-state behavior, while ADR-0011 remains the accepted design authority for not-yet-landed PLAN-ENG-4 details;
-- `docs/reference/api.md` changes only when the HTTP/SSE behavior actually changes;
-- the game-consumer planning remains downstream and should only update when entry-gate status changes or its consumption contract materially changes;
-- Governance planning updates only when revision/evidence responsibilities change, not merely because PLAN-ENG-4 carries existing provenance values;
-- Operational Execution planning updates only if the operational adapter boundary itself changes;
-- accepted ADR history is immutable; later changes to ADR-0011 require a new Accepted superseding ADR rather than editing this decision in place.
-
-## 11. Completion condition
-
-This delivery plan has done its job when:
-
-1. PLAN-ENG-W1 benchmark evidence is recorded and PLAN-ENG-W1 status is resolved;
-2. PLAN-ENG-4 has headless supported observations and ordered authoritative runtime events through the consumer-neutral runtime boundary;
-3. PLAN-ENG-4 acceptance evidence is executable and current architecture reflects what is actually implemented;
-4. outward consumer convergence is explicit: legacy API/SSE projects the supported contract, and CLI/reference execution either consumes the supported runtime boundary where semantically appropriate or documents a deliberate broader orchestration adapter boundary;
-5. a consumer-neutral headless/reference path can prove and consume supported observations/events without UI DTOs, undocumented internal stores, or raw internal-event replay;
-6. recovery/versioning/checkpoint work is clearly owned by distribution hardening rather than hidden inside PLAN-ENG-4;
-7. no knowledge required to continue the work depends on a conversational session.
+Land remaining work from fresh `main` in small dependency-aware PRs. Reconcile PLAN-ENG-4-D status here and in the parent Engine plan as each outward consumer converges. Do not combine outward transport migration with unrelated spatial/Operational/research changes.

--- a/docs/planning/runtime-observation-event-delivery.md
+++ b/docs/planning/runtime-observation-event-delivery.md
@@ -114,7 +114,7 @@ PLAN-ENG-4-D closes when:
 6. behavior-changing slices update current-state docs in the same PR; and
 7. no protocol/broker/event-bus/interchange framework is introduced to accomplish convergence.
 
-D1 and D2 should normally be separate reviewable PRs when their code surfaces differ.
+PLAN-ENG-4-D1 and PLAN-ENG-4-D2 should normally be separate reviewable PRs when their code surfaces differ.
 
 ## 4. Provenance boundary
 

--- a/docs/product/charter.md
+++ b/docs/product/charter.md
@@ -157,18 +157,26 @@ Current architecture and enduring architectural principles
         ├── docs/product/concepts.md / docs/reference/api.md / UI docs
         │   Current capability/reference documentation
         │
-        └── docs/planning/ and historical plans
-            Temporary analysis, proposals, assessments, and past plans
+        ├── docs/research/
+        │   Non-authoritative investigations, hypotheses, evidence, and open questions
+        │
+        ├── docs/planning/
+        │   Admitted implementation work, sequencing, blockers, and acceptance evidence
+        │
+        └── historical ADRs and plans
+            Retained context that is no longer an active authority
 ```
 
-Repository documentation carries one of four statuses, applied where it materially helps a reader avoid confusing them:
+Repository documentation uses these status categories, applied where they materially help a reader avoid confusing them:
 
 - **Normative** — enduring direction and principles. This charter, and the enduring-principle portions of `docs/architecture/overview.md`.
 - **Current state** — what Arcogine implements now. `docs/product/concepts.md`, `docs/reference/api.md`, `/product/interfaces/web/README.md`, the current-implementation portions of `docs/architecture/overview.md`.
-- **Proposed** — under consideration; not established. Proposed ADRs, `docs/planning/` analyses.
+- **Research** — unresolved investigations, hypotheses, and evidence gathering that are not accepted architecture or implementation commitment. `docs/research/` and its linked detailed artifacts.
+- **Planned** — admitted implementation work with bounded ownership, prerequisites, sequencing, and acceptance evidence. `docs/planning/`.
+- **Proposed** — under consideration but not yet established as durable direction. Proposed ADRs and other explicitly proposed material outside the research and planning authorities.
 - **Historical** — retained for context but no longer authoritative. Superseded ADRs.
 
-A reader should never be left guessing whether a statement is mature product ambition, current implementation, an open proposal, or a historical artifact.
+A reader should never be left guessing whether a statement is mature product ambition, current implementation, an open research question, admitted implementation work, an open proposal, or a historical artifact.
 
 ## 11. Decision test
 

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,104 @@
+# Research
+
+> **Status:** Maintained research register  
+> **Scope:** Open, active, and concluded Arcogine research questions that require evidence before architecture, product, or executable delivery planning should change  
+> **Authority:** Research only; this directory does not describe current capability, accepted architecture, or committed delivery work
+
+## 1. Purpose
+
+`docs/research/` answers:
+
+> **What do we still need to understand or decide?**
+
+It is deliberately separate from `docs/planning/`, which answers:
+
+> **Given what is currently known or decided, what executable work should be performed, in what order, and under what acceptance criteria?**
+
+Research may confirm a hypothesis, falsify it, narrow it, discover that no action is required, justify an architecture decision, refine product direction, or create evidence for later delivery work. Recording a conclusion here does not by itself make that conclusion authoritative.
+
+Durable outcomes must be reconciled into the narrowest appropriate authority:
+
+```text
+Research question
+      |
+      v
+Evidence + conclusion
+      |
+      +--> no action
+      +--> product clarification
+      +--> architecture update
+      +--> architecture decision
+      +--> executable delivery work
+                     |
+                     v
+                docs/planning/
+```
+
+Research discovers. Product and architecture establish durable direction. Planning sequences executable work.
+
+## 2. Research lifecycle
+
+Use these statuses consistently:
+
+| Status | Meaning |
+|---|---|
+| **CANDIDATE** | Material uncertainty has been identified, but the investigation is not yet sufficiently bounded or timely to start |
+| **READY** | The research question, scope, evidence expectations, and exit criteria are sufficiently clear to start |
+| **ACTIVE** | Evidence gathering or synthesis is currently in progress |
+| **CONCLUDED** | The investigation reached a decision-quality result and its durable consequences have been reconciled into the appropriate authority, or explicitly resulted in no action |
+| **SUPERSEDED** | A later question, decision, or evidence base replaced the investigation before normal conclusion |
+
+Do not use percentage completion for research. Progress is better represented by evidence gathered, hypotheses falsified, and exit criteria closed.
+
+## 3. Boundary with delivery planning
+
+Research artifacts must not become a shadow roadmap.
+
+- Do not assign temporary delivery coordinates to research questions or research documents.
+- Do not treat research priority as an implementation commitment.
+- Do not introduce production code merely to make a research hypothesis look complete.
+- If an investigation produces executable work, capture that work in `docs/planning/` only after the relevant product or architecture decision is sufficiently established.
+- If an investigation changes durable semantics, reconcile the result into architecture or an architecture decision rather than leaving the research report as the only authority.
+- If an investigation changes only a product hypothesis, reconcile it into the appropriate product or consumer-planning document.
+- A conclusion of **no new abstraction / no implementation** is a successful research result when supported by the evidence.
+
+Research documents may link to planning documents, architecture, implementation, standards, issues, and external sources as evidence. They should remain understandable without relying on transient delivery coordinates.
+
+## 4. Maintenance policy
+
+Maintain this register as research progresses:
+
+1. Add a question when a material uncertainty is discovered and either bound it immediately or leave it `CANDIDATE`.
+2. Mark a question `READY` only when its problem, scope, evidence expectations, and exit criteria are clear enough for an independent researcher to execute.
+3. Mark a question `ACTIVE` when research actually starts; existence of a prompt or investigation document alone does not mean work is active.
+4. When research concludes, record the concise verdict and link the durable destination of any resulting product, architecture, or planning change.
+5. Keep concluded entries visible as a lightweight record of investigated uncertainty, but do not duplicate the authoritative conclusion here.
+6. During periodic planning/consistency review, prune obsolete candidates, mark superseded work explicitly, and reprioritize based on current repository evidence.
+
+## 5. Research register
+
+Priority is portfolio guidance, not committed sequencing.
+
+| Research question | Area | Priority | Status | Why now / what it unlocks | Detailed artifact or authority | Expected conclusion destination | Last reviewed |
+|---|---|---:|---|---|---|---|---|
+| What is the minimum durable semantic boundary among actor attribution, decision production, subject, capability, semantic operation, realization, and transition? | Cross-cutting | High | **READY** | Tests whether Arcogine needs any platform-level `Agent` meaning before generalized agent abstractions or ownership are introduced | [Agency and decision boundary](agency-decision-boundary.md) | Architecture and possibly an architecture decision; executable planning only if shared implementation responsibility survives | 2026-09-08 |
+| What independently continuing operational history or partition needs durable identity, and what makes two records belong to the same one versus different ones? | Operational Execution / Digital Twin | **Critical-path** | **READY** | Resolves the architecture hold that blocks durable operational identity and downstream operational-history attribution | [ADR-0013](../architecture/decisions/0013-execution-context-identity.md) and [Operational readiness](../planning/operational-execution-digital-twin-readiness.md) | Revised architecture decision, then operational planning | 2026-09-08 |
+| Does Factory Design need a reusable equipment/resource definition distinct from installed resource instances, and what semantic invariant would that distinction carry? | Factory Design | High | **READY** | Current `ResourceDefinition` intentionally collapses type and installed unit; the game catalogue, future industrial consumers, and capability modeling provide concrete pressure to test the deferred split | [Factory design capability](../planning/factory-design-capability.md), [Factory design architecture](../architecture/factory-design.md), and [ISA-95 mapping](../architecture/isa-95-semantic-mapping.md) | Factory Design architecture; planning only if the split or another decomposition is justified | 2026-09-08 |
+| Does the proposed factory-design game loop make production-system optimization understandable, experimentally useful, and engaging? | Factory-Design Challenge / Game | High | **READY** | The first playable slice is explicitly a product hypothesis; challenge infrastructure can exist without proving the player loop | [Factory-design game vertical slice](../planning/factory-design-game-vertical-slice.md) | Consumer/product hypothesis and playtest plan; implementation changes only after evidence | 2026-09-08 |
+| What player-facing evidence best exposes bottlenecks, queues, utilization, processing versus transfer loss, and attempt-to-attempt causal differences without exposing raw runtime internals? | Factory-Design Challenge / Game | High | **READY** | The vertical slice depends on players being able to explain why one design performs better, not merely observe a score | [Factory-design game vertical slice](../planning/factory-design-game-vertical-slice.md) and [runtime observation/event delivery](../planning/runtime-observation-event-delivery.md) | Consumer UX/product evidence; runtime planning only if a real supported-observation gap is demonstrated | 2026-09-08 |
+| Which spatial and material-flow semantics, if any, should follow the current factory-model spatial policy: orientation, paths/aisles, conveyors, transport resources, connection points, congestion, or other concepts? | Factory Design / Engine | High | **CANDIDATE** | Current spatial semantics intentionally stop at authored placement/footprint and deterministic transfer interpretation; the next expansion should be consumer-driven rather than assumed | [Factory Model v2](../architecture/factory-model-v2.md), [Engine Semantics v1](../architecture/engine-semantics-v1.md), and [Factory design capability](../planning/factory-design-capability.md) | Factory/Engine architecture and only then delivery planning | 2026-09-08 |
+| What design-authoring lifecycle is genuinely cross-consumer rather than editor-specific: incomplete drafts, alternatives, templates, undo/history, branching, collaboration, optimizer-generated candidates, and publication handoff? | Factory Design | Medium | **CANDIDATE** | Factory Design deliberately keeps authoring consumer-specific until multiple consumers justify shared lifecycle semantics | [Factory design architecture](../architecture/factory-design.md) and [Factory design capability](../planning/factory-design-capability.md) | Factory Design architecture or no shared abstraction | 2026-09-08 |
+| What semantic comparison of factory-design alternatives is useful across consumers beyond the current initial comparison slice? | Factory Design / Governance | Medium | **CANDIDATE** | Finer comparison is explicitly consumer-triggered; game and industrial design may eventually require different explanatory depth | [Factory design capability](../planning/factory-design-capability.md) and [Governance capability](../planning/governance-conformance-capability.md) | Factory/Governance architecture and planning only for demonstrated shared needs | 2026-09-08 |
+| What challenge, scoring, and level-construction structures create multiple understandable viable factory strategies without a dominant opaque meta or reward-function exploitation? | Factory-Design Challenge / Game | Medium | **CANDIDATE** | The reference challenge requires meaningful capacity/layout/cost trade-offs and at least two credible solutions; exact content parameters are intentionally subject to tuning | [Factory-design game vertical slice](../planning/factory-design-game-vertical-slice.md) | Consumer product/content design; no Arcogine semantic change unless evidence demands one | 2026-09-08 |
+| What minimum actor, trust, authority, and capability semantics are shared between synthetic decision-makers and externally consequential operational actors? | Operational Execution / Cross-cutting | High | **CANDIDATE** | Operational architecture identifies the need, but the agency investigation should first clarify actor/controller/subject and capability boundaries so ownership is not duplicated | [Agency investigation](agency-decision-boundary.md) and [Operational readiness](../planning/operational-execution-digital-twin-readiness.md) | Cross-cutting/Operational architecture, then planning if a concrete shared contract survives | 2026-09-08 |
+
+## 6. Current research focus
+
+The strongest currently ready investigations are intentionally from different lanes:
+
+1. **Durable operational identity** — actual architecture blocker for Operational Execution.
+2. **Agency and decision boundary** — bounded cross-cutting investigation intended to prevent premature generalized agent abstractions.
+3. **Factory equipment/resource ontology** — Factory Design domain-model investigation testing the deferred definition/installed-instance split.
+4. **Factory-design game core loop and diagnostics** — product/game research testing whether the existing deterministic semantics become understandable and engaging to a player.
+
+These may proceed independently where their evidence does not assume conclusions from another investigation. Research priority should be re-grounded against current repository state before starting a new investigation.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,104 +1,75 @@
 # Research
 
 > **Status:** Maintained research register  
-> **Scope:** Open, active, and concluded Arcogine research questions that require evidence before architecture, product, or executable delivery planning should change  
+> **Scope:** Open, active, and concluded Arcogine questions that require evidence before product, architecture, or executable delivery planning should change  
 > **Authority:** Research only; this directory does not describe current capability, accepted architecture, or committed delivery work
 
-## 1. Purpose
+## Boundary
 
 `docs/research/` answers:
 
 > **What do we still need to understand or decide?**
 
-It is deliberately separate from `docs/planning/`, which answers:
+`docs/planning/` answers:
 
-> **Given what is currently known or decided, what executable work should be performed, in what order, and under what acceptance criteria?**
+> **Given what is already known or decided, what work can an implementer execute and validate?**
 
-Research may confirm a hypothesis, falsify it, narrow it, discover that no action is required, justify an architecture decision, refine product direction, or create evidence for later delivery work. Recording a conclusion here does not by itself make that conclusion authoritative.
+Research may confirm, falsify, or narrow a hypothesis; conclude that no change is needed; justify an architecture/product decision; or create evidence for later implementation. A research conclusion becomes durable only after it is reconciled into the appropriate product, architecture, ADR, reference, or implementation plan.
 
-Durable outcomes must be reconciled into the narrowest appropriate authority:
+Research documents never receive temporary delivery coordinates.
 
-```text
-Research question
-      |
-      v
-Evidence + conclusion
-      |
-      +--> no action
-      +--> product clarification
-      +--> architecture update
-      +--> architecture decision
-      +--> executable delivery work
-                     |
-                     v
-                docs/planning/
-```
-
-Research discovers. Product and architecture establish durable direction. Planning sequences executable work.
-
-## 2. Research lifecycle
-
-Use these statuses consistently:
+## Lifecycle
 
 | Status | Meaning |
 |---|---|
-| **CANDIDATE** | Material uncertainty has been identified, but the investigation is not yet sufficiently bounded or timely to start |
-| **READY** | The research question, scope, evidence expectations, and exit criteria are sufficiently clear to start |
-| **ACTIVE** | Evidence gathering or synthesis is currently in progress |
-| **CONCLUDED** | The investigation reached a decision-quality result and its durable consequences have been reconciled into the appropriate authority, or explicitly resulted in no action |
-| **SUPERSEDED** | A later question, decision, or evidence base replaced the investigation before normal conclusion |
+| **CANDIDATE** | Material uncertainty exists, but the investigation is not yet sufficiently bounded or timely to start |
+| **READY** | Question, scope, evidence expectations, and exit criteria are sufficiently clear to start |
+| **ACTIVE** | Evidence gathering or synthesis is in progress |
+| **CONCLUDED** | A decision-quality result exists and durable consequences have been reconciled, or the result was explicitly no action |
+| **SUPERSEDED** | Later evidence/question/decision replaced the investigation before normal conclusion |
 
-Do not use percentage completion for research. Progress is better represented by evidence gathered, hypotheses falsified, and exit criteria closed.
+Do not use percentage completion. Track evidence, falsified hypotheses, and exit criteria instead.
 
-## 3. Boundary with delivery planning
+## Promotion rule
 
-Research artifacts must not become a shadow roadmap.
+```text
+Research
+   |
+   v
+Decision-quality evidence
+   |
+   +--> no action
+   +--> product clarification
+   +--> architecture / ADR
+   +--> concrete implementation responsibility
+                       |
+                       v
+                  docs/planning/
+```
 
-- Do not assign temporary delivery coordinates to research questions or research documents.
-- Do not treat research priority as an implementation commitment.
-- Do not introduce production code merely to make a research hypothesis look complete.
-- If an investigation produces executable work, capture that work in `docs/planning/` only after the relevant product or architecture decision is sufficiently established.
-- If an investigation changes durable semantics, reconcile the result into architecture or an architecture decision rather than leaving the research report as the only authority.
-- If an investigation changes only a product hypothesis, reconcile it into the appropriate product or consumer-planning document.
-- A conclusion of **no new abstraction / no implementation** is a successful research result when supported by the evidence.
+A topic is ready for implementation planning only when semantic/product meaning, ownership, prerequisites, and acceptance evidence are sufficiently settled. A blocked implementation contract may live in planning; an unresolved question that still determines the contract stays here.
 
-Research documents may link to planning documents, architecture, implementation, standards, issues, and external sources as evidence. They should remain understandable without relying on transient delivery coordinates.
+## Research register
 
-## 4. Maintenance policy
+Priority is portfolio guidance, not delivery commitment.
 
-Maintain this register as research progresses:
+| Research question | Area | Priority | Status | Detailed artifact / authority | Expected destination | Last reviewed |
+|---|---|---:|---|---|---|---|
+| What is the minimum durable boundary among actor attribution, decision production, subject, capability, semantic operation, realization, and transition? | Cross-cutting | High | **READY** | [Agency and decision boundary](agency-decision-boundary.md) | Architecture/ADR if shared semantics survive; planning only for concrete implementation | 2026-09-08 |
+| What independently continuing operational history, if any, needs durable identity, and what equality/continuity/fork rules define it? | Operational / Digital Twin | **Critical-path** | **READY** | [Operational boundary research](operational-execution-digital-twin-boundaries.md) and ADR-0013 | Revised ADR/architecture, then the first narrow Operational implementation slice | 2026-09-08 |
+| What other Operational boundaries are required for actor/trust/authority, external operation realization, correspondence, reconciliation, drift, and resilience? | Operational / Cross-cutting | High | **CANDIDATE** | [Operational boundary research](operational-execution-digital-twin-boundaries.md) | Architecture and then implementation planning only as needed | 2026-09-08 |
+| Does Factory Design need a reusable equipment/resource definition distinct from installed resource instances, and what invariant would that distinction carry? | Factory Design | High | **READY** | [Factory Design evolution research](factory-design-evolution.md) | Factory architecture/ADR if warranted | 2026-09-08 |
+| Which richer validation, comparison, resource-pool, shared-draft, or governed-change semantics are genuinely cross-consumer? | Factory Design | Medium | **CANDIDATE** | [Factory Design evolution research](factory-design-evolution.md) | Factory/Governance architecture or no shared abstraction | 2026-09-08 |
+| Does the proposed factory-design game loop make production-system optimization understandable, experimentally useful, and engaging? | Game / Challenge consumer | High | **READY** | [Factory-design game vertical-slice research](factory-design-game-vertical-slice.md) | Bounded product requirement set, then game consumer implementation planning | 2026-09-08 |
+| What player-facing evidence best exposes bottlenecks and causal performance differences? | Game / Engine consumer | High | **READY** | [Factory-design game vertical-slice research](factory-design-game-vertical-slice.md) | Game UX; Engine change only if a real supported-observation gap is proven | 2026-09-08 |
+| What scoring, challenge, and level structures create several understandable viable strategies without an opaque dominant meta? | Game | Medium | **CANDIDATE** | [Factory-design game vertical-slice research](factory-design-game-vertical-slice.md) | Product/content decision | 2026-09-08 |
+| Which spatial/material-flow semantics should follow current placement/footprint and deterministic transfer semantics? | Factory Design / Engine | High | **CANDIDATE** | [Factory Design evolution research](factory-design-evolution.md) plus current spatial architecture | Factory/Engine architecture | 2026-09-08 |
+| When are lot/batch/material-lot semantics, capability/resource pools, or dispatch-policy evolution justified? | Engine | Medium | **CANDIDATE** | [Engine evolution research](engine-evolution.md) | Engine/Factory architecture and versioned implementation plan | 2026-09-08 |
 
-1. Add a question when a material uncertainty is discovered and either bound it immediately or leave it `CANDIDATE`.
-2. Mark a question `READY` only when its problem, scope, evidence expectations, and exit criteria are clear enough for an independent researcher to execute.
-3. Mark a question `ACTIVE` when research actually starts; existence of a prompt or investigation document alone does not mean work is active.
-4. When research concludes, record the concise verdict and link the durable destination of any resulting product, architecture, or planning change.
-5. Keep concluded entries visible as a lightweight record of investigated uncertainty, but do not duplicate the authoritative conclusion here.
-6. During periodic planning/consistency review, prune obsolete candidates, mark superseded work explicitly, and reprioritize based on current repository evidence.
+## Maintenance
 
-## 5. Research register
-
-Priority is portfolio guidance, not committed sequencing.
-
-| Research question | Area | Priority | Status | Why now / what it unlocks | Detailed artifact or authority | Expected conclusion destination | Last reviewed |
-|---|---|---:|---|---|---|---|---|
-| What is the minimum durable semantic boundary among actor attribution, decision production, subject, capability, semantic operation, realization, and transition? | Cross-cutting | High | **READY** | Tests whether Arcogine needs any platform-level `Agent` meaning before generalized agent abstractions or ownership are introduced | [Agency and decision boundary](agency-decision-boundary.md) | Architecture and possibly an architecture decision; executable planning only if shared implementation responsibility survives | 2026-09-08 |
-| What independently continuing operational history or partition needs durable identity, and what makes two records belong to the same one versus different ones? | Operational Execution / Digital Twin | **Critical-path** | **READY** | Resolves the architecture hold that blocks durable operational identity and downstream operational-history attribution | [ADR-0013](../architecture/decisions/0013-execution-context-identity.md) and [Operational readiness](../planning/operational-execution-digital-twin-readiness.md) | Revised architecture decision, then operational planning | 2026-09-08 |
-| Does Factory Design need a reusable equipment/resource definition distinct from installed resource instances, and what semantic invariant would that distinction carry? | Factory Design | High | **READY** | Current `ResourceDefinition` intentionally collapses type and installed unit; the game catalogue, future industrial consumers, and capability modeling provide concrete pressure to test the deferred split | [Factory design capability](../planning/factory-design-capability.md), [Factory design architecture](../architecture/factory-design.md), and [ISA-95 mapping](../architecture/isa-95-semantic-mapping.md) | Factory Design architecture; planning only if the split or another decomposition is justified | 2026-09-08 |
-| Does the proposed factory-design game loop make production-system optimization understandable, experimentally useful, and engaging? | Factory-Design Challenge / Game | High | **READY** | The first playable slice is explicitly a product hypothesis; challenge infrastructure can exist without proving the player loop | [Factory-design game vertical slice](../planning/factory-design-game-vertical-slice.md) | Consumer/product hypothesis and playtest plan; implementation changes only after evidence | 2026-09-08 |
-| What player-facing evidence best exposes bottlenecks, queues, utilization, processing versus transfer loss, and attempt-to-attempt causal differences without exposing raw runtime internals? | Factory-Design Challenge / Game | High | **READY** | The vertical slice depends on players being able to explain why one design performs better, not merely observe a score | [Factory-design game vertical slice](../planning/factory-design-game-vertical-slice.md) and [runtime observation/event delivery](../planning/runtime-observation-event-delivery.md) | Consumer UX/product evidence; runtime planning only if a real supported-observation gap is demonstrated | 2026-09-08 |
-| Which spatial and material-flow semantics, if any, should follow the current factory-model spatial policy: orientation, paths/aisles, conveyors, transport resources, connection points, congestion, or other concepts? | Factory Design / Engine | High | **CANDIDATE** | Current spatial semantics intentionally stop at authored placement/footprint and deterministic transfer interpretation; the next expansion should be consumer-driven rather than assumed | [Factory Model v2](../architecture/factory-model-v2.md), [Engine Semantics v1](../architecture/engine-semantics-v1.md), and [Factory design capability](../planning/factory-design-capability.md) | Factory/Engine architecture and only then delivery planning | 2026-09-08 |
-| What design-authoring lifecycle is genuinely cross-consumer rather than editor-specific: incomplete drafts, alternatives, templates, undo/history, branching, collaboration, optimizer-generated candidates, and publication handoff? | Factory Design | Medium | **CANDIDATE** | Factory Design deliberately keeps authoring consumer-specific until multiple consumers justify shared lifecycle semantics | [Factory design architecture](../architecture/factory-design.md) and [Factory design capability](../planning/factory-design-capability.md) | Factory Design architecture or no shared abstraction | 2026-09-08 |
-| What semantic comparison of factory-design alternatives is useful across consumers beyond the current initial comparison slice? | Factory Design / Governance | Medium | **CANDIDATE** | Finer comparison is explicitly consumer-triggered; game and industrial design may eventually require different explanatory depth | [Factory design capability](../planning/factory-design-capability.md) and [Governance capability](../planning/governance-conformance-capability.md) | Factory/Governance architecture and planning only for demonstrated shared needs | 2026-09-08 |
-| What challenge, scoring, and level-construction structures create multiple understandable viable factory strategies without a dominant opaque meta or reward-function exploitation? | Factory-Design Challenge / Game | Medium | **CANDIDATE** | The reference challenge requires meaningful capacity/layout/cost trade-offs and at least two credible solutions; exact content parameters are intentionally subject to tuning | [Factory-design game vertical slice](../planning/factory-design-game-vertical-slice.md) | Consumer product/content design; no Arcogine semantic change unless evidence demands one | 2026-09-08 |
-| What minimum actor, trust, authority, and capability semantics are shared between synthetic decision-makers and externally consequential operational actors? | Operational Execution / Cross-cutting | High | **CANDIDATE** | Operational architecture identifies the need, but the agency investigation should first clarify actor/controller/subject and capability boundaries so ownership is not duplicated | [Agency investigation](agency-decision-boundary.md) and [Operational readiness](../planning/operational-execution-digital-twin-readiness.md) | Cross-cutting/Operational architecture, then planning if a concrete shared contract survives | 2026-09-08 |
-
-## 6. Current research focus
-
-The strongest currently ready investigations are intentionally from different lanes:
-
-1. **Durable operational identity** — actual architecture blocker for Operational Execution.
-2. **Agency and decision boundary** — bounded cross-cutting investigation intended to prevent premature generalized agent abstractions.
-3. **Factory equipment/resource ontology** — Factory Design domain-model investigation testing the deferred definition/installed-instance split.
-4. **Factory-design game core loop and diagnostics** — product/game research testing whether the existing deterministic semantics become understandable and engaging to a player.
-
-These may proceed independently where their evidence does not assume conclusions from another investigation. Research priority should be re-grounded against current repository state before starting a new investigation.
+- Add a material unknown instead of hiding it in an implementation plan.
+- Mark research `READY` only when an independent researcher can execute it from the stated evidence/exit criteria.
+- When research concludes, record the verdict here and link the durable destination; do not duplicate the authoritative conclusion.
+- During planning/consistency review, flag exploratory content that has leaked back into `docs/planning/` and relocate it here.
+- Keep concluded research visible when it provides useful history, but prefer current architecture/reference for durable semantics.

--- a/docs/research/agency-decision-boundary.md
+++ b/docs/research/agency-decision-boundary.md
@@ -2,7 +2,7 @@
 
 > **Status:** Proposed bounded architecture investigation  
 > **Scope:** Determine the smallest durable semantic boundary between observation, decision production, actor attribution, capability, semantic operation, and resulting state change  
-> **Authority:** Planning/research only; this document does not establish a new platform abstraction, module owner, delivery track, or current product capability  
+> **Authority:** Research only; this document does not establish a new platform abstraction, module owner, delivery track, or current product capability  
 > **Related:** [Product Charter](../product/charter.md), [Architecture Overview](../architecture/overview.md), [Operational Execution and Digital Twin Architecture](../architecture/operational-execution-digital-twin.md), [Standards Alignment](../architecture/standards-alignment.md)
 
 ## 1. Why this investigation exists
@@ -281,7 +281,7 @@ The repository should not accumulate textbook summaries of those fields. Researc
 
 This investigation does **not** authorize:
 
-- a new `PLAN-*` track or track code;
+- a new delivery track or track code;
 - a generalized `Agent` framework or superclass;
 - BDI, GOAP, behavior-tree, RL, LLM, or game-AI concepts in the common domain model;
 - generic memory, belief, goal, plan, personality, prompt, or reasoning-trace semantics;

--- a/docs/research/agency-decision-boundary.md
+++ b/docs/research/agency-decision-boundary.md
@@ -1,6 +1,6 @@
 # Agency and Decision Boundary Investigation
 
-> **Status:** Proposed bounded architecture investigation  
+> **Status:** READY
 > **Scope:** Determine the smallest durable semantic boundary between observation, decision production, actor attribution, capability, semantic operation, and resulting state change  
 > **Authority:** Research only; this document does not establish a new platform abstraction, module owner, delivery track, or current product capability  
 > **Related:** [Product Charter](../product/charter.md), [Architecture Overview](../architecture/overview.md), [Operational Execution and Digital Twin Architecture](../architecture/operational-execution-digital-twin.md), [Standards Alignment](../architecture/standards-alignment.md)

--- a/docs/research/engine-evolution.md
+++ b/docs/research/engine-evolution.md
@@ -1,0 +1,53 @@
+# Engine Evolution Research
+
+> **Status:** CANDIDATE  
+> **Scope:** Result-affecting Engine questions intentionally outside the currently accepted deterministic runtime semantics  
+> **Authority:** Research only; current Engine semantics remain fixed by accepted architecture and executable evidence
+
+## Purpose
+
+The Engine implementation must not silently evolve result-affecting policy under an existing semantics identity. This document holds candidate extensions until a concrete use case and architecture decision justify a new implementation contract.
+
+## Lot, batch, and material-lot semantics
+
+Current accepted quantity execution creates independently dispatchable unit work under one aggregate production request. That does not establish domain semantics for lots, batches, transfer batches, material lots, genealogy, or configurable work chunking.
+
+Research these only when a concrete manufacturing or consumer requirement needs them. The result must distinguish physical/domain batch identity from an implementation optimization used merely to reduce object count.
+
+## Capability requirements and resource pools
+
+Current dispatch uses explicit eligible resource instances. A future capability requirement, work center, or resource pool may be justified when heterogeneous resources must satisfy the same operation through stable shared semantics or when scheduling/reporting requires a real group boundary.
+
+Research must answer:
+
+- what capability identity means;
+- whether capability parameters are required;
+- how eligibility is derived;
+- whether a pool owns scheduling/capacity semantics or is merely grouping;
+- how the model-side concept relates to deterministic Engine selection.
+
+Do not introduce a capability taxonomy only to replace an explicit eligible-instance set that already works.
+
+## Dispatch-policy evolution
+
+The current result-affecting dispatch ordering and tie-breaking policy is versioned Engine semantics. Candidate policies such as projected completion time, richer load balancing, priorities, setup-aware dispatch, or optimization-based assignment require evidence that the existing policy is insufficient.
+
+Any accepted change that can alter assignments or outcomes for identical explicit inputs requires an explicit Engine-semantics evolution decision, not a silent implementation tweak.
+
+## Session/advancement evolution
+
+Current consumer-neutral bounded advancement is established. Revisit the command/advancement surface only when a concrete consumer proves that event-count/tick semantics, scheduling control, or ownership cannot be expressed through the existing boundary.
+
+## Distribution/recovery research boundary
+
+Transport versioning, retained supported-event history, reconnect/resynchronization, exact checkpoint/restore, and sidecar packaging become implementation work only after their external contract is explicitly selected. Performance or packaging prototypes may supply evidence, but research must not redefine simulation semantics.
+
+## Promotion rule
+
+Promote a question only when:
+
+- the concrete consumer/problem is identified;
+- result-affecting semantics are explicit;
+- compatibility/version consequences are understood;
+- ownership between Factory, Engine, and consumers is settled; and
+- deterministic acceptance evidence can be written before implementation.

--- a/docs/research/factory-design-evolution.md
+++ b/docs/research/factory-design-evolution.md
@@ -1,0 +1,86 @@
+# Factory Design Evolution Research
+
+> **Status:** Maintained research programme  
+> **Scope:** Factory-model and authoring questions that are not admitted to implementation because their durable invariant or cross-consumer need is not yet established  
+> **Authority:** Research only; accepted Factory Model v1/v2 semantics and current implementation remain authoritative elsewhere
+
+## Purpose
+
+The current Factory Design implementation has a usable canonical publication seam. This document keeps **unresolved extensions** out of executable planning until evidence establishes what they should mean.
+
+## Equipment/resource ontology — READY
+
+Research question:
+
+> Does Factory Design need a reusable equipment/resource definition distinct from installed resource instances, and what semantic invariant would that distinction carry?
+
+Current implementation deliberately allows one resource record to represent one concrete installed unit. Reuse in a game catalogue or editor is not by itself sufficient reason to introduce canonical type/instance semantics.
+
+The investigation must compare at least:
+
+- reusable equipment definition/class/model;
+- installed resource identity;
+- capability and operation requirement;
+- station/work-center/resource-pool semantics;
+- physical placement versus equipment hierarchy;
+- tool, worker, transport, and storage roles;
+- external physical-asset identity versus canonical design identity.
+
+A split should be promoted only if sharing a definition implies a durable semantic invariant beyond authoring convenience.
+
+## Validation finding taxonomy — CANDIDATE
+
+Current validation supplies deterministic executability rejection sufficient for admitted Factory Model work. A richer common diagnostic contract may eventually need stable finding codes, severity, warnings, and structured remediation context.
+
+Promote this only when at least one concrete consumer requires diagnostics that the current validator cannot expose reliably. The research must decide which diagnostics are cross-consumer semantics versus editor presentation.
+
+## Semantic comparison depth — CANDIDATE
+
+The implemented comparison slice identifies add/remove/modify changes to current factory entities through the Governance semantic-change seam. Finer comparison is not admitted merely because more detailed diffs are imaginable.
+
+Research should test concrete needs for:
+
+- routing/operation-detail changes;
+- spatial/layout changes;
+- capability/constraint changes;
+- policy-version transitions;
+- cross-policy comparison where an older model never authored the newer facts;
+- explanations useful to game players, industrial reviewers, optimizers, and governed change.
+
+Promote only shared semantics that more than one concrete consumer needs or that Governance requires for an accepted workflow.
+
+## Shared draft lifecycle — CANDIDATE
+
+Consumer-specific drafts, undo/redo, local persistence, branching, collaboration, comments, locks, and autosave do not automatically belong to Arcogine.
+
+Research a shared draft lifecycle only when multiple concrete workflows need common semantic behavior—for example industrial design plus optimizer/game authoring, human/agent co-design, or multi-user controlled design review.
+
+The question is not whether editors need these features; it is whether Arcogine must own a **shared lifecycle invariant** that consumers cannot safely implement independently.
+
+## Factory participation in governed change — CANDIDATE
+
+Governance owns controlled revision identity/history, semantic change, conformance/evidence, and governed-change records. Operational work will own application to independently existing systems once those semantics are accepted.
+
+Research is needed only if a concrete workflow demonstrates a Factory-specific semantic responsibility that is not already expressible through those sibling contracts. Do not create a Factory-only approval repository, deployment mechanism, telemetry path, or reconciliation model.
+
+## Resource pools and work centers — CANDIDATE
+
+A group deserves a canonical concept only if it owns real behavior or interpretation such as scheduling scope, aggregate capacity, responsibility, reporting, or capability aggregation. UI folders and physical proximity are insufficient.
+
+This research should remain coupled to the equipment ontology and Engine scheduling evidence rather than introducing an empty hierarchy abstraction.
+
+## Spatial/material-flow evolution
+
+Questions such as orientation, paths/aisles, conveyors, connection points, explicit transport resources, buffers, or congestion are tracked separately in the research register because current Factory Model v2 and Engine Semantics v1 deliberately stop before those capabilities.
+
+## Promotion rule
+
+A research item enters `docs/planning/` only when:
+
+1. a concrete consumer or accepted architecture creates the need;
+2. the durable semantic invariant is explicit;
+3. ownership is settled;
+4. migration/compatibility implications are understood; and
+5. executable acceptance evidence can be stated.
+
+Until then, current Factory Model semantics remain truthful and no placeholder abstraction should be introduced.

--- a/docs/research/factory-design-game-vertical-slice.md
+++ b/docs/research/factory-design-game-vertical-slice.md
@@ -1,0 +1,126 @@
+# Factory-Design Game Vertical-Slice Research
+
+> **Status:** READY  
+> **Scope:** Test the product hypothesis for the first playable factory-design game before playable implementation is admitted to delivery planning  
+> **Authority:** Research/product evidence only; this document does not authorize game implementation or change Arcogine semantics
+
+## Research question
+
+Can Arcogine's deterministic production-system semantics support a factory-design puzzle in which a player can understand, test, and improve meaningful capacity, layout, and capital trade-offs?
+
+The candidate loop is:
+
+```text
+Understand a fixed production requirement
+        |
+        v
+Design a factory
+        |
+        v
+Publish the design
+        |
+        v
+Run production
+        |
+        v
+Diagnose queues, utilization, transfers, and bottlenecks
+        |
+        v
+Revise and compare
+```
+
+The intended player role is a production-system designer or industrial engineer, not a live shift operator. The product is successful only if the player can explain **why** a design performs better, not merely discover a hidden score formula.
+
+## Hypotheses to test
+
+1. **Capacity is legible.** Adding compatible capacity at a true bottleneck can improve the fixed production requirement, while adding capacity elsewhere may not.
+2. **Spatial arrangement is consequential.** Shorter production flows can compete with additional equipment because transfer consequences are deterministic and observable.
+3. **Capital creates a real trade-off.** More equipment is not universally optimal once construction cost is considered.
+4. **Diagnosis is possible from supported evidence.** The player can identify the bottleneck and major delay sources without reading raw scheduler/event internals.
+5. **Retry behaves like an experiment.** A player can relate a changed draft to changed authoritative outcomes and learn from the difference.
+6. **Several credible solutions exist.** The reference challenge does not collapse to one obvious dominant strategy.
+
+## Reference challenge candidate
+
+Use one fixed game-owned production requirement with a simple three-step routing, for example:
+
+```text
+Product A
+CUT -> ASSEMBLE -> INSPECT
+```
+
+Candidate content parameters may begin around:
+
+```text
+quantity:       20 units
+floor:          12 x 10 cells
+budget:         40,000 credits
+deadline:       400 simulation ticks
+```
+
+These numbers are **research/playtest parameters**, not Arcogine contracts. Tune or replace them when evidence shows that they do not create useful decisions.
+
+The challenge should make at least two approaches credible, such as:
+
+- spend more capital on parallel bottleneck capacity; or
+- retain less capacity and reduce transfer loss through layout.
+
+Arcogine's accepted order/work-item semantics remain authoritative: one accepted quantity-bearing requirement is decomposed by Arcogine into independently dispatchable unit work while aggregate progress remains order-level. The game must not manufacture multiple production orders merely to create parallelism.
+
+## Player-facing evidence under test
+
+The product research should determine which presentation lets a player answer:
+
+- Where is work waiting?
+- Which operation or resource is the current bottleneck?
+- Which resources are saturated or underused?
+- How much time is attributable to processing versus transfer?
+- How far is the production requirement from completion?
+- What materially changed between this attempt and the previous attempt?
+
+Candidate techniques may include resource overlays, queue indicators, flow/transfer visualization, timeline summaries, bottleneck callouts, and attempt comparison. These are consumer presentation hypotheses. They do not become Engine semantics unless a concrete missing supported observation is proven.
+
+## Product decisions to resolve before implementation
+
+Research should resolve or deliberately defer these consumer choices:
+
+| Decision | Evidence needed |
+|---|---|
+| Rendering/input technology | Target platforms, packaging constraints, team capability, and a representative interaction/performance prototype |
+| Sidecar versus supported in-process integration | Available Arcogine consumer surfaces plus target runtime/packaging constraints |
+| Draft-to-canonical projection UX | Editor usability prototype against the actual canonical model contract |
+| Visual interpolation policy | Supported event/observation timing plus desired presentation behavior |
+| Game-save wrapper | Available checkpoint/recovery contract plus game-owned persistence needs |
+| Scoring formula | Playtests showing understandable trade-offs without an opaque dominant meta |
+| Tutorial sequence | First-time-user observation showing which concepts require instruction versus discovery |
+
+These decisions are intentionally absent from executable planning until evidence selects a contract.
+
+## Product success criteria
+
+The hypothesis is supported when evidence shows that:
+
+1. players understand the objective, constraints, and available equipment without Arcogine-specific tooling knowledge;
+2. capacity investment creates an understandable conditional trade-off;
+3. spatial arrangement creates an understandable performance trade-off;
+4. solving one bottleneck can expose another;
+5. players can identify bottlenecks and major delay sources from presented evidence;
+6. retrying after a design change is perceived as an informative experiment;
+7. at least two credible solutions exist for the reference challenge; and
+8. scoring or rating rewards useful performance without obscuring the causal explanation.
+
+## Arcogine boundary
+
+Research must not use game pressure to invent shared semantics. In particular:
+
+- game catalogue prices, availability, score, progression, tutorial state, and presentation remain game-owned;
+- canonical executability remains Arcogine-owned;
+- production workload, dispatch, queues, processing, transfers, time, and performance facts remain Arcogine-owned;
+- game attempt snapshots may explain player-authored differences without requiring a new canonical model-diff abstraction;
+- unresolved equipment ontology, spatial evolution, and richer design comparison remain separate research questions.
+
+## Exit and promotion
+
+This research is complete when the product team can state a bounded playable requirement set, supported by playtest/prototype evidence, that no longer depends on unresolved consumer decisions.
+
+Only then promote the selected requirements into the game consumer implementation plan. If the research shows that the loop is not understandable or engaging, record that conclusion rather than manufacturing implementation work.

--- a/docs/research/operational-execution-digital-twin-boundaries.md
+++ b/docs/research/operational-execution-digital-twin-boundaries.md
@@ -1,0 +1,149 @@
+# Operational Execution and Digital-Twin Boundary Research
+
+> **Status:** READY, with durable operational identity on the critical path  
+> **Scope:** Resolve the semantic and safety boundaries required before Arcogine admits implementation that connects shared production semantics to independently existing operational systems  
+> **Authority:** Research only; this document defines no implementation queue or Operational module contract
+
+## Purpose
+
+Arcogine's executable core is simulation-first. Future operational and digital-twin use creates requirements pressure around independently existing subjects, real consequence, trust, external observations, and reconciliation. Those concerns must be resolved without creating a second production ontology or a global simulation/production mode.
+
+The target conceptual continuity is:
+
+```text
+Published production semantics
+        |
+        v
+Governed semantic identity / revision when applicable
+        |
+        v
+Subjects, operations, and state transitions
+        |
+        v
+Synthetic and/or external realization
+        |
+        v
+External observations with independent provenance
+        |
+        v
+Authoritative subject correspondence
+        |
+        v
+Reconciliation
+        |
+        v
+Drift / calibration feedback
+```
+
+## Established constraints
+
+Research must preserve these already-established boundaries:
+
+1. **One semantic model.** Synthetic and externally grounded realization reuse shared domain semantics.
+2. **No global reality kind.** Production, staging, simulation, historical, replay, or consequence are not mutually exclusive whole-execution classifications.
+3. **Hybrid composition is normal.** Reality relationship, trust, authority, and consequence may differ by subject/relationship in one modeled system.
+4. **Digital twin is relational.** Twin-ness comes from authoritative correspondence, observations, provenance, and reconciliation.
+5. **Operation, realization, transition, observation, and reconciliation are distinct facts.** Transport acknowledgements do not prove physical state change.
+6. **Raw external observations are independent facts.** They keep source/subject/time/quality/trust provenance and need not carry Arcogine model/revision/history identity at ingestion.
+7. **Subject correspondence is explicit.** Names, endpoints, namespaces, connector topology, and configuration keys never prove identity.
+8. **Generic actor/capability semantics are not inherently Operational.** Consequential use adds verified identity, trust, safety, and authority requirements.
+9. **Seek, replay, checkpoint/restore, and fork are distinct capabilities.** None is an execution kind.
+
+## Durable operational identity — READY / critical path
+
+ADR-0013 must resolve:
+
+> What independently continuing operational history or partition, if any, needs durable identity, and what makes two records belong to the same one versus different ones?
+
+The candidate identity must be tested against restart, failover, disaster recovery, lifecycle changes, changing telemetry/control availability, hybrid composition, several independent twins/interpretations of one physical installation, historical inspection, stale restore, split brain, and deliberate divergent fork.
+
+It must remain distinct from runtime/run identity, model fingerprint, controlled revision, actor, target, deployment, and external subject identity.
+
+Do not introduce a renamed operational identifier until referent, equality, continuity, and divergence rules are explicit.
+
+## Actor, trust, authority, and capability — CANDIDATE
+
+Research the minimum shared semantics for who/what may perform which operation on which subject, while distinguishing generic participation from consequential operational assurance.
+
+Test:
+
+- claimed versus verified identity;
+- delegation and accountable actor/principal;
+- capability versus authorization/policy;
+- source/peer/target authenticity;
+- least privilege and loss/revocation of authority;
+- physical-safety/fail-safe requirements;
+- interaction with the Agency and Decision Boundary research.
+
+The output must settle ownership so Operational does not duplicate a generic authorization model.
+
+## External operation and command-result lifecycle — CANDIDATE
+
+Determine the smallest durable semantics needed to preserve:
+
+```text
+requested semantic operation
+!= submitted/accepted external command
+!= actual transition
+!= observation of transition
+!= reconciled interpretation
+```
+
+Investigate correlation, idempotency, retry, timeout, partial outcome, cancellation/compensation, actor/authority provenance, target trust, requested/effective value, and relationship to evidence/reconciliation.
+
+## Deployment semantics — CANDIDATE
+
+Determine what a deployment/application record must prove about:
+
+- source model/revision;
+- external target identity;
+- transformation/mapping/profile version;
+- material tool version;
+- effective rendered/applied artifact;
+- authorization;
+- application acknowledgement;
+- verification and rollback/compensation.
+
+Deployment identity must not be conflated with model, revision, target, or durable operational-history identity.
+
+## External observation and subject correspondence — CANDIDATE
+
+Research a raw-observation boundary that preserves independent provenance and an explicit correspondence responsibility between namespace-qualified external subjects and Arcogine semantic subjects.
+
+Correspondence research must cover asserting authority, mapping/profile version, effective interval, historical preservation, unknown/unmapped state, and conflict/replacement/alias semantics where required.
+
+Raw ingestion may precede mapping; reconciliation may not claim subject equivalence without an authoritative binding.
+
+## Reconciliation and temporal truth — CANDIDATE
+
+Determine how Arcogine produces historically attributable interpretations of observed reality while keeping modeled intent, observation, reconciled state, and predicted continuation distinct.
+
+Research needs include observation selection, correspondence used, trust decisions, freshness/temporal alignment, policy/version, pending external operations, and explicit match/pending/stale/missing/conflict/divergence/unknown states.
+
+Late/corrected evidence may justify valid/effective-time versus knowledge/recorded-time semantics, but no persistence technology should be selected before the required queries/history are concrete.
+
+## Drift and calibration — CANDIDATE
+
+Determine how reconciled discrepancies become governed candidate changes without mutating published semantics directly. Reuse Governance-owned semantic change, requirements, conformance/findings, and evidence-use contracts rather than duplicating them.
+
+## Resilience and recovery — CANDIDATE
+
+Only after command/observation/correspondence contracts are accepted, determine their failure, idempotency, retry, recovery, trust-loss, ambiguity, and physical-reversibility semantics.
+
+Unknown outcomes must remain unknown; observation loss must not become implicit success.
+
+## First live-system proving case — CANDIDATE
+
+Select one narrow integration only after the preceding boundaries are sufficiently settled. The proving case should demonstrate explicit external identity/correspondence, observation provenance, operation realization, trust where consequence requires it, command/result versus observed/reconciled truth, provenance, and recovery without allowing a protocol to define Arcogine's ontology.
+
+## Exit and promotion
+
+Operational implementation is admitted to `docs/planning/` only when the relevant research has produced:
+
+1. decision-quality semantics and ownership;
+2. required ADR/architecture updates;
+3. a bounded implementation responsibility;
+4. explicit prerequisites; and
+5. executable safety/correctness acceptance evidence.
+
+The first promotion should be the narrowest implementation slice whose semantic referent is no longer under investigation.


### PR DESCRIPTION
## Summary

Separate unresolved research from executable delivery planning and sweep the entire `docs/planning/` directory so it no longer doubles as an exploratory roadmap.

### Research boundary

- add `docs/research/` as the maintained home for bounded investigations and research backlog
- move the Agency and Decision Boundary investigation out of `docs/planning/`
- add dedicated research programmes for Factory Design evolution, Engine evolution, factory-design game product hypotheses, and Operational Execution / Digital-Twin semantic boundaries
- keep research free of temporary delivery coordinates and separate research lifecycle/priority from implementation commitment

### Planning admission policy

- add `docs/planning/README.md`
- define `docs/planning/` as an implementation-admission surface, not a research backlog
- require settled semantic/product meaning, known ownership, explicit prerequisites, bounded implementation responsibility, pre-stated acceptance evidence, and explicit non-goals before work belongs in planning
- allow concrete prerequisite blockers and implementation non-goals, but relocate unresolved alternatives, ontology questions, technology investigations, and product-learning questions to research

### Planning sweep

Reconcile every existing planning file:

- Factory Design: retain landed baseline plus admitted Factory Model v2 work; relocate resource ontology, richer comparison/diagnostics, shared drafts, groups, governed-change extensions, and later spatial questions
- Engine readiness: retain completed deterministic runtime contracts plus current outward-convergence/spatial delivery; relocate future result-affecting policy questions
- Runtime observation/event delivery: retain completed core, concrete outward convergence, and recovery invariants; relocate unselected policy/technology choices
- Game consumer: remove the exploratory client-decision table while retaining settled ownership, prerequisites, implementation admission, and integration acceptance
- Game vertical slice: relocate the product hypothesis, reference challenge, scoring/tutorial, and technology questions; leave an implementation-admission gate
- Challenge: reduce planning to implemented headless capability, downstream guards, and promotion of concrete new requirements
- Governance: retain landed substrate and admitted evidence/governed-change/exceptions/mapping/audit sequence while removing speculative extensions
- Governance continuity: reduce completed identity/history material to a downstream compatibility guard
- Operational: relocate the unresolved semantic programme and leave concrete implementation-admission constraints/promotion criteria
- Spatial runtime consequences: leave unchanged because ADR-0014 / ADR-0015 already fix its architecture and it is executable delivery work

### Review reconciliation

The branch was reconciled with current `main`, then the independent review findings were addressed:

- Product Charter now distinguishes research authority/lifecycle from admitted implementation planning
- Work Planner now consults material research dependencies separately from planning and does not treat research priority as implementation commitment
- Consistency agent now reviews research lifecycle/status and planning admission as distinct consistency surfaces
- Agency and Decision Boundary detailed research status now matches the register (`READY`)

## Validation

- branch is based on current `main`
- repository-local Markdown-link validation passes locally
- delivery-label validation passes locally
- previous CI-discovered legacy `D1`/`D2` shorthand was corrected to `PLAN-ENG-4-D1` / `PLAN-ENG-4-D2`
- research artifacts contain no temporary delivery coordinates
- no production code or executable product behavior changed
