### PR TITLE
docs(research): surface transferable research knowledge

### DIFF
--- a/docs/development/researching.md
+++ b/docs/development/researching.md
@@ -12,6 +12,8 @@ For AI execution of this policy, the repository-owned **Researcher** procedure l
 
 This document must not become a second research backlog, roadmap, architecture authority, or implementation plan. It defines method, not content: it does not list Arcogine's open questions (`docs/research/README.md` does), does not decide any Arcogine semantic question (an ADR, architecture doc, or product doc does), and does not sequence implementation (`docs/planning/` does).
 
+Potentially transferable findings that do not themselves justify an Arcogine research question may survive reconciliation only through the narrow, non-authoritative synthesis-seed mechanism defined in §10 and [`docs/research/synthesis-seeds.md`](../research/synthesis-seeds.md). A seed preserves recurrence-detection value; it does not create work or establish a broader claim.
+
 ## 1. What research is for
 
 Arcogine research exists to answer a **material bounded uncertainty that can change an Arcogine decision** — a question whose answer would plausibly change product direction, architecture, an ADR, or an implementation contract, and whose current uncertainty is real enough that guessing would be worse than investigating.
@@ -52,6 +54,8 @@ A researcher must:
 5. inspect the current product, architecture, ADR, planning, implementation, and test surfaces the question actually touches;
 6. search semantic neighbors rather than reading only the files named in the brief — a question about identity, ownership, or lifecycle usually has cousins elsewhere in `docs/architecture/`, `docs/planning/`, and the codebase that the brief's author did not anticipate;
 7. state any important surface that could not be inspected, rather than silently omitting it.
+
+Do **not** include `docs/research/synthesis-seeds.md` in routine start-of-run grounding for an investigation that is meant to provide independent evidence. First derive the bounded question's candidates, evidence needs, proving/failure cases, and result from its own brief and repository/external evidence. Compare against synthesis seeds only after reaching that result. If a seed is deliberately used as input to the question or materially shapes candidates, proving cases, or reasoning, label any later similarity as **reuse**, not independent recurrence.
 
 For a long-running investigation, perform a final current-state recheck before presenting repository-dependent conclusions. If `main` moved materially during the investigation, reconcile whether the conclusion still holds against the new head rather than silently reporting against a stale one.
 
@@ -203,6 +207,8 @@ An adversarial reviewer specifically attempts to discover, as applicable:
 - an unresolved question silently declared settled;
 - a conclusion stronger than its evidence.
 
+When a report proposes a potentially transferable result, challenge that scope explicitly as part of the same adversarial pass: seek Arcogine-specific causes, contrary contexts, design choices presented as necessities, and narrower claims that survive where the broader formulation does not.
+
 A clean adversarial review — one that finds nothing that survives scrutiny — is a valid and useful result. Do not optimize for producing findings, and do not establish a minimum finding count. An adversarial reviewer who manufactures a finding to justify the pass has failed the same way a PR reviewer who "optimizes for finding something wrong" has failed (`docs/development/reviewing.md`).
 
 ### Report input integrity
@@ -283,6 +289,10 @@ separate durable reconciliation on the same workspace by default
         v
 knowledge-transfer audit
         |
+        +--> reusable evidence / know-how
+        +--> qualifying synthesis seed (non-authoritative)
+        +--> explicit discard
+        |
         v
 reconciliation lands
         |
@@ -319,12 +329,29 @@ Temporary research evidence may be deleted only after every research question ca
 - accepted conclusions and invariants into the appropriate product, architecture, ADR, reference, or admitted planning authority;
 - qualifications that constrain an accepted conclusion into the same durable destination as that conclusion;
 - unresolved unknowns, reopening triggers, and newly exposed questions into `docs/research/` when they remain material;
