### PR TITLE
Fix redundant setMachineAvailability(machine, true) silently dispatching queued work

### DIFF
--- a/product/domains/factory/src/main/java/com/arcogine/factory/process/FactoryRuntime.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/process/FactoryRuntime.java
@@ -209,35 +209,39 @@ public class FactoryRuntime {
                     modelVersion);
         }
 
-        // Machine#setAvailability is a no-op when the machine is already in the
-        // requested online/offline state (e.g. bringing an already-idle machine online again).
-        // Only genuinely applied transitions -- online while previously Offline, or offline while
-        // previously not Offline -- may emit MACHINE_AVAILABILITY_CHANGED and advance the
-        // sequence; see the wasOffline/transitioned computation below.
+        // Machine#setAvailability is a no-op when the machine is already in the requested
+        // online/offline state (e.g. bringing an already-idle machine online again). Only
+        // genuinely applied transitions -- online while previously Offline, or offline while
+        // previously not Offline -- may mutate authoritative state, run the dispatch/recovery
+        // cascade, emit MACHINE_AVAILABILITY_CHANGED, or advance the sequence. A redundant
+        // request must never even attempt the cascade below: FactoryHandler#handleMachineAvailability
+        // always attempts to dispatch queued/pending work whenever `online` is true, regardless of
+        // whether the machine actually changed state, so calling it for a non-transition would let a
+        // redundant command silently dispatch already-waiting work -- an authoritative mutation with
+        // no corresponding supported event or sequence advancement (ADR-0011).
         boolean wasOffline = machine.get().state() == MachineState.Offline;
         boolean transitioned = online == wasOffline;
+        EventPayload.MachineAvailabilityChange requested = new EventPayload.MachineAvailabilityChange(machineId, online);
+        if (!transitioned) {
+            return new CommandResult.Accepted<>(requested, modelVersion, List.of());
+        }
 
-        // Snapshot every not-yet-dispatched job before mutating, so a genuine dispatch
-        // cascade triggered by this transition can be reported as JOB_DISPATCHED events derived
-        // from the resulting authoritative state, not copied from internal scheduler machinery.
-        List<JobView> waitingBefore = transitioned
-                ? factory.jobsView().filter(j -> j.status() == JobStatus.Queued).toList()
-                : List.of();
+        // Snapshot every not-yet-dispatched job before mutating, so the genuine dispatch cascade
+        // this transition can trigger is reported as JOB_DISPATCHED events derived from the
+        // resulting authoritative state, not copied from internal scheduler machinery.
+        List<JobView> waitingBefore = factory.jobsView().filter(j -> j.status() == JobStatus.Queued).toList();
 
         List<Event> scheduled = new ArrayList<>();
         scheduler.startCapturing(scheduled);
