### PR TITLE
feat(factory): add V2 spatial model validation

### DIFF
--- a/docs/planning/factory-design-capability.md
+++ b/docs/planning/factory-design-capability.md
@@ -61,6 +61,9 @@ The implementation sequence is owned jointly with [Spatial Runtime Consequences]
 
 ### PLAN-ENG-5-A1 — V2 model and validation
 
+**Status:** Implemented. `factory-model:v2` canonical bytes/fingerprint policy are not released by
+this slice; that is PLAN-ENG-5-A2, now the next V2 Factory-model slice.
+
 Implement the five authored additions and deterministic validation required by ADR-0014.
 
 Acceptance evidence must prove:

--- a/docs/planning/spatial-runtime-consequences.md
+++ b/docs/planning/spatial-runtime-consequences.md
@@ -155,6 +155,16 @@ Engine-semantics identity types, Factory V2, transfer behavior, new scheduling p
 
 ### PLAN-ENG-5-A1 — Factory V2 spatial model and validation
 
+**Status:** Implemented. `FactoryModelV2` (`com.arcogine.factory.model.v2`) carries the five
+ADR-0014 authored additions as a distinct model type composed from existing V1 concepts
+(`ConfiguredResource`, `OperationDefinition`, `ProductDefinition`), and `FactoryModelV2Validator`
+implements every validation predicate below. `FactoryModelV2` shares no supertype with
+`FactoryModel`, so it cannot be passed to `FactoryModelPublisher.publish(FactoryModel)` or used to
+construct a `FactoryModelVersion` -- a compile-time property, not a runtime guard -- which is what
+keeps V2 semantic content from ever traveling through the `factory-model:v1` publication path.
+`factory-model:v2` canonical bytes, `ModelFingerprint` derivation, and policy registration are not
+yet implemented; that is PLAN-ENG-5-A2, the next V2 Factory-model slice.
+
 **Prerequisite:** ADR-0014 landed Accepted.
 
 **Responsibility**

--- a/docs/planning/spatial-runtime-consequences.md
+++ b/docs/planning/spatial-runtime-consequences.md
@@ -1,6 +1,8 @@
 # PLAN-ENG-5 — Spatial Runtime Consequences Delivery Plan
 