-- reusable proving cases, counterexamples, failure modes, measurements, or implementation know-how into the durable surface that will need them, when retaining them changes future reasoning or validation;
+- reusable proving cases, counterexamples, failure modes, measurements, protocols, source maps, or implementation know-how into the durable surface that will need them, when retaining them changes future reasoning or validation;
+- qualifying cross-investigation signals into `docs/research/synthesis-seeds.md` when they are evidence-bearing, potentially transferable beyond the immediate Arcogine implementation context, and loss-sensitive enough that workspace retirement would materially reduce later recurrence detection;
 - findings that no longer merit retention as explicitly discarded rather than accidentally lost with branch deletion.
 
-The reconciliation must name the workspace(s) covered by its transfer audit and state whether each is retirement-eligible. If any material item still lacks a durable destination or explicit discard decision, keep the workspace available. Once the reconciliation has landed and its independent PR review has validated the transfer, deleting a retirement-eligible workspace branch is immediate post-merge cleanup. The reconciliation owns that retirement decision even though deleting the Git ref is an operational action after merge rather than part of repository content.
+### Synthesis-seed custody
 
-This retirement rule does not create another lifecycle state, research issue ledger, or permanent report archive; it closes the custody gap between session-local research and durable reconciliation while keeping artifact-level integrity in immutable commit coordinates rather than branch proliferation.
+A **synthesis seed** is a compact, non-authoritative record that preserves the ability to recognize a potentially generalizable signal across otherwise independent investigations. It is not an Arcogine research question, accepted product/architecture semantics, implementation commitment, publication candidate, or work item.
+
+Admit or extend a seed only during reconciliation or another explicit knowledge-transfer review, after the originating investigation has reached its own result. The candidate must satisfy all three conditions:
+
+1. **Evidence-bearing** — it arose from substantive evidence, discriminating proving cases, experiment, counterexample, implementation experience, or another actual investigation result rather than free-form speculation.
+2. **Potentially transferable** — after Arcogine-specific class names and implementation details are removed, an intelligible proposition, distinction, failure mode, method, or counterexample remains.
+3. **Loss-sensitive** — retiring the workspace without the compact signal would materially reduce the chance that a later independent investigation could recognize recurrence.
+
+The seed should preserve only what later synthesis needs: the narrow signal, origin/provenance, truthful evidence posture, known boundaries/counterevidence, links to durable reusable assets, later occurrences, and a concrete `Revisit when` condition. Do not copy the whole report or use the seed index as a shadow evidence archive.
+
+When reconciling a new candidate, search existing seeds for semantic neighbors **only after** the originating investigation has reached its own result. Extend an existing seed when the underlying signal is genuinely the same. Record a later result as an **independent occurrence** only if the seed was not used as a load-bearing premise or framing input to that investigation; otherwise record **reuse**. Recurrence may justify considering a bounded synthesis question, but it does not establish generality by itself.
+
+Every seed must state a concrete `Revisit when` condition such as independent recurrence in another domain, materially comparable external evidence, implementation experience that confirms or falsifies the signal, or reuse of the same proving method across distinct questions. When the condition fires, surface that fact for an explicit decision about whether a bounded cross-investigation synthesis question should be admitted to the normal research register. Do not automatically create research work, change priority, or promote the broader claim.
+
+The reconciliation must name the workspace(s) covered by its transfer audit and state whether each is retirement-eligible. If any material item still lacks a durable destination, qualifying synthesis-seed record, or explicit discard decision, keep the workspace available. Once the reconciliation has landed and its independent PR review has validated the transfer, deleting a retirement-eligible workspace branch is immediate post-merge cleanup. The reconciliation owns that retirement decision even though deleting the Git ref is an operational action after merge rather than part of repository content.
+
+This retirement rule does not create another lifecycle state, permanent report archive, research issue ledger, publication backlog, or second research roadmap. `docs/research/README.md` remains the sole research portfolio/lifecycle authority; `docs/research/synthesis-seeds.md` is only a low-authority recurrence index and cannot admit or prioritize work.
 
 ## 11. What this document intentionally does not decide
 