-        EventPayload.MachineAvailabilityChange requested = new EventPayload.MachineAvailabilityChange(machineId, online);
         SimTime changedAt = scheduler.currentTime();
         try {
             factory.handleMachineAvailability(machineId, online, scheduler, scheduler.currentTime());
-            if (transitioned) {
-                emit(
-                        RuntimeEventType.MACHINE_AVAILABILITY_CHANGED,
-                        changedAt,
-                        new RuntimeEventPayload.MachineAvailabilityChanged(machineId, online),
-                        List.of(new AffectedEntityRef.MachineRef(machineId)));
-                emitNewlyDispatchedJobs(waitingBefore, changedAt);
-            }
+            emit(
+                    RuntimeEventType.MACHINE_AVAILABILITY_CHANGED,
+                    changedAt,
+                    new RuntimeEventPayload.MachineAvailabilityChanged(machineId, online),
+                    List.of(new AffectedEntityRef.MachineRef(machineId)));
+            emitNewlyDispatchedJobs(waitingBefore, changedAt);
             return new CommandResult.Accepted<>(requested, modelVersion, scheduled);
         } catch (SimError e) {
             // The availability change itself (Machine#setAvailability) is the first thing
@@ -245,17 +249,13 @@ public class FactoryRuntime {
             // passed -- only the subsequent dispatch cascade can fault. So `requested` genuinely
             // was applied by the time any SimError reaches here, and belongs on Faulted too; the
             // supported MACHINE_AVAILABILITY_CHANGED event is emitted for the same reason -- that
-            // authoritative change genuinely occurred even though the later cascade did not. Since
-            // `transitioned` was computed from pre-mutation state, it still accurately reports
-            // whether this genuinely was a transition.
-            if (transitioned) {
-                emit(
-                        RuntimeEventType.MACHINE_AVAILABILITY_CHANGED,
-                        changedAt,
-                        new RuntimeEventPayload.MachineAvailabilityChanged(machineId, online),
-                        List.of(new AffectedEntityRef.MachineRef(machineId)));
-                emitNewlyDispatchedJobs(waitingBefore, changedAt);
-            }
+            // authoritative change genuinely occurred even though the later cascade did not.
+            emit(
+                    RuntimeEventType.MACHINE_AVAILABILITY_CHANGED,
+                    changedAt,
+                    new RuntimeEventPayload.MachineAvailabilityChanged(machineId, online),
+                    List.of(new AffectedEntityRef.MachineRef(machineId)));
+            emitNewlyDispatchedJobs(waitingBefore, changedAt);
             return new CommandResult.Faulted<>(requested, e, modelVersion, scheduled);
         } finally {
             scheduler.stopCapturing();

--- a/product/domains/factory/src/test/java/com/arcogine/factory/process/RuntimeEventDeliveryAcceptanceTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/process/RuntimeEventDeliveryAcceptanceTest.java
@@ -16,6 +16,7 @@ import com.arcogine.factory.model.OperationDefinition;
 import com.arcogine.factory.model.OperationStepDefinition;
 import com.arcogine.factory.model.ProductDefinition;
 import com.arcogine.factory.model.ConfiguredResource;
+import com.arcogine.types.JobStatus;
 import com.arcogine.types.MachineId;
 import com.arcogine.types.MachineState;
 import com.arcogine.types.OrderId;
@@ -260,6 +261,70 @@ class RuntimeEventDeliveryAcceptanceTest {
 
         assertTrue(runtime.drainSupportedEvents().isEmpty());
         assertEquals(0, runtime.observe().metadata().latestEventSequence());
+    }
+
+    /** One machine, concurrency 2, so a redundant online request can be tested against a machine
+     * that still has a free concurrency slot alongside queued work. */
+    private static FactoryModelVersion singleMachineConcurrencyTwoModel() {
+        return FactoryModelPublisher.publish(new FactoryModel(
+                List.of(new ConfiguredResource(new MachineId(1), "M1", 2, null, 0)),
+                List.of(new OperationDefinition(
+                        1,
+                        "Op",
+                        List.of(new OperationStepDefinition(1, "STEP", Set.of(new MachineId(1)), 100)))),
+                List.of(new ProductDefinition(new ProductId(1), "Widget", 1))));
+    }
+
+    /**
+     * The discriminating case {@link #acceptedNoOpAvailabilityRequestEmitsNothing} does not cover:
+     * a machine that is already online, still has a free concurrency slot, and has work legitimately
+     * waiting in its own queue. {@code tryDispatchFromQueue} only ever dequeues one job per call, so
+     * bringing a concurrency-2 machine online from Offline with two jobs queued dispatches only the
+     * first, leaving the second genuinely {@link JobStatus#Queued} with one free slot still open --
+     * exactly the state a redundant {@code setMachineAvailability(machine, true)} must not be able to
+     * silently drain by dispatching the second job without any corresponding supported event or
+     * {@code latestEventSequence} advancement (ADR-0011).
+     */
+    @Test
+    void acceptedNoOpAvailabilityRequestWithWaitingWorkAndFreeCapacityStillEmitsNothing() {
+        FactoryRuntime runtime = FactoryRuntime.forModel(singleMachineConcurrencyTwoModel());
+
+        runtime.setMachineAvailability(new MachineId(1), false).orElseThrow();
+        runtime.submitWorkload(new ProductId(1), 2, UNIT_PRICE).orElseThrow();
+        runtime.setMachineAvailability(new MachineId(1), true).orElseThrow(); // dispatches only job 1
+        runtime.drainSupportedEvents();
+
+        RuntimeObservation before = runtime.observe();
+        MachineView machineBefore = runtime.machinesView().get(0);
+        assertEquals(1, machineBefore.activeJobs().size(), "only the first job should have dispatched");
+        assertEquals(1, machineBefore.queueDepth(), "the second job must still be genuinely waiting");
+
+        CommandResult<EventPayload.MachineAvailabilityChange> redundant =
+                runtime.setMachineAvailability(new MachineId(1), true);
+
+        assertInstanceOf(CommandResult.Accepted.class, redundant);
+        assertTrue(
+                redundant.scheduledEvents().isEmpty(),
+                "a redundant online request must not schedule any internal dispatch work either");
+        assertTrue(
+                runtime.drainSupportedEvents().isEmpty(),
+                "a redundant online request must not dispatch the still-queued job or emit any event");
+
+        RuntimeObservation after = runtime.observe();
+        assertEquals(
+                before.metadata().latestEventSequence(),
+                after.metadata().latestEventSequence(),
+                "the sequence must not advance for a request that changed no authoritative state");
+        MachineView machineAfter = runtime.machinesView().get(0);
+        assertEquals(1, machineAfter.activeJobs().size(), "the redundant request must not have dispatched anything");
+        assertEquals(1, machineAfter.queueDepth(), "the second job must remain genuinely waiting");
+        assertEquals(
+                JobStatus.Queued,
+                runtime.jobsView()
+                        .filter(j -> j.status() == JobStatus.Queued)
+                        .findFirst()
+                        .orElseThrow()
+                        .status());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `FactoryRuntime.setMachineAvailability` unconditionally called `FactoryHandler.handleMachineAvailability`, even when the requested availability matched the machine's current state (i.e. no genuine transition). That handler always retries queue/pending-backlog dispatch whenever `online=true`, regardless of whether the machine actually changed state — so a redundant `setMachineAvailability(machine, true)` against an already-online machine with free capacity and queued work could dispatch that work (mutating machine/job state, scheduling internal `TaskStart`/`TaskEnd`) while the `if (transitioned)` guard suppressed `MACHINE_AVAILABILITY_CHANGED`/`JOB_DISPATCHED` publication and `latestEventSequence` never advanced. Two `observe()` calls at the same sequence could then disagree on authoritative state — a genuine violation of ADR-0011's observation/event contract.
- Reproduced executably: a concurrency-2 machine brought online from offline dispatches only one of two queued jobs (`tryDispatchFromQueue` dequeues one job per call, not to capacity); a subsequent *redundant* `setMachineAvailability(machine, true)` then silently dispatched the second job with zero supported events and an unchanged sequence. Repeating the redundant call drains the whole queue one job per call.
- This is a command semantic defect, not a dispatch-policy question: the method's own javadoc and the existing `acceptedNoOpAvailabilityRequestEmitsNothing` test already establish a redundant availability command as a total no-op, matching `docs/planning/runtime-observation-event-delivery.md`'s "Rejected/no-op transitions do not emit successful state-change events." The fix is therefore semantics-preserving (no `EngineSemanticsVersion` change).

## Fix

`setMachineAvailability` now short-circuits before invoking `FactoryHandler.handleMachineAvailability` at all when the request is not a genuine transition, returning `Accepted` with no scheduled effects — a true total no-op. `FactoryHandler.handleMachineAvailability` itself is unchanged; its other internal callers (economy/scenario-driven events) are unaffected.

## Test plan

- Added `acceptedNoOpAvailabilityRequestWithWaitingWorkAndFreeCapacityStillEmitsNothing` in `RuntimeEventDeliveryAcceptanceTest` — the discriminating case the existing no-op test didn't cover: an already-online machine with free capacity and genuinely queued work.
- `./gradlew compileJava compileTestJava checkstyleMain checkstyleTest test jacocoTestReport jacocoTestCoverageVerification` — BUILD SUCCESSFUL across the whole product (factory, api, economy, finance, agents, challenge).