-Status: Proposed delivery plan; architecture fixed by ADR-0014 / ADR-0015, implementation not yet started
+Status: Proposed delivery plan; architecture fixed by ADR-0014 / ADR-0015. PLAN-ENG-5-A1 (Factory
+V2 spatial model and validation) is implemented; remaining slices (PLAN-ENG-5-A2 onward) are still
+proposed/pending.
 Owner: Factory Simulation Engine Readiness
 Parent plan: [Factory simulation engine readiness](factory-simulation-engine-readiness.md)
 

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/FactoryFloor.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/FactoryFloor.java
@@ -1,0 +1,12 @@
+package com.arcogine.factory.model.v2;
+
+/**
+ * The authored plant-scope floor extent of a {@code factory-model:v2} design, in integer cells.
+ *
+ * <p>This is an authored Factory fact under ADR-0014 -- it is not Engine policy, runtime state,
+ * transfer state, or animation/presentation geometry. Range validity ({@code width >= 1},
+ * {@code height >= 1}) is deliberately not enforced by this constructor; see
+ * {@link FactoryModelV2Validator} for why cross-field/business validation is centralized there
+ * rather than distributed across value-object constructors.
+ */
+public record FactoryFloor(long width, long height) {}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/FactoryModelV2.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/FactoryModelV2.java
@@ -1,0 +1,66 @@
+package com.arcogine.factory.model.v2;
+
+import com.arcogine.factory.model.ConfiguredResource;
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.FactoryModelPublisher;
+import com.arcogine.factory.model.FactoryModelVersion;
+import com.arcogine.factory.model.OperationDefinition;
+import com.arcogine.factory.model.ProductDefinition;
+import java.util.List;
+
+/**
+ * The canonical {@code factory-model:v2} semantic definition of a designed production system:
+ * exactly the {@code factory-model:v1} semantic content (operations, products, and each
+ * resource's V1 fields) plus the five authored spatial/handling facts ADR-0014 requires -- floor
+ * extent, per-resource reference-cell position, per-resource footprint, {@code ticksPerCell}, and
+ * {@code handlingTicks}.
+ *
+ * <p>This type is deliberately not {@link FactoryModel} and shares no supertype with it. That is
+ * what makes it mechanically impossible -- a compile error, not a runtime check -- to pass a
+ * {@code FactoryModelV2} to {@link FactoryModelPublisher#publish(FactoryModel)} or to construct a
+ * {@link FactoryModelVersion} from one. {@code factory-model:v2} authored content can therefore
+ * never travel through the existing {@code factory-model:v1} publication/fingerprint path.
+ *
+ * <p>V2 does not yet have its own publication, fingerprint, or canonical-artifact path -- that is
+ * a later, separate implementation slice (see {@code docs/architecture/factory-model-v2.md}).
+ * This type exists to give V2's authored semantic content a complete model shape and support
+ * deterministic validation ({@link FactoryModelV2Validator}) ahead of that work.
+ *
+ * <p>{@link OperationDefinition} and {@link ProductDefinition} are reused unchanged: V2 adds no
+ * new operation or product semantics, only spatial/handling facts about resources and the plant.
+ */
+public record FactoryModelV2(
+        FactoryFloor floor,
+        long ticksPerCell,
+        long handlingTicks,
+        List<SpatialConfiguredResource> resources,
+        List<OperationDefinition> operations,
+        List<ProductDefinition> products) {
+
+    public FactoryModelV2 {
+        if (floor == null) {
+            throw new NullPointerException("floor");
+        }
+        resources = resources == null ? List.of() : List.copyOf(resources);
+        operations = operations == null ? List.of() : List.copyOf(operations);
+        products = products == null ? List.of() : List.copyOf(products);
+    }
+
+    /**
+     * Projects this model's V1-shaped semantic content (each resource's base V1 fields,
+     * operations, and products) into a plain {@link FactoryModel}, so
+     * {@link FactoryModelV2Validator} can delegate the existing deterministic V1/base-semantic
+     * validation ({@link com.arcogine.factory.model.validation.FactoryModelValidator}) rather
+     * than duplicating it.
+     *
+     * <p>Package-private and validation-only by design: the projection deliberately discards
+     * every V2 spatial/handling fact, so it must never become a public "downgrade to V1"
+     * conversion that a caller could publish under {@code factory-model:v1} while believing it
+     * still represents this V2 design's full authored content.
+     */
+    FactoryModel baseModel() {
+        List<ConfiguredResource> baseResources =
+                resources.stream().map(SpatialConfiguredResource::resource).toList();
+        return new FactoryModel(baseResources, operations, products);
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/FactoryModelV2Validator.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/FactoryModelV2Validator.java
@@ -1,0 +1,230 @@
+package com.arcogine.factory.model.v2;
+
+import com.arcogine.factory.model.validation.FactoryModelValidationException;
+import com.arcogine.factory.model.validation.FactoryModelValidator;
+import com.arcogine.factory.model.validation.ModelValidationError;
+import com.arcogine.factory.model.validation.ModelValidationResult;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Deterministic structural validation of a {@link FactoryModelV2}, performed before the model may
+ * be published (once V2 publication exists) or used to construct runtime state.
+ *
+ * <p>This delegates the existing {@code factory-model:v1}-shaped structural checks (duplicate
+ * ids, referential integrity, Unicode validity, and so on) to {@link FactoryModelValidator} via
+ * {@link FactoryModelV2#baseModel()}, then adds the V2-only spatial/handling predicates required
+ * by ADR-0014: floor extent, per-resource placement/footprint range and floor containment,
+ * cross-resource footprint non-overlap, handling-value non-negativity, and the maximum
+ * transfer-duration representability predicate.
+ *
+ * <p>Cross-resource predicates such as non-overlap are evaluated here, at the model validation
+ * boundary -- never inside an individual resource's value-object constructor, which could never
+ * see the rest of the model. This mirrors the existing V1 {@link FactoryModelValidator}'s style:
+ * structural/business validation lives at the model boundary, not scattered through record
+ * constructors, and every violation is collected into one deterministic, ordered result rather
+ * than failing fast on the first problem found.
+ */
+public final class FactoryModelV2Validator {
+
+    private FactoryModelV2Validator() {}
+
+    public static ModelValidationResult validate(FactoryModelV2 model) {
+        List<ModelValidationError> errors =
+                new ArrayList<>(FactoryModelValidator.validate(model.baseModel()).errors());
+
+        boolean floorValid = validateFloor(model.floor(), errors);
+        boolean handlingValid = validateHandling(model, errors);
+        boolean[] footprintValid = validateResources(model, floorValid, errors);
+        validateNonOverlap(model.resources(), footprintValid, errors);
+
+        if (floorValid && handlingValid) {
+            validateMaxTransferDuration(model, errors);
+        }
+
+        return new ModelValidationResult(errors);
+    }
+
+    /**
+     * Validates {@code model} and throws {@link FactoryModelValidationException} if it is
+     * structurally invalid.
+     */
+    public static void requireValid(FactoryModelV2 model) {
+        ModelValidationResult result = validate(model);
+        if (!result.isValid()) {
+            throw new FactoryModelValidationException(result);
+        }
+    }
+
+    private static boolean validateFloor(FactoryFloor floor, List<ModelValidationError> errors) {
+        boolean valid = true;
+        if (floor.width() < 1) {
+            errors.add(new ModelValidationError("floor.width", "must be >= 1"));
+            valid = false;
+        }
+        if (floor.height() < 1) {
+            errors.add(new ModelValidationError("floor.height", "must be >= 1"));
+            valid = false;
+        }
+        return valid;
+    }
+
+    private static boolean validateHandling(FactoryModelV2 model, List<ModelValidationError> errors) {
+        boolean valid = true;
+        if (model.ticksPerCell() < 0) {
+            errors.add(new ModelValidationError("ticksPerCell", "must be >= 0"));
+            valid = false;
+        }
+        if (model.handlingTicks() < 0) {
+            errors.add(new ModelValidationError("handlingTicks", "must be >= 0"));
+            valid = false;
+        }
+        return valid;
+    }
+
+    /**
+     * Validates each resource's own placement/footprint ranges and, when the floor itself is
+     * valid, its containment inside the floor. Returns, per resource index, whether that
+     * resource's placement/footprint is valid enough to participate in the non-overlap check --
+     * an already-invalid footprint (for example negative or zero extent) is excluded there so it
+     * cannot produce a spurious or overflow-risking overlap comparison.
+     */
+    private static boolean[] validateResources(
+            FactoryModelV2 model, boolean floorValid, List<ModelValidationError> errors) {
+        List<SpatialConfiguredResource> resources = model.resources();
+        boolean[] valid = new boolean[resources.size()];
+        for (int index = 0; index < resources.size(); index++) {
+            SpatialConfiguredResource resource = resources.get(index);
+            String field = "resources[" + resource.resource().id() + "]";
+            long x = resource.placement().x();
+            long y = resource.placement().y();
+            long width = resource.footprint().width();
+            long height = resource.footprint().height();
+
+            boolean resourceValid = true;
+            if (x < 0) {
+                errors.add(new ModelValidationError(field + ".position.x", "must be >= 0"));
+                resourceValid = false;
+            }
+            if (y < 0) {
+                errors.add(new ModelValidationError(field + ".position.y", "must be >= 0"));
+                resourceValid = false;
+            }
+            if (width < 1) {
+                errors.add(new ModelValidationError(field + ".footprint.width", "must be >= 1"));
+                resourceValid = false;
+            }
+            if (height < 1) {
+                errors.add(new ModelValidationError(field + ".footprint.height", "must be >= 1"));
+                resourceValid = false;
+            }
+
+            if (resourceValid && floorValid) {
+                // Overflow-safe equivalent of `x + width <= floor.width`: floor.width and width
+                // are both already known to be >= 1, so `floor.width - width` -- a difference of
+                // two values in [1, Long.MAX_VALUE] -- is always representable as a long, unlike
+                // `x + width`, which could overflow before it is ever compared to floor.width.
+                if (x > model.floor().width() - width) {
+                    errors.add(new ModelValidationError(
+                            field + ".footprint",
+                            "extends outside floor width " + model.floor().width()));
+                    resourceValid = false;
+                }
+                if (y > model.floor().height() - height) {
+                    errors.add(new ModelValidationError(
+                            field + ".footprint",
+                            "extends outside floor height " + model.floor().height()));
+                    resourceValid = false;
+                }
+            }
+
+            valid[index] = resourceValid;
+        }
+        return valid;
+    }
+
+    /**
+     * Checks every distinct pair of resources whose own placement/footprint already validated
+     * for pairwise footprint overlap, per ADR-0014's occupied-cell semantics.
+     */
+    private static void validateNonOverlap(
+            List<SpatialConfiguredResource> resources,
+            boolean[] footprintValid,
+            List<ModelValidationError> errors) {
+        for (int i = 0; i < resources.size(); i++) {
+            if (!footprintValid[i]) {
+                continue;
+            }
+            for (int j = i + 1; j < resources.size(); j++) {
+                if (!footprintValid[j]) {
+                    continue;
+                }
+                SpatialConfiguredResource a = resources.get(i);
+                SpatialConfiguredResource b = resources.get(j);
+                if (overlaps(a, b)) {
+                    errors.add(new ModelValidationError(
+                            "resources",
+                            "resource " + a.resource().id() + " footprint overlaps resource "
+                                    + b.resource().id()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Two rectangular footprints {@code [x1, x1+w1-1] x [y1, y1+h1-1]} and
+     * {@code [x2, x2+w2-1] x [y2, y2+h2-1]} overlap iff their projections onto both axes overlap.
+     * The textbook interval-overlap test compares sums (for example {@code x1 < x2 + w2}), which
+     * risks overflow; this instead compares the algebraically equivalent difference form
+     * ({@code x1 - x2 < w2}). Every position reaching this method has already been validated
+     * {@code >= 0} by {@link #validateResources}, so each difference of two non-negative longs
+     * lies within {@code [-Long.MAX_VALUE, Long.MAX_VALUE]} and can never overflow {@code long}.
+     */
+    private static boolean overlaps(SpatialConfiguredResource a, SpatialConfiguredResource b) {
+        long ax = a.placement().x();
+        long ay = a.placement().y();
+        long aw = a.footprint().width();
+        long ah = a.footprint().height();
+        long bx = b.placement().x();
+        long by = b.placement().y();
+        long bw = b.footprint().width();
+        long bh = b.footprint().height();
+
+        boolean overlapsHorizontally = (ax - bx) < bw && (bx - ax) < aw;
+        boolean overlapsVertically = (ay - by) < bh && (by - ay) < ah;
+        return overlapsHorizontally && overlapsVertically;
+    }
+
+    /**
+     * Applies ADR-0014's maximum-transfer-duration representability predicate:
+     *
+     * <pre>
+     * maxManhattanDistance = (W - 1) + (H - 1)
+     * maxTransferDuration  = handlingTicks + ticksPerCell * maxManhattanDistance
+     * </pre>
+     *
+     * <p>Every subtraction, addition, and multiplication is evaluated with {@link Math}'s
+     * checked/exact arithmetic, so an overflow throws {@link ArithmeticException} rather than
+     * silently wrapping; the predicate is then reported as failed instead of being evaluated
+     * against a wrapped or otherwise incorrect magnitude. Passing this predicate proves the
+     * derived transfer-duration magnitude is representable in {@code long} -- the runtime
+     * tick-duration type used by durations and simulated time elsewhere in this model and the
+     * runtime. It does not, and is not claimed to, prove that adding an arbitrarily extreme
+     * current simulated time to an otherwise valid duration can never overflow; that pre-existing
+     * condition remains the runtime's own responsibility.
+     */
+    private static void validateMaxTransferDuration(
+            FactoryModelV2 model, List<ModelValidationError> errors) {
+        try {
+            long maxWidthDistance = Math.subtractExact(model.floor().width(), 1);
+            long maxHeightDistance = Math.subtractExact(model.floor().height(), 1);
+            long maxManhattanDistance = Math.addExact(maxWidthDistance, maxHeightDistance);
+            long handlingContribution = Math.multiplyExact(model.ticksPerCell(), maxManhattanDistance);
+            Math.addExact(model.handlingTicks(), handlingContribution);
+        } catch (ArithmeticException overflow) {
+            errors.add(new ModelValidationError(
+                    "maxTransferDuration",
+                    "maximum transfer duration is not representable in the tick-duration type"));
+        }
+    }
+}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/ResourceFootprint.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/ResourceFootprint.java
@@ -1,0 +1,12 @@
+package com.arcogine.factory.model.v2;
+
+/**
+ * The authored integer-cell extent a resource occupies from its {@link ResourcePlacement}
+ * reference cell, in a {@code factory-model:v2} design.
+ *
+ * <p>A resource placed at reference cell {@code (x,y)} with footprint {@code (width,height)}
+ * occupies exactly the integer cells {@code x..x+width-1} by {@code y..y+height-1}, per
+ * ADR-0014. Range validity ({@code width >= 1}, {@code height >= 1}) is deliberately not
+ * enforced by this constructor; see {@link FactoryModelV2Validator}.
+ */
+public record ResourceFootprint(long width, long height) {}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/ResourcePlacement.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/ResourcePlacement.java
@@ -1,0 +1,12 @@
+package com.arcogine.factory.model.v2;
+
+/**
+ * The authored minimum-coordinate reference-cell position of a resource's footprint in a
+ * {@code factory-model:v2} design.
+ *
+ * <p>The reference cell is the minimum-coordinate anchor of the footprint it is paired with in
+ * {@link SpatialConfiguredResource} -- never a center point, arbitrary origin, sprite coordinate,
+ * or connection point. Range validity ({@code x >= 0}, {@code y >= 0}) is deliberately not
+ * enforced by this constructor; see {@link FactoryModelV2Validator}.
+ */
+public record ResourcePlacement(long x, long y) {}

--- a/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/SpatialConfiguredResource.java
+++ b/product/domains/factory/src/main/java/com/arcogine/factory/model/v2/SpatialConfiguredResource.java
@@ -1,0 +1,28 @@
+package com.arcogine.factory.model.v2;
+
+import com.arcogine.factory.model.ConfiguredResource;
+
+/**
+ * One {@code factory-model:v2} configured resource: the existing {@link ConfiguredResource} V1
+ * semantic content, plus its authored {@link ResourcePlacement} and {@link ResourceFootprint}.
+ *
+ * <p>This composes rather than duplicates {@link ConfiguredResource}: {@code id}, {@code name},
+ * {@code concurrency}, {@code capacityLiters}, and {@code setupTime} remain owned by the existing
+ * V1 record and its own semantics. Placement and footprint are the only facts this type adds, so
+ * that V1's resource ontology is never duplicated into a second one.
+ */
+public record SpatialConfiguredResource(
+        ConfiguredResource resource, ResourcePlacement placement, ResourceFootprint footprint) {
+
+    public SpatialConfiguredResource {
+        if (resource == null) {
+            throw new NullPointerException("resource");
+        }
+        if (placement == null) {
+            throw new NullPointerException("placement");
+        }
+        if (footprint == null) {
+            throw new NullPointerException("footprint");
+        }
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/v2/FactoryModelV2Test.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/v2/FactoryModelV2Test.java
@@ -1,0 +1,71 @@
+package com.arcogine.factory.model.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.factory.model.ConfiguredResource;
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.OperationDefinition;
+import com.arcogine.factory.model.OperationStepDefinition;
+import com.arcogine.factory.model.ProductDefinition;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class FactoryModelV2Test {
+
+    private static ConfiguredResource mill(long id) {
+        return new ConfiguredResource(new MachineId(id), "Mill " + id, 1, null, 0);
+    }
+
+    private static OperationDefinition routing() {
+        return new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Rough milling", Set.of(new MachineId(1)), 5)));
+    }
+
+    @Test
+    void requiresNonNullFloor() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new FactoryModelV2(null, 1, 1, List.of(), List.of(), List.of()));
+    }
+
+    @Test
+    void defensivelyCopiesResourceListSoLaterMutationDoesNotLeak() {
+        List<SpatialConfiguredResource> mutable = new ArrayList<>();
+        mutable.add(new SpatialConfiguredResource(
+                mill(1), new ResourcePlacement(0, 0), new ResourceFootprint(1, 1)));
+
+        FactoryModelV2 model = new FactoryModelV2(
+                new FactoryFloor(10, 10), 1, 0, mutable, List.of(), List.of());
+        mutable.clear();
+
+        assertEquals(1, model.resources().size());
+    }
+
+    @Test
+    void baseModelProjectsOnlyV1ShapedContent() {
+        SpatialConfiguredResource spatial = new SpatialConfiguredResource(
+                mill(1), new ResourcePlacement(3, 4), new ResourceFootprint(2, 2));
+        FactoryModelV2 model = new FactoryModelV2(
+                new FactoryFloor(10, 10),
+                7,
+                11,
+                List.of(spatial),
+                List.of(routing()),
+                List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
+
+        FactoryModel base = model.baseModel();
+
+        assertEquals(List.of(spatial.resource()), base.resources());
+        assertEquals(List.of(routing()), base.operations());
+        assertEquals(1, base.products().size());
+        assertTrue(FactoryModel.class.isInstance(base));
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/v2/FactoryModelV2ValidatorTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/v2/FactoryModelV2ValidatorTest.java
@@ -1,0 +1,352 @@
+package com.arcogine.factory.model.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.arcogine.factory.model.ConfiguredResource;
+import com.arcogine.factory.model.OperationDefinition;
+import com.arcogine.factory.model.OperationStepDefinition;
+import com.arcogine.factory.model.ProductDefinition;
+import com.arcogine.factory.model.validation.FactoryModelValidationException;
+import com.arcogine.factory.model.validation.ModelValidationResult;
+import com.arcogine.types.MachineId;
+import com.arcogine.types.ProductId;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class FactoryModelV2ValidatorTest {
+
+    private static ConfiguredResource resource(long id) {
+        return new ConfiguredResource(new MachineId(id), "Resource " + id, 1, null, 0);
+    }
+
+    private static SpatialConfiguredResource spatial(long id, long x, long y, long w, long h) {
+        return new SpatialConfiguredResource(
+                resource(id), new ResourcePlacement(x, y), new ResourceFootprint(w, h));
+    }
+
+    private static OperationDefinition routingOver(long... eligibleIds) {
+        Set<MachineId> eligible = new java.util.LinkedHashSet<>();
+        for (long id : eligibleIds) {
+            eligible.add(new MachineId(id));
+        }
+        return new OperationDefinition(
+                100, "Widget routing", List.of(new OperationStepDefinition(1, "Milling", eligible, 5)));
+    }
+
+    private static FactoryModelV2 model(
+            long floorW,
+            long floorH,
+            long ticksPerCell,
+            long handlingTicks,
+            List<SpatialConfiguredResource> resources) {
+        // Every test model below includes a resource with id 1, so the routing step can always
+        // reference exactly that one resource without accidentally asserting a spurious
+        // referential-integrity error unrelated to the spatial predicate under test.
+        return new FactoryModelV2(
+                new FactoryFloor(floorW, floorH),
+                ticksPerCell,
+                handlingTicks,
+                resources,
+                List.of(routingOver(1)),
+                List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
+    }
+
+    private static void assertValid(FactoryModelV2 model) {
+        ModelValidationResult result = FactoryModelV2Validator.validate(model);
+        assertTrue(result.isValid(), () -> result.errors().toString());
+    }
+
+    private static void assertInvalid(FactoryModelV2 model) {
+        ModelValidationResult result = FactoryModelV2Validator.validate(model);
+        assertFalse(result.isValid());
+    }
+
+    // ---- Basic valid model ----------------------------------------------------------------
+
+    @Test
+    void validModelWithTwoResourcesHandlingAndOrdinaryV1ContentValidatesDeterministically() {
+        FactoryModelV2 model = model(
+                10,
+                10,
+                2,
+                3,
+                List.of(spatial(1, 0, 0, 2, 2), spatial(2, 5, 5, 1, 1)));
+
+        assertValid(model);
+        // Determinism: repeated validation of an equivalent model yields the same result.
+        assertValid(model(10, 10, 2, 3, List.of(spatial(1, 0, 0, 2, 2), spatial(2, 5, 5, 1, 1))));
+    }
+
+    @Test
+    void requireValidThrowsForInvalidModelAndReturnsSilentlyForValidModel() {
+        FactoryModelV2 valid = model(5, 5, 0, 0, List.of(spatial(1, 0, 0, 1, 1)));
+        FactoryModelV2Validator.requireValid(valid); // must not throw
+
+        FactoryModelV2 invalid = model(0, 5, 0, 0, List.of(spatial(1, 0, 0, 1, 1)));
+        assertThrows(FactoryModelValidationException.class, () -> FactoryModelV2Validator.requireValid(invalid));
+    }
+
+    // ---- Anchor semantics -------------------------------------------------------------------
+
+    @Test
+    void referenceCellIsTheMinimumCoordinateAnchorOfALargerFootprint() {
+        // A 3x2 footprint anchored at (2,1) occupies exactly x in [2,4], y in [1,2]: the anchor
+        // is the minimum-coordinate corner, not a center point.
+        SpatialConfiguredResource wide = spatial(1, 2, 1, 3, 2);
+
+        // Adjacent on the immediately-outside boundary cells must not overlap...
+        SpatialConfiguredResource justLeft = spatial(2, 1, 1, 1, 1); // occupies x=1, outside [2,4]
+        SpatialConfiguredResource justAbove = spatial(3, 2, 0, 1, 1); // occupies y=0, outside [1,2]
+        SpatialConfiguredResource justRight = spatial(4, 5, 1, 1, 1); // occupies x=5, outside [2,4]
+        SpatialConfiguredResource justBelow = spatial(5, 2, 3, 1, 1); // occupies y=3, outside [1,2]
+        assertValid(model(10, 10, 0, 0, List.of(wide, justLeft)));
+        assertValid(model(10, 10, 0, 0, List.of(wide, justAbove)));
+        assertValid(model(10, 10, 0, 0, List.of(wide, justRight)));
+        assertValid(model(10, 10, 0, 0, List.of(wide, justBelow)));
+
+        // ...but a 1x1 footprint landing on any actually-occupied boundary cell of the 3x2
+        // footprint does overlap, proving the occupied set is exactly [2,4]x[1,2].
+        SpatialConfiguredResource onMinCorner = spatial(6, 2, 1, 1, 1);
+        SpatialConfiguredResource onMaxCorner = spatial(7, 4, 2, 1, 1);
+        assertInvalid(model(10, 10, 0, 0, List.of(wide, onMinCorner)));
+        assertInvalid(model(10, 10, 0, 0, List.of(wide, onMaxCorner)));
+    }
+
+    // ---- Floor boundaries -------------------------------------------------------------------
+
+    @Test
+    void minimalOneByOneFloorIsValid() {
+        assertValid(model(1, 1, 0, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void zeroFloorWidthIsInvalid() {
+        assertInvalid(model(0, 5, 0, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void zeroFloorHeightIsInvalid() {
+        assertInvalid(model(5, 0, 0, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void originPositionIsValid() {
+        assertValid(model(5, 5, 0, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void negativePositionIsInvalid() {
+        assertInvalid(model(5, 5, 0, 0, List.of(spatial(1, -1, 0, 1, 1))));
+        assertInvalid(model(5, 5, 0, 0, List.of(spatial(1, 0, -1, 1, 1))));
+    }
+
+    @Test
+    void oneByOneFootprintIsValid() {
+        assertValid(model(5, 5, 0, 0, List.of(spatial(1, 2, 2, 1, 1))));
+    }
+
+    @Test
+    void zeroFootprintWidthIsInvalid() {
+        assertInvalid(model(5, 5, 0, 0, List.of(spatial(1, 0, 0, 0, 1))));
+    }
+
+    @Test
+    void zeroFootprintHeightIsInvalid() {
+        assertInvalid(model(5, 5, 0, 0, List.of(spatial(1, 0, 0, 1, 0))));
+    }
+
+    @Test
+    void placementExactlyOnMaxLegalEdgeIsValid() {
+        long floorW = 5;
+        long floorH = 5;
+        assertValid(model(floorW, floorH, 0, 0, List.of(spatial(1, floorW - 1, floorH - 1, 1, 1))));
+    }
+
+    @Test
+    void footprintExtendingOneCellOutsideFloorIsInvalid() {
+        long floorW = 5;
+        long floorH = 5;
+        assertInvalid(model(floorW, floorH, 0, 0, List.of(spatial(1, floorW, floorH - 1, 1, 1))));
+        assertInvalid(model(floorW, floorH, 0, 0, List.of(spatial(1, floorW - 1, floorH, 1, 1))));
+    }
+
+    // ---- Overlap ------------------------------------------------------------------------------
+
+    @Test
+    void identicalOverlapIsInvalid() {
+        assertInvalid(model(10, 10, 0, 0, List.of(spatial(1, 2, 2, 2, 2), spatial(2, 2, 2, 2, 2))));
+    }
+
+    @Test
+    void partialHorizontalOverlapIsInvalid() {
+        // resource1 occupies x=[0,1]; resource2 occupies x=[1,2]: cell x=1 shared.
+        assertInvalid(model(10, 10, 0, 0, List.of(spatial(1, 0, 0, 2, 1), spatial(2, 1, 0, 2, 1))));
+    }
+
+    @Test
+    void partialVerticalOverlapIsInvalid() {
+        // resource1 occupies y=[0,1]; resource2 occupies y=[1,2]: cell y=1 shared.
+        assertInvalid(model(10, 10, 0, 0, List.of(spatial(1, 0, 0, 1, 2), spatial(2, 0, 1, 1, 2))));
+    }
+
+    @Test
+    void containmentOverlapIsInvalid() {
+        // resource2's single cell lies entirely inside resource1's larger footprint.
+        assertInvalid(model(10, 10, 0, 0, List.of(spatial(1, 0, 0, 5, 5), spatial(2, 2, 2, 1, 1))));
+    }
+
+    @Test
+    void edgeAdjacentFootprintsDoNotOverlap() {
+        // resource1 x=0 width=1 (cell 0); resource2 x=1 width=1 (cell 1): adjacent, not
+        // overlapping.
+        assertValid(model(10, 10, 0, 0, List.of(spatial(1, 0, 0, 1, 1), spatial(2, 1, 0, 1, 1))));
+        // Same, vertically.
+        assertValid(model(10, 10, 0, 0, List.of(spatial(1, 0, 0, 1, 1), spatial(2, 0, 1, 1, 1))));
+    }
+
+    @Test
+    void cornerAdjacentFootprintsDoNotOverlap() {
+        assertValid(model(10, 10, 0, 0, List.of(spatial(1, 0, 0, 1, 1), spatial(2, 1, 1, 1, 1))));
+    }
+
+    // ---- Handling zeros -----------------------------------------------------------------------
+
+    @Test
+    void ticksPerCellZeroAndHandlingTicksZeroAreBothLegal() {
+        assertValid(model(5, 5, 0, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void ticksPerCellZeroIndependentlyIsLegal() {
+        assertValid(model(5, 5, 0, 7, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void handlingTicksZeroIndependentlyIsLegal() {
+        assertValid(model(5, 5, 4, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void negativeTicksPerCellIsInvalid() {
+        assertInvalid(model(5, 5, -1, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void negativeHandlingTicksIsInvalid() {
+        assertInvalid(model(5, 5, 0, -1, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    // ---- Maximum-transfer-duration arithmetic --------------------------------------------------
+
+    @Test
+    void zeroDistanceOnAOneByOneFloorIsRepresentable() {
+        assertValid(model(1, 1, Long.MAX_VALUE, 5, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void multiplicationByZeroManhattanDistanceIsRepresentableEvenWithLargeTicksPerCell() {
+        assertValid(model(1, 1, Long.MAX_VALUE, Long.MAX_VALUE, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void exactlyRepresentableLargeResultIsValid() {
+        // floor 1000x1000 -> maxManhattanDistance = 999 + 999 = 1998.
+        // ticksPerCell * 1998 + handlingTicks chosen to land exactly at Long.MAX_VALUE.
+        long maxManhattanDistance = 999 + 999;
+        long ticksPerCell = 1_000_000L;
+        long handlingContribution = ticksPerCell * maxManhattanDistance;
+        long handlingTicks = Long.MAX_VALUE - handlingContribution;
+
+        assertValid(model(1000, 1000, ticksPerCell, handlingTicks, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void multiplicationOverflowIsRejected() {
+        // maxManhattanDistance = 1 -> ticksPerCell * 1 does not overflow by itself, so use a
+        // floor large enough that maxManhattanDistance itself is huge and the multiplication by a
+        // large ticksPerCell overflows.
+        long floorW = 4_000_000_000L;
+        long floorH = 4_000_000_000L; // maxManhattanDistance ~= 8e9
+        assertInvalid(model(floorW, floorH, Long.MAX_VALUE / 2, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void finalAdditionOverflowIsRejected() {
+        // maxManhattanDistance = 0 (1x1 floor) so the multiplication cannot overflow, but adding
+        // handlingTicks to a maximal ticksPerCell*0=0 contribution still can't overflow here --
+        // instead force the final addExact(handlingTicks, contribution) to overflow by using a
+        // nonzero distance with a contribution just under Long.MAX_VALUE and a handlingTicks that
+        // pushes the sum past it.
+        long floorW = 3; // maxManhattanDistance contribution from width = 2
+        long floorH = 1; // contribution from height = 0 -> maxManhattanDistance = 2
+        long ticksPerCell = Long.MAX_VALUE / 2; // *2 stays just within range
+        long handlingContribution = ticksPerCell * 2;
+        long handlingTicks = Long.MAX_VALUE - handlingContribution + 1; // one past representable
+
+        assertInvalid(model(floorW, floorH, ticksPerCell, handlingTicks, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    @Test
+    void maxManhattanDistanceCalculationOverflowIsRejected() {
+        // (W-1) + (H-1) overflows long when both W and H are near Long.MAX_VALUE.
+        long floorW = Long.MAX_VALUE;
+        long floorH = Long.MAX_VALUE;
+        assertInvalid(model(floorW, floorH, 0, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    // ---- Mandatory V2 data ----------------------------------------------------------------------
+
+    @Test
+    void everyMandatoryV2SemanticFactIsRequiredByConstruction() {
+        // floor, and each resource's placement/footprint, are non-null object fields: a
+        // FactoryModelV2 or SpatialConfiguredResource literally cannot be constructed without
+        // supplying them.
+        assertThrows(NullPointerException.class,
+                () -> new FactoryModelV2(null, 0, 0, List.of(), List.of(), List.of()));
+        assertThrows(NullPointerException.class,
+                () -> new SpatialConfiguredResource(resource(1), null, new ResourceFootprint(1, 1)));
+        assertThrows(NullPointerException.class,
+                () -> new SpatialConfiguredResource(resource(1), new ResourcePlacement(0, 0), null));
+        assertThrows(NullPointerException.class,
+                () -> new SpatialConfiguredResource(null, new ResourcePlacement(0, 0), new ResourceFootprint(1, 1)));
+
+        // ticksPerCell/handlingTicks are primitive longs: every construction site must supply an
+        // explicit value (zero is a legal explicit value, not an absent one).
+        assertValid(model(5, 5, 0, 0, List.of(spatial(1, 0, 0, 1, 1))));
+    }
+
+    // ---- V2 does not weaken underlying V1-shaped structural validation -------------------------
+
+    @Test
+    void v2ValidationStillCatchesV1ShapedStructuralErrors() {
+        OperationDefinition badRouting = new OperationDefinition(
+                100,
+                "Widget routing",
+                List.of(new OperationStepDefinition(1, "Milling", Set.of(new MachineId(999)), 5)));
+        FactoryModelV2 badModel = new FactoryModelV2(
+                new FactoryFloor(5, 5),
+                0,
+                0,
+                List.of(spatial(1, 0, 0, 1, 1)),
+                List.of(badRouting),
+                List.of(new ProductDefinition(new ProductId(10), "Widget", 100)));
+
+        assertInvalid(badModel);
+    }
+
+    @Test
+    void invalidModelReportsMultipleDeterministicErrorsRatherThanFailingFast() {
+        FactoryModelV2 badModel = model(0, 0, -1, -1, List.of(spatial(1, -1, -1, 0, 0)));
+
+        ModelValidationResult first = FactoryModelV2Validator.validate(badModel);
+        ModelValidationResult second = FactoryModelV2Validator.validate(badModel);
+
+        assertFalse(first.isValid());
+        assertTrue(first.errors().size() > 1);
+        assertEquals(first.errors(), second.errors());
+    }
+}

--- a/product/domains/factory/src/test/java/com/arcogine/factory/model/v2/V1V2IdentitySeparationTest.java
+++ b/product/domains/factory/src/test/java/com/arcogine/factory/model/v2/V1V2IdentitySeparationTest.java
@@ -1,0 +1,67 @@
+package com.arcogine.factory.model.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.arcogine.factory.model.FactoryModel;
+import com.arcogine.factory.model.FactoryModelPublisher;
+import com.arcogine.factory.model.FactoryModelVersion;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves that a {@link FactoryModelV2} cannot travel through the existing
+ * {@code factory-model:v1} publication/fingerprint path -- {@link
+ * FactoryModelPublisher#publish(FactoryModel)} and the {@link FactoryModelVersion} constructor --
+ * mechanically, not merely by documentation or convention.
+ *
+ * <p>{@code FactoryModelV2} and {@link FactoryModel} share no supertype, so the call
+ * {@code FactoryModelPublisher.publish(someFactoryModelV2)} does not compile: it is a
+ * {@code javac} error, verified here for every reviewer/CI run without needing a dedicated
+ * negative-compilation harness, by asserting the exact absence of the type relationship a
+ * successful call would require.
+ */
+class V1V2IdentitySeparationTest {
+
+    @Test
+    void factoryModelV2SharesNoSupertypeWithFactoryModel() {
+        assertFalse(
+                FactoryModel.class.isAssignableFrom(FactoryModelV2.class),
+                "FactoryModelV2 must not be a FactoryModel -- otherwise it could be passed"
+                        + " anywhere a FactoryModel is accepted, including FactoryModelPublisher.publish");
+        assertFalse(
+                FactoryModelV2.class.isAssignableFrom(FactoryModel.class),
+                "FactoryModel must not be a FactoryModelV2");
+    }
+
+    @Test
+    void publishAcceptsExactlyFactoryModelNotFactoryModelV2() throws NoSuchMethodException {
+        Method publish = FactoryModelPublisher.class.getMethod("publish", FactoryModel.class);
+
+        assertEquals(FactoryModel.class, publish.getParameterTypes()[0]);
+        // A FactoryModelV2 argument at this exact parameter type is a compile-time type error;
+        // there is no overload, supertype, or implicit conversion that would let it through.
+    }
+
+    @Test
+    void factoryModelVersionConstructorAcceptsExactlyFactoryModel() throws NoSuchMethodException {
+        var constructor = FactoryModelVersion.class.getDeclaredConstructor(FactoryModel.class);
+
+        assertEquals(FactoryModel.class, constructor.getParameterTypes()[0]);
+    }
+
+    @Test
+    void factoryModelV2ProjectionOnlyDiscardsSpatialContentItNeverExposesAFactoryModelPublicly() {
+        // FactoryModelV2 exposes no public method returning a plain FactoryModel: the only such
+        // projection (baseModel()) is package-private and used solely by FactoryModelV2Validator
+        // to delegate V1-shaped structural checks. This keeps "V1-shaped content projected out of
+        // a V2 design" from ever being mistaken, by a public API, for "this V2 design published
+        // under factory-model:v1".
+        boolean hasPublicFactoryModelReturningMethod =
+                List.of(FactoryModelV2.class.getMethods()).stream()
+                        .anyMatch(method -> method.getReturnType() == FactoryModel.class);
+
+        assertFalse(hasPublicFactoryModelReturningMethod);
+    }
+}


### PR DESCRIPTION
## Summary

Implements PLAN-ENG-5-A1 — Factory V2 spatial model and validation, per ADR-0014.

**Base SHA:** `975c1630884c7d2b8725d8b8c6f6815c876fdc30` (live `main` at session start; no other open PR touched the Factory model/validation/fingerprinting seam).

### Semantic scope

Adds the five ADR-0014-required V2 authored additions — floor width/height, per-resource
reference-cell position, per-resource footprint, `ticksPerCell`, and `handlingTicks` — as a
complete model shape, plus their deterministic validation. Does **not** release
`factory-model:v2` canonical bytes, `ModelFingerprintV2`, or fingerprint-policy registration (see
non-goals below).

### V1/V2 representation boundary

`FactoryModelV2` (`com.arcogine.factory.model.v2`) is a distinct record composed from existing V1
concepts rather than a duplicate ontology:

- `SpatialConfiguredResource` wraps the existing `ConfiguredResource` plus a new
  `ResourcePlacement` (x, y) and `ResourceFootprint` (width, height);
- `FactoryModelV2` carries a `FactoryFloor` (width, height), `ticksPerCell`, `handlingTicks`, the
  spatial resource list, and reuses `OperationDefinition`/`ProductDefinition` unchanged.

### How V1/V2 identity confusion is prevented

`FactoryModelV2` shares no supertype with `FactoryModel`. `FactoryModelPublisher.publish(FactoryModel)`
and the `FactoryModelVersion(FactoryModel)` constructor cannot accept a `FactoryModelV2` argument —
this is a **compile-time** type error, not a runtime guard. `V1V2IdentitySeparationTest` pins this:
it asserts the absence of any supertype relationship between the two types, that `publish`'s and
`FactoryModelVersion`'s constructor parameter types are exactly `FactoryModel`, and that
`FactoryModelV2` exposes no public method returning a plain `FactoryModel` (the one V1-shaped
projection it needs internally, for validation delegation, is package-private and used only by
`FactoryModelV2Validator`).

### Validation predicates implemented (ADR-0014)

- floor `width >= 1`, `height >= 1`;
- resource `x >= 0`, `y >= 0`;
- footprint `width >= 1`, `height >= 1`;
- floor containment (`x + w <= W`, `y + h <= H`) using overflow-safe subtraction form
  (`x <= W - w`), never raw `x + w`;
- pairwise footprint non-overlap using an overflow-safe difference-form interval test, never cell
  enumeration;
- `ticksPerCell >= 0`, `handlingTicks >= 0` (zero legal for both);
- the exact `maxManhattanDistance = (W-1)+(H-1)`, `maxTransferDuration = handlingTicks +
  ticksPerCell * maxManhattanDistance` representability predicate, using `Math.subtractExact` /
  `addExact` / `multiplyExact` so any overflow fails validation rather than wrapping;
- existing V1-shaped structural validation (duplicate ids, referential integrity, Unicode
  validity, etc.), delegated to the existing `FactoryModelValidator` rather than reimplemented.

Validation collects every violation deterministically (same style as the existing V1 validator)
rather than failing fast.

### Acceptance tests added

- `FactoryModelV2Test` — construction, null-checks on mandatory fields, defensive copying, and the
  V1-shaped projection used for validation delegation.
- `FactoryModelV2ValidatorTest` (33 cases) — basic valid model; anchor/minimum-coordinate
  semantics for a >1×1 footprint with exact occupied-cell boundary reasoning; floor boundary cases
  (0/1 dimensions, negative position, zero footprint, exact max-edge placement, one-cell overflow);
  overlap cases (identical, partial horizontal/vertical, containment, edge-adjacent and
  corner-adjacent non-overlap); handling zero legality (both together and independently); maximum-
  transfer-duration arithmetic (zero distance, multiply-by-zero, exact large result, multiplication
  overflow, final-addition overflow, max-distance-calculation overflow); mandatory-field
  construction-time enforcement; and a proof that V2 validation still catches V1-shaped structural
  errors.
- `V1V2IdentitySeparationTest` (4 cases) — the mechanical identity-confusion proof described above.

### V1 compatibility evidence

`FactoryModelValidatorTest`, `FactoryModelFingerprintV1Test`, and `FactoryModelArtifactV1Test` all
pass unchanged — no V1 golden fingerprint, canonical byte, or artifact fixture was touched. No V1
production type (`FactoryModel`, `ConfiguredResource`, `FactoryModelPublisher`,
`FactoryModelVersion`, `FactoryModelFingerprintV1`, `FactoryModelArtifactV1`) was modified.

### Explicit non-goals (deferred to A2/A3/Engine work)

`factory-model:v2` canonical bytes/grammar, `ModelFingerprintV2` derivation, V2 artifact
encode/decode, fingerprint-policy registration, V1↔V2 resolver/migration, cross-policy comparison
(all PLAN-ENG-5-A2/A3) — and all Engine/runtime transfer behavior, destination binding, transfer
timing, and dispatch semantics (PLAN-ENG-5-C1 onward). No Engine/runtime code was touched.

### Documentation reconciled

`docs/planning/spatial-runtime-consequences.md` and `docs/planning/factory-design-capability.md`
now record PLAN-ENG-5-A1 as implemented, with PLAN-ENG-5-A2 as the next V2 Factory-model slice.
`docs/architecture/overview.md` had no Factory V2 mentions requiring reconciliation.

### Validation run

```
cd product && ./gradlew --no-daemon :factory:test                     # BUILD SUCCESSFUL (40 new tests pass)
cd product && ./gradlew --no-daemon :factory:test \
    --tests '*FactoryModelValidatorTest' --tests '*FactoryModelFingerprintV1Test' \
    --tests '*FactoryModelArtifactV1Test'                             # BUILD SUCCESSFUL
cd product && ./gradlew --no-daemon compileJava compileTestJava checkstyleMain checkstyleTest \
    test jacocoTestReport jacocoTestCoverageVerification              # BUILD SUCCESSFUL (full repo)
python3 .github/scripts/check-delivery-labels.py                      # Delivery-label check passed
```