@@ -332,7 +359,7 @@ This document defines method. It does not:
 
 - list Arcogine's current open research questions — see `docs/research/README.md`;
 - decide any live Arcogine semantic question (agency, operational identity, resource semantics, or otherwise) — those remain open exactly as the research register and any in-flight ADR record them;
-- create a Research delivery track, a second research roadmap, research delivery coordinates, a research sprint system, a permanent report archive, or a new issue ledger;
+- create a Research delivery track, a second research roadmap, research delivery coordinates, a research sprint system, a permanent report archive, publication lifecycle/backlog, or new issue ledger;
 - change how `docs/research/README.md`'s lifecycle (`CANDIDATE`, `READY`, `ACTIVE`, `CONCLUDED`, `SUPERSEDED`) or promotion boundary work.
 
-Research documents remain research evidence only. They do not become accepted architecture simply because a report exists.
+Research documents remain research evidence only. Synthesis seeds remain non-authoritative recurrence signals only. Neither becomes accepted architecture simply because it exists.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -6,6 +6,8 @@
 
 This document owns the research **portfolio, lifecycle, and promotion policy**: what questions are open, at what priority and status, and when a conclusion is durable enough to reconcile. It does not define how an individual investigation is conducted, what makes a report decision-quality, or what "independent" and "adversarial" review require — that normative method lives in [`docs/development/researching.md`](../development/researching.md), executed by the repository's [Researcher](../../.github/agents/researcher.agent.md) role. Use [`report-template.md`](report-template.md) as the reusable structure for a decision-quality report.
 
+[`synthesis-seeds.md`](synthesis-seeds.md) is a deliberately weaker surface: a non-authoritative cross-investigation signal index for evidence-bearing, potentially transferable observations whose recurrence may matter later. It is not part of the research portfolio or lifecycle, does not admit work, and must not be treated as accepted semantics or a publication backlog.
+
 ## Boundary
 
 `docs/research/` answers:
@@ -17,6 +19,12 @@ This document owns the research **portfolio, lifecycle, and promotion policy**: 
 > **Given what is already known or decided, what work can an implementer execute and validate?**
 
 Research may confirm, falsify, or narrow a hypothesis; conclude that no change is needed; justify an architecture/product decision; or create evidence for later implementation. A research conclusion becomes durable only after it is reconciled into the appropriate product, architecture, ADR, reference, or implementation plan.
+
+A synthesis seed answers a different and much weaker question:
+
+> **What evidence-bearing signal is worth being able to rediscover if a later independent investigation encounters the same phenomenon?**
+
+A seed therefore does not become an Arcogine research question unless a later deliberate admission decision creates or updates one in this register.
 
 Research documents never receive temporary delivery coordinates.
 
@@ -31,6 +39,8 @@ Research documents never receive temporary delivery coordinates.
 | **SUPERSEDED** | Later evidence/question/decision replaced the investigation before normal conclusion |
 
 Do not use percentage completion. Track evidence, falsified hypotheses, and exit criteria instead.
+
+These lifecycle values apply only to research questions in the register. Synthesis seeds have no lifecycle, priority, owner, delivery commitment, or percentage completion.
 
 ## Promotion rule
 
@@ -51,6 +61,8 @@ Decision-quality evidence
 
 A topic is ready for implementation planning only when semantic/product meaning, ownership, prerequisites, and acceptance evidence are sufficiently settled. A blocked implementation contract may live in planning; an unresolved question that still determines the contract stays here.
 
+A synthesis seed is outside this promotion path. If recurrence later justifies a bounded cross-investigation question, that question must be admitted into this register through the normal research lifecycle before investigation begins.
+
 ## Evidence custody and retirement
 
 Research that must survive a session uses a temporary, semantically named **research-evidence workspace branch** as defined by [`docs/development/researching.md`](../development/researching.md). The normal workspace unit is one bounded research question. An explicitly coupled set of questions may share one workspace only when they are intended to be reviewed/reconciled as one packet. Do not create a separate branch merely because a report and its adversarial review are different artifacts, do not create a fresh branch merely because that workspace has entered durable reconciliation, and do not create one permanent repository-wide research branch.
@@ -63,11 +75,13 @@ Research workspaces provide reproducible cross-session custody only. Their conte
 
 When a workspace with handed-off evidence must catch up to `main`, preserve the exact evidence SHAs. Use a history-preserving merge-style update rather than rebasing or force-pushing away completed artifact commits. Before the reconciliation PR lands, temporary evidence/handoff files that are not deliberately promoted should be absent from the final tree; the PR should carry the durable transfer rather than an evidence archive.
 
-A temporary research-evidence workspace may be retired only after every research question it carries is `CONCLUDED` or `SUPERSEDED` and the knowledge-transfer audit has accounted for every material result that should survive: accepted conclusions and qualifications in their durable authority, remaining unknowns/reopening triggers/new questions back in research, implementation responsibilities in admitted planning when ready, reusable proving cases/counterexamples/measurements/know-how in the surface that will need them, and explicit discard decisions for findings that no longer merit retention. If any material item remains unaccounted for, keep the workspace available.
+A temporary research-evidence workspace may be retired only after every research question it carries is `CONCLUDED` or `SUPERSEDED` and the knowledge-transfer audit has accounted for every material result that should survive: accepted conclusions and qualifications in their durable authority, remaining unknowns/reopening triggers/new questions back in research, implementation responsibilities in admitted planning when ready, reusable proving cases/counterexamples/measurements/know-how in the surface that will need them, qualifying cross-investigation synthesis seeds in [`synthesis-seeds.md`](synthesis-seeds.md), and explicit discard decisions for findings that no longer merit retention. If any material item remains unaccounted for, keep the workspace available.
+
+Synthesis-seed retention is intentionally stricter than "interesting." The signal must be evidence-bearing, remain intelligible outside its immediate Arcogine implementation context, and be loss-sensitive enough that retiring the workspace would materially reduce the chance of recognizing recurrence later. The seed carries only the compact signal, evidence posture, boundaries, durable reusable assets, provenance, and a concrete revisit trigger; it does not preserve the whole report.
 
 The reconciliation that completes that audit owns the retirement decision. Once the reconciliation has landed, deleting the listed temporary workspace branch is immediate post-merge cleanup; branch deletion is not itself part of repository authority and must not happen before the reviewed transfer is durable.
 
-This custody rule does not add a lifecycle status, permanent report archive, or second research ledger. The register continues to track the research question; temporary workspaces only preserve in-progress and completed evidence until reconciliation is complete enough to retire them safely.
+This custody rule does not add a lifecycle status, permanent report archive, second research roadmap, or second research ledger. The research register continues to track questions and lifecycle; `synthesis-seeds.md` records only low-authority recurrence signals and cannot by itself create work.
 
 ## Research register
 
@@ -97,5 +111,6 @@ Priority is portfolio guidance, not delivery commitment.
 - Mark research `READY` only when an independent researcher can execute it from the stated evidence/exit criteria — see `docs/development/researching.md` for what a sufficiently bounded brief and decision-quality report require.
 - When research concludes, record the verdict here and link the durable destination; do not duplicate the authoritative conclusion.
 - Before retiring a temporary research-evidence workspace, perform the knowledge-transfer audit above; branch deletion is not a substitute for deciding what should survive.
+- During reconciliation, admit a synthesis seed only under `docs/development/researching.md`'s evidence-bearing / transferable / loss-sensitive criteria; compare with existing seeds after the originating investigation has reached its own result, so similarity is not manufactured by anchoring.
 - During planning/consistency review, flag exploratory content that has leaked back into `docs/planning/` and relocate it here.
 - Keep concluded research visible when it provides useful history, but prefer current architecture/reference for durable semantics.

--- a/docs/research/report-template.md
+++ b/docs/research/report-template.md
@@ -74,13 +74,14 @@ For each material candidate for reuse, distinguish:
 - **boundary conditions / counter-contexts** — where the broader claim should not be expected to hold, including contrary examples when known;
 - **evidence level** — whether the broader claim is established by this investigation, supported but not established by external evidence, or only a hypothesis suggested by the result;
 - **reusable research asset** — any proving case, counterexample, failure mode, benchmark/scenario, trace, experimental or playtest protocol, measurement method, falsification criterion, source map, or implementation know-how worth carrying forward;
-- **strengthening evidence** — what independent evidence, replication, second consumer/domain, or contrary-case testing would be needed before making a broader claim confidently.
+- **strengthening evidence** — what independent evidence, replication, second consumer/domain, or contrary-case testing would be needed before making a broader claim confidently;
+- **synthesis-seed candidate**, if applicable — the smallest evidence-bearing, potentially transferable, loss-sensitive signal that reconciliation should consider preserving in `synthesis-seeds.md`, plus a concrete `Revisit when` condition. Nomination here does not admit the seed automatically.
 
-Do not silently promote `works for Arcogine` into `general principle`. A potentially transferable result remains research evidence until independently supported at the broader scope. This section does not create a publication lifecycle, publication candidate status, or obligation to preserve the whole report.
+Do not silently promote `works for Arcogine` into `general principle`. A potentially transferable result remains research evidence until independently supported at the broader scope. This section does not create a publication lifecycle, publication candidate status, or obligation to preserve the whole report. Do not read the synthesis-seed index merely to manufacture a match during the investigation; the reconciliation method defines the later comparison and anchoring controls.
 
 ## What did not survive
 
-Candidates, assumptions, or prior framings that the proving cases or evidence ruled out, and why. This is useful negative evidence for future researchers; do not omit it merely because the write-up already states a positive conclusion. When forgetting a failed hypothesis, broken analogy, misleading metric, or counterexample would plausibly cause future research to repeat the same mistake, identify the reusable negative knowledge explicitly so reconciliation can preserve it in the narrowest appropriate surface.
+Candidates, assumptions, or prior framings that the proving cases or evidence ruled out, and why. This is useful negative evidence for future researchers; do not omit it merely because the write-up already states a positive conclusion. When forgetting a failed hypothesis, broken analogy, misleading metric, or counterexample would plausibly cause future research to repeat the same mistake, identify the reusable negative knowledge explicitly so reconciliation can preserve it in the narrowest appropriate surface or, when it meets the stricter synthesis-seed admission test, retain the cross-context signal without retaining the whole report.
 
 ## Confidence and limitations
 
@@ -94,7 +95,7 @@ What remains genuinely open after this investigation, distinct from what the inv
 
 The smallest consequences that may deserve reconciliation into: no action; product; architecture; ADR; reference; implementation responsibility. State them — do not perform that promotion by writing this section; the actual ADR/architecture/planning change is a separate, independently reviewed change.
 
-Also identify any reusable research assets or negative knowledge from `Transferability and reuse` / `What did not survive` that would change future reasoning or validation if lost. The later knowledge-transfer audit should preserve the asset in the durable surface that will need it, or make an explicit discard decision; it should not retain the whole report merely because the report contains potentially reusable material.
+Also identify any reusable research assets or negative knowledge from `Transferability and reuse` / `What did not survive` that would change future reasoning or validation if lost. The later knowledge-transfer audit should preserve such assets in the durable surface that will need them. If a potentially transferable signal is not a current Arcogine research question or accepted semantic consequence but meets the synthesis-seed admission criteria, reconciliation may preserve a compact non-authoritative seed instead. Otherwise make an explicit discard decision; do not retain the whole report merely because it contains potentially reusable material.
 
 ## Implementation implication
 
@@ -102,7 +103,7 @@ What this means for implementation, including explicitly stating "no implementat
 
 ## Follow-up triggers
 
-What future evidence, consumer, or event should reopen or extend this question, and where that follow-up should be tracked (normally a new or updated entry in `docs/research/README.md`).
+What future evidence, consumer, or event should reopen or extend this question, and where that follow-up should be tracked (normally a new or updated entry in `docs/research/README.md`). A synthesis seed's `Revisit when` condition is different: it preserves a signal for possible cross-investigation synthesis and does not by itself reopen or admit Arcogine research.
 
 ## Sources
 

--- a/docs/research/report-template.md
+++ b/docs/research/report-template.md
@@ -57,13 +57,30 @@ The concrete scenarios used to discriminate between the candidate models, derive
 
 For a write-up still awaiting independent review, distinguish the author's own self-challenge from a later independent pass — do not present a self-administered check with the weight of independent review. Once an independent adversarial review exists, keep this reviewed report revision unchanged: the review artifact records this report's exact commit SHA and its disposition (`ACCEPT`, `ACCEPT WITH QUALIFICATIONS`, `MORE EVIDENCE REQUIRED`, or `REOPEN` — see `docs/development/researching.md` §9), and the later reconciliation references both exact evidence coordinates. If the report itself is revised after review, that new commit is a distinct report revision and, where independent review is required for promotion, must receive its own applicable adversarial review before its conclusions are promoted.
 
+Where the report proposes that a result may transfer beyond its immediate Arcogine context, explicitly attack that generalization too: look for an Arcogine-specific assumption that actually causes the result, a plausible counter-context where the broader claim fails, evidence of a useful design choice being presented as a necessary property, or a claim whose scope is stronger than the evidence. Prefer narrowing a transferability claim to the smallest version that survives over defending a broader formulation.
+
 ## Surviving invariants
 
 The smallest cross-case semantic rules the investigation actually established — not a restatement of every proving case's outcome, and not generalized beyond what the cases actually cover.
 
+## Transferability and reuse
+
+Optional. Use this section only when the investigation produced a result or research asset that may be useful outside the immediate Arcogine question. Do not add it merely to make a report look broader or more publishable.
+
+For each material candidate for reuse, distinguish:
+
+- **Arcogine-specific dependency** — which repository architecture, assumptions, consumers, or constraints the result depends on;
+- **potentially transferable result** — the narrowest claim that might remain useful when those implementation details are removed;
+- **boundary conditions / counter-contexts** — where the broader claim should not be expected to hold, including contrary examples when known;
+- **evidence level** — whether the broader claim is established by this investigation, supported but not established by external evidence, or only a hypothesis suggested by the result;
+- **reusable research asset** — any proving case, counterexample, failure mode, benchmark/scenario, trace, experimental or playtest protocol, measurement method, falsification criterion, source map, or implementation know-how worth carrying forward;
+- **strengthening evidence** — what independent evidence, replication, second consumer/domain, or contrary-case testing would be needed before making a broader claim confidently.
+
+Do not silently promote `works for Arcogine` into `general principle`. A potentially transferable result remains research evidence until independently supported at the broader scope. This section does not create a publication lifecycle, publication candidate status, or obligation to preserve the whole report.
+
 ## What did not survive
 
-Candidates, assumptions, or prior framings that the proving cases or evidence ruled out, and why. This is useful negative evidence for future researchers; do not omit it merely because the write-up already states a positive conclusion.
+Candidates, assumptions, or prior framings that the proving cases or evidence ruled out, and why. This is useful negative evidence for future researchers; do not omit it merely because the write-up already states a positive conclusion. When forgetting a failed hypothesis, broken analogy, misleading metric, or counterexample would plausibly cause future research to repeat the same mistake, identify the reusable negative knowledge explicitly so reconciliation can preserve it in the narrowest appropriate surface.
 
 ## Confidence and limitations
 
@@ -76,6 +93,8 @@ What remains genuinely open after this investigation, distinct from what the inv
 ## Durable consequences
 
 The smallest consequences that may deserve reconciliation into: no action; product; architecture; ADR; reference; implementation responsibility. State them — do not perform that promotion by writing this section; the actual ADR/architecture/planning change is a separate, independently reviewed change.
+
+Also identify any reusable research assets or negative knowledge from `Transferability and reuse` / `What did not survive` that would change future reasoning or validation if lost. The later knowledge-transfer audit should preserve the asset in the durable surface that will need it, or make an explicit discard decision; it should not retain the whole report merely because the report contains potentially reusable material.
 
 ## Implementation implication
 

--- a/docs/research/synthesis-seeds.md
+++ b/docs/research/synthesis-seeds.md
@@ -1,0 +1,67 @@
+# Synthesis seeds
+
+> **Status:** Maintained non-authoritative cross-investigation signal index  
+> **Scope:** Evidence-bearing observations, distinctions, counterexamples, methods, or hypotheses that are not currently Arcogine research questions or accepted semantics, but whose recurrence may justify later cross-investigation synthesis  
+> **Authority:** None over product, architecture, research priority, or delivery; a seed records only that a signal is worth being able to rediscover
+
+This file preserves the smallest amount of information needed to recognize potentially generalizable knowledge after temporary research-evidence workspaces are retired. It is **not** a second research register, publication backlog, permanent report archive, or claim that a broader result has been established.
+
+`docs/research/README.md` remains the only research portfolio/lifecycle ledger. `docs/development/researching.md` defines when reconciliation may retain a synthesis seed and how later investigations may use this index without manufacturing recurrence through anchoring.
+
+## Admission
+
+Create or extend a seed only when all of the following are true:
+
+- **Evidence-bearing** — the signal arose from actual repository/external evidence, discriminating proving cases, experiment, counterexample, implementation experience, or another substantive investigation result; it is not free-form speculation.
+- **Potentially transferable** — after removing Arcogine-specific class names or implementation details, an intelligible proposition, distinction, failure mode, method, or counterexample remains.
+- **Loss-sensitive** — once the originating temporary evidence workspace is retired, losing the signal would materially reduce the chance of recognizing the same phenomenon in a later independent investigation.
+
+Prefer preserving reusable proving cases, counterexamples, measurements, protocols, tests, or other research assets in the durable Arcogine surface that will actually use them. A synthesis seed is connective tissue: it points to those assets and exact evidence coordinates rather than duplicating whole reports.
+
+Do not create a seed merely because a finding is interesting, because publication is imaginable, or because a researcher wants to keep notes. If the item is an unresolved Arcogine decision, track it in the research register instead. If it has an accepted Arcogine semantic consequence, reconcile that consequence into its authoritative destination. If it is situational and not worth future recovery, discard it explicitly.
+
+## Anchoring control and recurrence
+
+Do not use this index as routine start-of-run grounding for an independent Arcogine investigation. The researcher should first derive candidates, evidence needs, and proving/failure cases from the bounded question and current repository authorities. Compare against synthesis seeds only **after** reaching the investigation's own result, unless a seed is deliberately being used as input to the new question.
+
+When a later investigation encounters a related signal:
+
+- if the investigation reached the result without using the seed as a load-bearing premise, record it as an **independent occurrence**;
+- if the seed materially shaped the question, candidates, proving cases, or reasoning, record it as **reuse**, not independent recurrence;
+- extend an existing semantic seed when it is genuinely the same underlying signal rather than creating near-duplicate entries;
+- do not infer generality merely from recurrence — recurrence is a trigger to consider synthesis, not proof of a general rule.
+
+## Revisit triggers
+
+Every seed states a concrete `Revisit when` condition. When that condition becomes true, reconciliation or later review should surface that the trigger has fired. Firing the trigger does not automatically create work, change research priority, or establish the broader claim; it means a bounded cross-investigation synthesis question may now be worth admitting deliberately.
+
+Useful triggers include independent recurrence in another Arcogine domain, implementation experience that confirms or falsifies the signal, materially comparable evidence from an external industrial system, or reuse of the same proving method across different questions.
+
+## Seed template
+
+### <Narrow semantic signal>
+
+**Signal**  
+State the smallest potentially transferable observation, distinction, counterexample, method, or hypothesis.
+
+**Origin**  
+Name the originating investigation and give exact evidence coordinates where practical, plus the durable reconciliation destination if one exists.
+
+**Evidence posture**  
+State what is actually established: for example, `Arcogine-specific result; broader applicability unestablished`.
+
+**Boundaries / counterevidence**  
+State known conditions where the signal may not hold, contrary examples, or what remains untested.
+
+**Reusable assets**  
+Point to durable proving cases, counterexamples, measurements, protocols, tests, source maps, or other research assets. Do not copy the whole originating report.
+
+**Occurrences**  
+Record later `independent occurrence` or `reuse` entries with their evidence coordinates and the materially similar aspect.
+
+**Revisit when**  
+State the evidence or recurrence condition that would justify considering a bounded synthesis investigation.
+
+---
+
+No synthesis seeds have been admitted yet.


### PR DESCRIPTION
## Summary

Adds a minimal custody path for potentially transferable research knowledge so Arcogine can preserve weak cross-investigation signals without turning research into a publication program or a second backlog.

The change now covers both halves of the problem:

1. **detect** evidence-bearing results that may generalize beyond the immediate Arcogine question;
2. **preserve** only the compact signal needed to recognize recurrence after temporary research workspaces are retired.

## What changes

### `docs/research/report-template.md`

- keeps the optional `Transferability and reuse` section;
- distinguishes Arcogine-specific dependencies, potentially transferable claims, boundaries/counter-contexts, evidence level, reusable research assets, strengthening evidence, and optional synthesis-seed candidates;
- strengthens report-level challenge of over-generalization;
- makes reusable negative knowledge explicit;
- allows the report to nominate, but not itself admit, a synthesis seed.

### `docs/development/researching.md`

- adds a **synthesis seed** as a valid knowledge-transfer disposition for evidence-bearing, potentially transferable, loss-sensitive signals that are neither current Arcogine research questions nor accepted semantic consequences;
- defines the three admission tests: evidence-bearing, potentially transferable, and loss-sensitive;
- requires synthesis-seed comparison only after the originating investigation has reached its own result, to avoid manufacturing recurrence through anchoring;
- distinguishes **independent occurrence** from **reuse** when later work encounters the same signal;
- requires every seed to have a concrete `Revisit when` trigger;
- makes a fired trigger an invitation to consider admitting a bounded synthesis question, not proof of generality or an automatic work item.

### `docs/research/README.md`

- keeps the research register as the sole portfolio/lifecycle authority;
- clarifies that synthesis seeds have no lifecycle, priority, owner, or delivery commitment;
- includes qualifying synthesis seeds in the existing knowledge-transfer/retirement audit;
- makes clear that seeds sit outside the normal research promotion path until a deliberate admission decision creates a real research question.

### `docs/research/synthesis-seeds.md`

Adds a small non-authoritative cross-investigation signal index with:

- strict admission criteria;
- anchoring/recurrence rules;
- independent-occurrence vs reuse distinction;
- trigger-based reconsideration;
- a compact seed template;
- no initial seeds.

The index stores connective tissue, not reports. Reusable proving cases, counterexamples, measurements, protocols, tests, and other research assets should still live in the durable Arcogine surface that will actually use them.

## Boundaries

This deliberately does **not**:

- add a journal or publication workflow;
- add a publication-candidate status, score, or maturity ladder;
- add a new research lifecycle state;
- create a second research roadmap or issue ledger;
- make synthesis seeds authoritative;
- make recurrence prove generality;
- automatically create work when a seed's revisit trigger fires;
- preserve whole research reports as a permanent archive;
- change product, architecture, ADRs, planning, or runtime behavior.

## Interaction with current work

This still intentionally avoids `docs/research/brief-template.md`, so it remains independent of the in-flight failure-oriented brief-template work.

## Validation

Documentation/process-only change. The PR now changes four research-process files and adds no runtime behavior.

Requesting normal independent review. I will not merge.